### PR TITLE
test(ui): add dom tests for shared components

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "vite": "catalog:",
     "vitest": "catalog:",
     "vue": "catalog:",
+    "vue-i18n": "catalog:",
     "vue-tsc": "catalog:",
     "wrangler": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ catalogs:
       specifier: 3.5.26
       version: 3.5.26
     vue-i18n:
-      specifier: ^11.2.7
+      specifier: 11.2.7
       version: 11.2.7
     vue-router:
       specifier: ^4.6.4
@@ -377,6 +377,9 @@ importers:
       vue:
         specifier: 'catalog:'
         version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.7(vue@3.5.26(typescript@5.9.3))
       vue-tsc:
         specifier: 'catalog:'
         version: 3.2.1(typescript@5.9.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -98,7 +98,7 @@ catalog:
   vite-plugin-vue-devtools: ^8.0.5
   vitest: ^4.0.16
   vue: 3.5.26
-  vue-i18n: ^11.2.7
+  vue-i18n: 11.2.7
   vue-router: ^4.6.4
   vue-tsc: ^3.2.1
   webrtc-ips: ^0.2.0

--- a/shared/ui/src/components/base/buttons/CopyToClipboardButton.dom.test.ts
+++ b/shared/ui/src/components/base/buttons/CopyToClipboardButton.dom.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import CopyToClipboardButton from './CopyToClipboardButton.vue'
+
+// Mock the composable
+const mockCopy = vi.fn()
+vi.mock('../../../composables/base/clipboard/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({
+    copy: mockCopy,
+  }),
+}))
+
+// Mock naive-ui useMessage
+vi.mock('naive-ui', async () => {
+  const actual = await vi.importActual('naive-ui')
+  return {
+    ...actual,
+    useMessage: () => ({
+      create: vi.fn(),
+      error: vi.fn(),
+    }),
+  }
+})
+
+describe('CopyToClipboardButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render button', () => {
+    const wrapper = mount(CopyToClipboardButton)
+    // Check that the component renders and contains a button element
+    expect(wrapper.find('button').exists()).toBe(true)
+  })
+
+  it('should emit click event on click', async () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      props: { content: 'test content' },
+    })
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(wrapper.emitted('click')).toBeTruthy()
+  })
+
+  it('should call copy function on click', async () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      props: { content: 'test content' },
+    })
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(mockCopy).toHaveBeenCalled()
+  })
+
+  it('should accept content prop as string', () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      props: { content: 'string content' },
+    })
+    expect(wrapper.props('content')).toBe('string content')
+  })
+
+  it('should accept content prop as number', () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      props: { content: 12345 },
+    })
+    expect(wrapper.props('content')).toBe(12345)
+  })
+
+  it('should render custom icon slot', () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      slots: {
+        icon: '<span class="custom-icon">Custom</span>',
+      },
+    })
+    expect(wrapper.find('.custom-icon').exists()).toBe(true)
+  })
+
+  it('should render custom label slot', () => {
+    const wrapper = mount(CopyToClipboardButton, {
+      slots: {
+        label: 'Custom Label',
+      },
+    })
+    expect(wrapper.text()).toContain('Custom Label')
+  })
+})

--- a/shared/ui/src/components/base/buttons/RegenerateButton.dom.test.ts
+++ b/shared/ui/src/components/base/buttons/RegenerateButton.dom.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import RegenerateButton from './RegenerateButton.vue'
+
+describe('RegenerateButton', () => {
+  it('should render button with default label', () => {
+    const wrapper = mount(RegenerateButton)
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(wrapper.text()).toContain('Regenerate')
+  })
+
+  it('should emit click event on click', async () => {
+    const wrapper = mount(RegenerateButton)
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('click')).toBeTruthy()
+  })
+
+  it('should render custom label and icon slots', () => {
+    const wrapper = mount(RegenerateButton, {
+      slots: {
+        label: 'Custom Label',
+        icon: '<span class="custom-icon">Icon</span>',
+      },
+    })
+    expect(wrapper.text()).toContain('Custom Label')
+    expect(wrapper.find('.custom-icon').exists()).toBe(true)
+  })
+})

