### PR TITLE
fix(pwa): correct mask icon asset

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
         'favicon-dark.ico',
         'favicon.svg',
         'apple-touch-icon.png',
-        'masked-icon.svg',
+        'mask-icon.svg',
       ],
       manifest: {
         name: 'InBrowser.App',


### PR DESCRIPTION
## Summary
- fix PWA asset list to use the existing mask icon filename

## Testing
- not run (config-only change)