--- a/shared/ui/src/components/base/input/text-or-file/TextOrFileInput.dom.test.ts
+++ b/shared/ui/src/components/base/input/text-or-file/TextOrFileInput.dom.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import TextOrFileInput from './TextOrFileInput.vue'
+
+describe('TextOrFileInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render text input initially', () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: '' },
+    })
+    expect(wrapper.find('textarea').exists()).toBe(true)
+  })
+
+  it('should emit update:value with text on input', async () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: '' },
+    })
+    await wrapper.find('textarea').setValue('hello world')
+    await flushPromises()
+    expect(wrapper.emitted('update:value')).toBeTruthy()
+    expect(wrapper.emitted('update:value')![0]).toEqual(['hello world'])
+  })
+
+  it('should initialize with string value from prop', async () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: 'initial text' },
+    })
+    await flushPromises()
+    expect(wrapper.find('textarea').element.value).toBe('initial text')
+  })
+
+  it('should update text value when prop changes', async () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: 'initial' },
+    })
+    await wrapper.setProps({ value: 'updated' })
+    await flushPromises()
+    expect(wrapper.find('textarea').element.value).toBe('updated')
+  })
+
+  it('should have upload area when no text', () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: '' },
+    })
+    // Check that there's an upload area (NUpload renders this)
+    expect(wrapper.html()).toContain('text-or-file-input')
+  })
+
+  it('should accept custom accept prop', () => {
+    const wrapper = mount(TextOrFileInput, {
+      props: { value: '', accept: '.txt,.csv' },
+    })
+    expect(wrapper.props('accept')).toBe('.txt,.csv')
+  })
+})

--- a/shared/ui/src/components/base/link/CustomRouterLink.dom.test.ts
+++ b/shared/ui/src/components/base/link/CustomRouterLink.dom.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent, h } from 'vue'
+import CustomRouterLink from './CustomRouterLink.vue'
+
+const { prefetchSpy, localizedPath } = vi.hoisted(() => ({
+  prefetchSpy: vi.fn(),
+  localizedPath: { value: '/localized', __v_isRef: true },
+}))
+
+vi.mock('./use-prefetch-view', () => ({
+  usePrefetchView: () => ({
+    prefetch: prefetchSpy,
+  }),
+}))
+
+vi.mock('./use-localized-path', () => ({
+  useLocalizedPath: () => ({
+    localizedPath,
+  }),
+}))
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLink',
+  props: {
+    to: {
+      type: [String, Object],
+      required: false,
+    },
+  },
+  emits: ['mouseenter', 'touchstart'],
+  setup(_props, { slots, emit }) {
+    const navigate = vi.fn()
+    const href = '/stub-href'
+    return () =>
+      h(
+        'a',
+        {
+          class: 'router-link',
+          onMouseenter: () => emit('mouseenter'),
+          onTouchstart: () => emit('touchstart'),
+        },
+        slots.default?.({ navigate, href }),
+      )
+  },
+})
+
+describe('CustomRouterLink', () => {
+  beforeEach(() => {
+    prefetchSpy.mockClear()
+  })
+
+  it('should render slot content and use localized path', () => {
+    const wrapper = mount(CustomRouterLink, {
+      props: {
+        to: '/original',
+      },
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+      slots: {
+        default: ({ href }) => h('span', { class: 'slot' }, href),
+      },
+    })
+
+    expect(wrapper.find('.slot').text()).toBe('/stub-href')
+    expect(wrapper.findComponent({ name: 'RouterLink' }).props('to')).toBe('/localized')
+  })
+
+  it('should prefetch on mouseenter and touchstart', async () => {
+    const wrapper = mount(CustomRouterLink, {
+      props: {
+        to: '/original',
+      },
+      global: {
+        stubs: {
+          RouterLink: RouterLinkStub,
+        },
+      },
+      slots: {
+        default: () => 'Link',
+      },
+    })
+
+    await wrapper.find('.router-link').trigger('mouseenter')
+    await wrapper.find('.router-link').trigger('touchstart')
+
+    expect(prefetchSpy).toHaveBeenCalledTimes(2)
+  })
+})

--- a/shared/ui/src/components/domain/mac-address/MACAddressInput.dom.test.ts
+++ b/shared/ui/src/components/domain/mac-address/MACAddressInput.dom.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import MACAddressInput from './MACAddressInput.vue'
+
+const VALID_MAC_COLON = '00:1A:2B:3C:4D:5E'
+const VALID_MAC_DASH = '00-1A-2B-3C-4D-5E'
+const INVALID_MAC = 'invalid-mac'
+const RANDOM_MAC = 'AA:BB:CC:DD:EE:FF'
+
+// Mock randomMACAddress
+vi.mock('@utils/mac-address', () => ({
+  randomMACAddress: vi.fn(() => RANDOM_MAC),
+}))
+
+describe('MACAddressInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render with provided address prop', () => {
+    const wrapper = mount(MACAddressInput, {
+      props: { address: VALID_MAC_COLON },
+    })
+    expect(wrapper.find('input').element.value).toBe(VALID_MAC_COLON)
+  })
+
+  it('should emit update:address on valid MAC with colons', async () => {
+    const wrapper = mount(MACAddressInput, {
+      props: { address: '' },
+    })
+    await wrapper.find('input').setValue(VALID_MAC_COLON)
+    await flushPromises()
+    expect(wrapper.emitted('update:address')).toBeTruthy()
+  })
+
+  it('should emit update:address on valid MAC with dashes', async () => {
+    const wrapper = mount(MACAddressInput, {
+      props: { address: '' },
+    })
+    await wrapper.find('input').setValue(VALID_MAC_DASH)
+    await flushPromises()
+    expect(wrapper.emitted('update:address')).toBeTruthy()
+  })
+
+  it('should not emit on invalid input', async () => {
+    const wrapper = mount(MACAddressInput, {
+      props: { address: '' },
+    })
+    await wrapper.find('input').setValue(INVALID_MAC)
+    await flushPromises()
+    expect(wrapper.emitted('update:address')).toBeFalsy()
+  })
+
+  it('should render clickable refresh area', () => {
+    const wrapper = mount(MACAddressInput, {
+      props: { address: VALID_MAC_COLON },
+    })
+    // Check that there's a clickable element for random generation
+    expect(wrapper.find('[style*="cursor: pointer"]').exists()).toBe(true)
+  })
+})

--- a/shared/ui/src/components/domain/uuid/UUIDInput.dom.test.ts
+++ b/shared/ui/src/components/domain/uuid/UUIDInput.dom.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import UUIDInput from './UUIDInput.vue'
+
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000'
+const INVALID_UUID = 'invalid-uuid'
+
+// Mock uuid module
+vi.mock('uuid', () => ({
+  v4: vi.fn(() => VALID_UUID),
+  validate: (uuid: string) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(uuid),
+}))
+
+describe('UUIDInput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should render with empty input', () => {
+    const wrapper = mount(UUIDInput)
+    expect(wrapper.find('input').exists()).toBe(true)
+  })
+
+  it('should render with provided uuid prop', () => {
+    const wrapper = mount(UUIDInput, {
+      props: { uuid: VALID_UUID },
+    })
+    expect(wrapper.find('input').element.value).toBe(VALID_UUID)
+  })
+
+  it('should emit update:uuid on valid input', async () => {
+    const wrapper = mount(UUIDInput)
+    await wrapper.find('input').setValue(VALID_UUID)
+    await flushPromises()
+    expect(wrapper.emitted('update:uuid')).toBeTruthy()
+    expect(wrapper.emitted('update:uuid')![0]).toEqual([VALID_UUID])
+  })
+
+  it('should not emit on invalid input by default', async () => {
+    const wrapper = mount(UUIDInput)
+    await wrapper.find('input').setValue(INVALID_UUID)
+    await flushPromises()
+    expect(wrapper.emitted('update:uuid')).toBeFalsy()
+  })
+
+  it('should emit on invalid input when emitOnInvalid is true', async () => {
+    const wrapper = mount(UUIDInput, {
+      props: { emitOnInvalid: true },
+    })
+    await wrapper.find('input').setValue(INVALID_UUID)
+    await flushPromises()
+    expect(wrapper.emitted('update:uuid')).toBeTruthy()
+  })
+
+  it('should hide refresh icon when showRandom is false', () => {
+    const wrapper = mount(UUIDInput, {
+      props: { showRandom: false },
+    })
+    // When showRandom is false, there should be no icon in the suffix
+    expect(wrapper.find('[style*="cursor: pointer"]').exists()).toBe(false)
+  })
+
+  it('should sync with external uuid prop changes', async () => {
+    const wrapper = mount(UUIDInput, {
+      props: { uuid: VALID_UUID },
+    })
+    expect(wrapper.find('input').element.value).toBe(VALID_UUID)
+
+    const newUuid = '6ba7b810-9dad-11d1-80b4-00c04fd430c8'
+    await wrapper.setProps({ uuid: newUuid })
+    expect(wrapper.find('input').element.value).toBe(newUuid)
+  })
+})

--- a/shared/ui/src/components/tool/grid/RelatedTools.dom.test.ts
+++ b/shared/ui/src/components/tool/grid/RelatedTools.dom.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import type { Ref } from 'vue'
+import RelatedTools from './RelatedTools.vue'
+import type { ToolInfo } from '@shared/tools'
+
+const { relatedToolsRef } = vi.hoisted(() => ({
+  relatedToolsRef: { value: undefined, __v_isRef: true } as unknown as Ref<ToolInfo[] | undefined>,
+}))
+
+vi.mock('@vueuse/core', async () => {
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
+  return {
+    ...actual,
+    computedAsync: () => relatedToolsRef,
+  }
+})
+
+const createTool = (toolID: string, tags: string[]): ToolInfo =>
+  ({
+    toolID,
+    path: `/tools/${toolID}`,
+    icon: {},
+    tags,
+    features: [],
+    meta: {
+      en: { name: toolID, description: `${toolID} description` },
+    },
+  }) as unknown as ToolInfo
+
+describe('RelatedTools', () => {
+  it('should render related tools based on shared tags', async () => {
+    relatedToolsRef.value = [createTool('match', ['tag-a', 'tag-b'])]
+
+    const wrapper = mount(RelatedTools, {
+      props: {
+        tool: {
+          toolID: 'current',
+          tags: ['tag-a'],
+        },
+      },
+      global: {
+        stubs: {
+          ToolSectionHeader: { template: '<div class="header"><slot /></div>' },
+          ToolSection: { template: '<div class="section"><slot /></div>' },
+          ToolsGrid: {
+            props: {
+              tools: {
+                type: Array,
+                default: () => [],
+              },
+            },
+            template: '<div class="tools-grid">{{ tools.length }}</div>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('.header').text()).toContain('Related Tools')
+    expect(wrapper.find('.tools-grid').text()).toBe('1')
+  })
+
+  it('should hide related tools when no matches exist', async () => {
+    relatedToolsRef.value = []
+
+    const wrapper = mount(RelatedTools, {
+      props: {
+        tool: {
+          toolID: 'current',
+          tags: ['tag-a'],
+        },
+      },
+      global: {
+        stubs: {
+          ToolSectionHeader: { template: '<div class="header"><slot /></div>' },
+          ToolSection: { template: '<div class="section"><slot /></div>' },
+          ToolsGrid: {
+            props: {
+              tools: {
+                type: Array,
+                default: () => [],
+              },
+            },
+            template: '<div class="tools-grid">{{ tools.length }}</div>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('.header').exists()).toBe(false)
+    expect(wrapper.find('.tools-grid').exists()).toBe(false)
+  })
+})

--- a/shared/ui/src/components/tool/grid/ToolLoadingThing.dom.test.ts
+++ b/shared/ui/src/components/tool/grid/ToolLoadingThing.dom.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import ToolLoadingThing from './ToolLoadingThing.vue'
+
+vi.mock('naive-ui', async () => {
+  const actual = await vi.importActual('naive-ui')
+  return {
+    ...actual,
+    useThemeVars: () => ({
+      cubicBezierEaseInOut: 'ease',
+      hoverColor: '#eee',
+    }),
+  }
+})
+
+describe('ToolLoadingThing', () => {
+  it('should render skeletons and avatar placeholder', () => {
+    const NThingStub = defineComponent({
+      name: 'NThing',
+      template:
+        '<div class="n-thing"><slot name="avatar" /><slot name="header" /><slot name="description" /></div>',
+    })
+
+    const wrapper = mount(ToolLoadingThing, {
+      global: {
+        stubs: {
+          NThing: NThingStub,
+          NAvatar: true,
+          NSkeleton: true,
+        },
+      },
+    })
+
+    expect(wrapper.find('.tool-link').exists()).toBe(true)
+  })
+})

--- a/shared/ui/src/components/tool/grid/ToolThing.dom.test.ts
+++ b/shared/ui/src/components/tool/grid/ToolThing.dom.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import ToolThing from './ToolThing.vue'
+import type { ToolInfo } from '@shared/tools'
+
+const RouterLinkStub = defineComponent({
+  name: 'CustomRouterLink',
+  props: ['to'],
+  template: '<div class="router-link"><slot /></div>',
+})
+
+const createTool = (overrides: Partial<ToolInfo> = {}): ToolInfo =>
+  ({
+    toolID: 'tool-1',
+    path: '/tools/tool-1',
+    icon: defineComponent({ template: '<span />' }),
+    tags: ['test'],
+    features: [],
+    meta: {
+      en: { name: 'Tool Name', description: 'Tool description' },
+    },
+    ...overrides,
+  }) as ToolInfo
+
+describe('ToolThing', () => {
+  it('should render internal tool with router link', () => {
+    const tool = createTool()
+    const wrapper = mount(ToolThing, {
+      props: { tool },
+      global: {
+        stubs: {
+          CustomRouterLink: RouterLinkStub,
+        },
+      },
+    })
+
+    const routerLink = wrapper.findComponent({ name: 'CustomRouterLink' })
+    expect(routerLink.exists()).toBe(true)
+    expect(routerLink.props('to')).toBe('/tools/tool-1')
+    expect(wrapper.text()).toContain('Tool Name')
+    expect(wrapper.text()).toContain('Tool description')
+    expect(wrapper.text()).not.toContain('Third Party')
+  })
+
+  it('should render external tool as anchor and show third party tag', () => {
+    const tool = createTool({ external: true, thirdParty: true })
+    const wrapper = mount(ToolThing, {
+      props: { tool },
+    })
+
+    const anchor = wrapper.find('a.tool-link')
+    expect(anchor.exists()).toBe(true)
+    expect(anchor.attributes('href')).toBe('/tools/tool-1')
+    expect(wrapper.findComponent({ name: 'CustomRouterLink' }).exists()).toBe(false)
+    expect(wrapper.text()).toContain('Third Party')
+  })
+})

--- a/shared/ui/src/components/tool/grid/ToolsGrid.dom.test.ts
+++ b/shared/ui/src/components/tool/grid/ToolsGrid.dom.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ToolsGrid from './ToolsGrid.vue'
+import type { ToolInfo } from '@shared/tools'
+
+// Mock child components
+const ToolThing = {
+  name: 'ToolThing',
+  template: '<div class="tool-thing">{{ tool.toolID }}</div>',
+  props: ['tool', 'showIcon'],
+}
+
+const ToolLoadingThing = {
+  name: 'ToolLoadingThing',
+  template: '<div class="tool-loading"></div>',
+}
+
+// Create mock tools
+const createMockTool = (id: string): ToolInfo =>
+  ({
+    toolID: id,
+    path: `/tools/${id}`,
+    icon: {},
+    tags: ['test'],
+    features: [],
+    meta: {
+      en: { name: id, description: `${id} description` },
+    },
+  }) as unknown as ToolInfo
+
+const mockTools: ToolInfo[] = [
+  createMockTool('tool-1'),
+  createMockTool('tool-2'),
+  createMockTool('tool-3'),
+]
+
+describe('ToolsGrid', () => {
+  it('should render loading state when tools is undefined', () => {
+    const wrapper = mount(ToolsGrid, {
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-loading').length).toBe(12) // default loadingSize
+  })
+
+  it('should render custom loading size', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: { loadingSize: 6 },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-loading').length).toBe(6)
+  })
+
+  it('should render all tools when provided', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: { tools: mockTools },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-thing').length).toBe(3)
+  })
+
+  it('should filter out single tool by string hide prop', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: {
+        tools: mockTools,
+        hide: 'tool-2',
+      },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    const toolThings = wrapper.findAll('.tool-thing')
+    expect(toolThings.length).toBe(2)
+    expect(toolThings.map((w) => w.text())).not.toContain('tool-2')
+  })
+
+  it('should filter out multiple tools by array hide prop', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: {
+        tools: mockTools,
+        hide: ['tool-1', 'tool-3'],
+      },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    const toolThings = wrapper.findAll('.tool-thing')
+    expect(toolThings.length).toBe(1)
+    expect(toolThings[0]?.text()).toBe('tool-2')
+  })
+
+  it('should render all tools when hide is empty array', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: {
+        tools: mockTools,
+        hide: [],
+      },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-thing').length).toBe(3)
+  })
+
+  it('should handle empty tools array', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: { tools: [] },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-thing').length).toBe(0)
+    expect(wrapper.findAll('.tool-loading').length).toBe(0)
+  })
+
+  it('should not hide any tools when hide prop is not provided', () => {
+    const wrapper = mount(ToolsGrid, {
+      props: { tools: mockTools },
+      global: {
+        stubs: { ToolThing, ToolLoadingThing },
+      },
+    })
+    expect(wrapper.findAll('.tool-thing').length).toBe(3)
+  })
+})

--- a/shared/ui/src/components/tool/layouts/ToolDefaultPageLayout.dom.test.ts
+++ b/shared/ui/src/components/tool/layouts/ToolDefaultPageLayout.dom.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { h } from 'vue'
+import ToolDefaultPageLayout from './ToolDefaultPageLayout.vue'
+import type { ToolInfo } from '@shared/tools'
+
+const { useHeadSpy } = vi.hoisted(() => ({
+  useHeadSpy: vi.fn(),
+}))
+
+vi.mock('@unhead/vue', () => ({
+  useHead: useHeadSpy,
+}))
+
+const createInfo = (
+  overrides: Partial<Pick<ToolInfo, 'meta' | 'toolID' | 'tags' | 'features'>> = {},
+) =>
+  ({
+    toolID: 'tool-id',
+    tags: ['tool'],
+    features: [],
+    meta: {
+      en: {
+        name: 'Tool Name',
+        description: 'Tool description',
+      },
+    } as ToolInfo['meta'],
+    ...overrides,
+  }) as Pick<ToolInfo, 'meta' | 'toolID' | 'tags' | 'features'>
+
+describe('ToolDefaultPageLayout', () => {
+  beforeEach(() => {
+    useHeadSpy.mockClear()
+  })
+
+  it('should render title, description, alert, and related tools by default', () => {
+    const wrapper = mount(ToolDefaultPageLayout, {
+      props: {
+        info: createInfo(),
+      },
+      global: {
+        stubs: {
+          ToolTitle: {
+            template: '<h1 class="tool-title"><slot /></h1>',
+          },
+          ToolDescription: {
+            template: '<p class="tool-description"><slot /></p>',
+          },
+          AirplaneModeEnabledAlert: {
+            template: '<div class="airplane-alert" />',
+          },
+          RelatedTools: {
+            template: '<div class="related-tools" />',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.text()).toContain('Tool Name')
+    expect(wrapper.text()).toContain('Tool description')
+    expect(wrapper.find('.airplane-alert').exists()).toBe(true)
+    expect(wrapper.find('.related-tools').exists()).toBe(true)
+    expect(useHeadSpy).toHaveBeenCalledWith({
+      title: 'Tool Name - InBrowser.App',
+      meta: [{ name: 'description', content: 'Tool description' }],
+    })
+  })
+
+  it('should hide related tools and alert when configured', () => {
+    const wrapper = mount(ToolDefaultPageLayout, {
+      props: {
+        info: createInfo({ features: ['offline'] }),
+        hideRelatedTools: true,
+      },
+      global: {
+        stubs: {
+          AirplaneModeEnabledAlert: {
+            template: '<div class="airplane-alert" />',
+          },
+          RelatedTools: {
+            template: '<div class="related-tools" />',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('.airplane-alert').exists()).toBe(false)
+    expect(wrapper.find('.related-tools').exists()).toBe(false)
+  })
+
+  it('should support custom title slot with translator', () => {
+    const wrapper = mount(ToolDefaultPageLayout, {
+      props: {
+        info: createInfo(),
+      },
+      slots: {
+        title: ({ t }) => h('div', { class: 'custom-title' }, t('name')),
+      },
+      global: {
+        stubs: {
+          ToolTitle: {
+            template: '<h1><slot /></h1>',
+          },
+          AirplaneModeEnabledAlert: {
+            template: '<div class="airplane-alert" />',
+          },
+          RelatedTools: {
+            template: '<div class="related-tools" />',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.find('.custom-title').text()).toBe('Tool Name')
+  })
+})

--- a/shared/ui/src/components/tool/layouts/ToolLayoutElements.dom.test.ts
+++ b/shared/ui/src/components/tool/layouts/ToolLayoutElements.dom.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ToolTitle from './ToolTitle.vue'
+import ToolDescription from './ToolDescription.vue'
+import ToolSectionHeader from './ToolSectionHeader.vue'
+import ToolSection from './ToolSection.vue'
+import ToolConfigHeader from './ToolConfigHeader.vue'
+
+describe('Tool layout text components', () => {
+  it('should render ToolTitle slot content', () => {
+    const wrapper = mount(ToolTitle, {
+      slots: { default: 'Tool Title' },
+    })
+    expect(wrapper.text()).toContain('Tool Title')
+  })
+
+  it('should render ToolDescription slot content', () => {
+    const wrapper = mount(ToolDescription, {
+      slots: { default: 'Description text' },
+    })
+    expect(wrapper.text()).toContain('Description text')
+  })
+
+  it('should render ToolSectionHeader slot content', () => {
+    const wrapper = mount(ToolSectionHeader, {
+      slots: { default: 'Section Header' },
+    })
+    expect(wrapper.text()).toContain('Section Header')
+  })
+
+  it('should render ToolSection slot content', () => {
+    const wrapper = mount(ToolSection, {
+      slots: { default: 'Section body' },
+    })
+    expect(wrapper.text()).toContain('Section body')
+  })
+
+  it('should render ToolConfigHeader localized text', () => {
+    const wrapper = mount(ToolConfigHeader)
+    expect(wrapper.text()).toContain('Configuration')
+  })
+})

--- a/shared/ui/src/composables/base/clipboard/useCopyToClipboard.dom.test.ts
+++ b/shared/ui/src/composables/base/clipboard/useCopyToClipboard.dom.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Ref } from 'vue'
+import { ref, defineComponent } from 'vue'
+import { mount } from '@vue/test-utils'
+import { useCopyToClipboard } from './useCopyToClipboard'
+
+// Mock naive-ui useMessage
+const mockCreate = vi.fn()
+const mockError = vi.fn()
+vi.mock('naive-ui', async () => {
+  const actual = await vi.importActual('naive-ui')
+  return {
+    ...actual,
+    useMessage: () => ({
+      create: mockCreate,
+      error: mockError,
+    }),
+  }
+})
+
+describe('useCopyToClipboard', () => {
+  const mockWriteText = vi.fn()
+
+  const mountWithCopy = (text: Ref<string | number | undefined> | string | number | undefined) => {
+    const TestComponent = defineComponent({
+      setup() {
+        const { copy } = useCopyToClipboard(text)
+        return { copy }
+      },
+      template: '<div />',
+    })
+    return mount(TestComponent)
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWriteText.mockResolvedValue(undefined)
+    // Mock clipboard using vi.stubGlobal
+    vi.stubGlobal('navigator', {
+      clipboard: {
+        writeText: mockWriteText,
+      },
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('should return copy function', () => {
+    const wrapper = mountWithCopy('test')
+    expect(typeof wrapper.vm.copy).toBe('function')
+  })
+
+  it('should copy string value to clipboard', async () => {
+    const wrapper = mountWithCopy('test text')
+    await wrapper.vm.copy()
+    expect(mockWriteText).toHaveBeenCalledWith('test text')
+  })
+
+  it('should copy number value to clipboard as string', async () => {
+    const wrapper = mountWithCopy(12345)
+    await wrapper.vm.copy()
+    expect(mockWriteText).toHaveBeenCalledWith('12345')
+  })
+
+  it('should copy ref value to clipboard', async () => {
+    const textRef = ref('ref text')
+    const wrapper = mountWithCopy(textRef)
+    await wrapper.vm.copy()
+    expect(mockWriteText).toHaveBeenCalledWith('ref text')
+  })
+
+  it('should show success message on successful copy', async () => {
+    const wrapper = mountWithCopy('test')
+    await wrapper.vm.copy()
+    expect(mockCreate).toHaveBeenCalled()
+  })
+
+  it('should show error message on clipboard error', async () => {
+    mockWriteText.mockRejectedValueOnce(new Error('Clipboard error'))
+    const wrapper = mountWithCopy('test')
+    await wrapper.vm.copy()
+    expect(mockError).toHaveBeenCalled()
+  })
+
+  it('should not copy when text is undefined', async () => {
+    const wrapper = mountWithCopy(undefined)
+    await wrapper.vm.copy()
+    expect(mockWriteText).not.toHaveBeenCalled()
+  })
+
+  it('should not copy when text is empty string', async () => {
+    const wrapper = mountWithCopy('')
+    await wrapper.vm.copy()
+    expect(mockWriteText).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
           name: 'dom',
           include: ['{apps,tools,shared,utils}/**/*.dom.test.ts'],
           environment: 'happy-dom',
+          setupFiles: ['./vitest.setup.ts'],
           retry: 2,
           typecheck: {
             enabled: true,

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,15 @@
+import { config } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+
+// Create a minimal i18n instance for tests
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: {},
+  missingWarn: false,
+  fallbackWarn: false,
+})
+
+// Configure global plugins for all component tests
+config.global.plugins = [i18n]


### PR DESCRIPTION
## Summary
- add DOM tests for shared UI grid/layout/link/button components and clipboard composable
- add vitest setup for i18n in DOM tests
- pin vue-i18n catalog version and wire dom test setup file

## Testing
- pnpm lint
- pnpm format
- pnpm type-check
- pnpm test:unit