### PR TITLE
feat(tools): add Unicode escape/unescape tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       '@tools/toml-to-yaml-converter':
         specifier: workspace:*
         version: link:../../tools/code/toml-to-yaml-converter
+      '@tools/unicode-escape-unescape':
+        specifier: workspace:*
+        version: link:../../tools/web/unicode-escape-unescape
       '@tools/unicode-punycode-converter':
         specifier: workspace:*
         version: link:../../tools/network/unicode-punycode-converter
@@ -2940,6 +2943,30 @@ importers:
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
 
   tools/web/number-base-converter:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.7(vue@3.5.26(typescript@5.9.3))
+
+  tools/web/unicode-escape-unescape:
     dependencies:
       '@shared/icons':
         specifier: workspace:*

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -67,6 +67,7 @@
     "@tools/text-diff": "workspace:*",
     "@tools/toml-to-json-converter": "workspace:*",
     "@tools/toml-to-yaml-converter": "workspace:*",
+    "@tools/unicode-escape-unescape": "workspace:*",
     "@tools/unicode-punycode-converter": "workspace:*",
     "@tools/unix-timestamp-converter": "workspace:*",
     "@tools/url-component-encoder-decoder": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -66,6 +66,7 @@ import { toolInfo as textDiffToolInfo } from '@tools/text-diff'
 import { toolInfo as colorConverterToolInfo } from '@tools/color-converter'
 import { toolInfo as caseConverterToolInfo } from '@tools/case-converter'
 import { toolInfo as numberBaseConverterToolInfo } from '@tools/number-base-converter'
+import { toolInfo as unicodeEscapeUnescapeToolInfo } from '@tools/unicode-escape-unescape'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -157,4 +158,7 @@ export const tools: ToolInfo[] = [
 
   // Number Tools
   numberBaseConverterToolInfo,
+
+  // Unicode Tools
+  unicodeEscapeUnescapeToolInfo,
 ]

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -64,6 +64,7 @@ import { routes as textDiffRoutes } from '@tools/text-diff/routes'
 import { routes as colorConverterRoutes } from '@tools/color-converter/routes'
 import { routes as caseConverterRoutes } from '@tools/case-converter/routes'
 import { routes as numberBaseConverterRoutes } from '@tools/number-base-converter/routes'
+import { routes as unicodeEscapeUnescapeRoutes } from '@tools/unicode-escape-unescape/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -131,4 +132,5 @@ export const routes: ToolRoute[] = [
   ...colorConverterRoutes,
   ...caseConverterRoutes,
   ...numberBaseConverterRoutes,
+  ...unicodeEscapeUnescapeRoutes,
 ]

--- a/tools/web/unicode-escape-unescape/package.json
+++ b/tools/web/unicode-escape-unescape/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/unicode-escape-unescape",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/web/unicode-escape-unescape/src/UnicodeEscapeUnescapeView.vue
+++ b/tools/web/unicode-escape-unescape/src/UnicodeEscapeUnescapeView.vue
@@ -1,0 +1,11 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <UnicodeConverter />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import UnicodeConverter from './components/UnicodeConverter.vue'
+</script>

--- a/tools/web/unicode-escape-unescape/src/components/UnicodeConverter.vue
+++ b/tools/web/unicode-escape-unescape/src/components/UnicodeConverter.vue
@@ -1,0 +1,258 @@
+<template>
+  <div>
+    <ToolSectionHeader>{{ t('plain-text') }}</ToolSectionHeader>
+    <ToolSection>
+      <n-input
+        v-model:value="plainText"
+        type="textarea"
+        :placeholder="t('plain-text-placeholder')"
+        :autosize="{ minRows: 4, maxRows: 12 }"
+      />
+    </ToolSection>
+    <ToolSection>
+      <CopyToClipboardButton :content="plainText" />
+    </ToolSection>
+
+    <ToolSectionHeader>{{ t('escape-format') }}</ToolSectionHeader>
+    <ToolSection>
+      <n-select v-model:value="escapeFormat" :options="formatOptions" />
+    </ToolSection>
+
+    <ToolSectionHeader>{{ t('escaped-text') }}</ToolSectionHeader>
+    <ToolSection>
+      <n-input
+        v-model:value="escapedText"
+        type="textarea"
+        :placeholder="t('escaped-text-placeholder')"
+        :autosize="{ minRows: 4, maxRows: 12 }"
+      />
+    </ToolSection>
+    <ToolSection>
+      <CopyToClipboardButton :content="escapedText" />
+    </ToolSection>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch, computed } from 'vue'
+import { NInput, NSelect } from 'naive-ui'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import { useI18n } from 'vue-i18n'
+import { CopyToClipboardButton } from '@shared/ui/base'
+import { useStorage } from '@vueuse/core'
+import { escapeUnicode, unescapeUnicode, escapeFormats, type EscapeFormat } from '../utils'
+
+const { t } = useI18n()
+
+const formatOptions = computed(() =>
+  escapeFormats.map((f) => ({
+    label: `${f.label} (${f.example})`,
+    value: f.value,
+  })),
+)
+
+const escapeFormat = useStorage<EscapeFormat>('tools:unicode-escape-unescape:escape-format', 'js')
+const plainText = useStorage<string>('tools:unicode-escape-unescape:plain-text', 'Hello 你好 🎉')
+const escapedText = ref<string>(escapeUnicode(plainText.value, escapeFormat.value))
+
+let isUpdatingFromPlain = false
+let isUpdatingFromEscaped = false
+
+watch(plainText, (newValue) => {
+  if (isUpdatingFromEscaped) return
+  isUpdatingFromPlain = true
+  escapedText.value = escapeUnicode(newValue, escapeFormat.value)
+  isUpdatingFromPlain = false
+})
+
+watch(escapedText, (newValue) => {
+  if (isUpdatingFromPlain) return
+  isUpdatingFromEscaped = true
+  plainText.value = unescapeUnicode(newValue)
+  isUpdatingFromEscaped = false
+})
+
+watch(escapeFormat, (newFormat) => {
+  escapedText.value = escapeUnicode(plainText.value, newFormat)
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "plain-text": "Plain Text",
+    "plain-text-placeholder": "Enter text to escape...",
+    "escape-format": "Escape Format",
+    "escaped-text": "Escaped Text",
+    "escaped-text-placeholder": "Enter escaped text to unescape..."
+  },
+  "zh": {
+    "plain-text": "纯文本",
+    "plain-text-placeholder": "输入要转义的文本...",
+    "escape-format": "转义格式",
+    "escaped-text": "转义后文本",
+    "escaped-text-placeholder": "输入要反转义的文本..."
+  },
+  "zh-CN": {
+    "plain-text": "纯文本",
+    "plain-text-placeholder": "输入要转义的文本...",
+    "escape-format": "转义格式",
+    "escaped-text": "转义后文本",
+    "escaped-text-placeholder": "输入要反转义的文本..."
+  },
+  "zh-TW": {
+    "plain-text": "純文字",
+    "plain-text-placeholder": "輸入要轉義的文字...",
+    "escape-format": "轉義格式",
+    "escaped-text": "轉義後文字",
+    "escaped-text-placeholder": "輸入要反轉義的文字..."
+  },
+  "zh-HK": {
+    "plain-text": "純文字",
+    "plain-text-placeholder": "輸入要轉義的文字...",
+    "escape-format": "轉義格式",
+    "escaped-text": "轉義後文字",
+    "escaped-text-placeholder": "輸入要反轉義的文字..."
+  },
+  "es": {
+    "plain-text": "Texto Plano",
+    "plain-text-placeholder": "Introduce texto para escapar...",
+    "escape-format": "Formato de Escape",
+    "escaped-text": "Texto Escapado",
+    "escaped-text-placeholder": "Introduce texto escapado para desescapar..."
+  },
+  "fr": {
+    "plain-text": "Texte Brut",
+    "plain-text-placeholder": "Entrez le texte à échapper...",
+    "escape-format": "Format d'Échappement",
+    "escaped-text": "Texte Échappé",
+    "escaped-text-placeholder": "Entrez le texte échappé à désechapper..."
+  },
+  "de": {
+    "plain-text": "Klartext",
+    "plain-text-placeholder": "Text zum Escapen eingeben...",
+    "escape-format": "Escape-Format",
+    "escaped-text": "Escapeter Text",
+    "escaped-text-placeholder": "Escapeten Text zum Unescapen eingeben..."
+  },
+  "it": {
+    "plain-text": "Testo Semplice",
+    "plain-text-placeholder": "Inserisci testo da escapare...",
+    "escape-format": "Formato Escape",
+    "escaped-text": "Testo Escapato",
+    "escaped-text-placeholder": "Inserisci testo escapato da unescapare..."
+  },
+  "ja": {
+    "plain-text": "プレーンテキスト",
+    "plain-text-placeholder": "エスケープするテキストを入力...",
+    "escape-format": "エスケープ形式",
+    "escaped-text": "エスケープ済みテキスト",
+    "escaped-text-placeholder": "アンエスケープするテキストを入力..."
+  },
+  "ko": {
+    "plain-text": "일반 텍스트",
+    "plain-text-placeholder": "이스케이프할 텍스트 입력...",
+    "escape-format": "이스케이프 형식",
+    "escaped-text": "이스케이프된 텍스트",
+    "escaped-text-placeholder": "언이스케이프할 텍스트 입력..."
+  },
+  "ru": {
+    "plain-text": "Обычный текст",
+    "plain-text-placeholder": "Введите текст для экранирования...",
+    "escape-format": "Формат экранирования",
+    "escaped-text": "Экранированный текст",
+    "escaped-text-placeholder": "Введите текст для деэкранирования..."
+  },
+  "pt": {
+    "plain-text": "Texto Simples",
+    "plain-text-placeholder": "Digite texto para escapar...",
+    "escape-format": "Formato de Escape",
+    "escaped-text": "Texto Escapado",
+    "escaped-text-placeholder": "Digite texto escapado para desescapar..."
+  },
+  "ar": {
+    "plain-text": "نص عادي",
+    "plain-text-placeholder": "أدخل النص للتحويل...",
+    "escape-format": "صيغة التحويل",
+    "escaped-text": "نص محول",
+    "escaped-text-placeholder": "أدخل النص المحول لعكس التحويل..."
+  },
+  "hi": {
+    "plain-text": "सादा पाठ",
+    "plain-text-placeholder": "एस्केप करने के लिए पाठ दर्ज करें...",
+    "escape-format": "एस्केप प्रारूप",
+    "escaped-text": "एस्केप किया हुआ पाठ",
+    "escaped-text-placeholder": "अनएस्केप करने के लिए पाठ दर्ज करें..."
+  },
+  "tr": {
+    "plain-text": "Düz Metin",
+    "plain-text-placeholder": "Kaçış için metin girin...",
+    "escape-format": "Kaçış Formatı",
+    "escaped-text": "Kaçırılmış Metin",
+    "escaped-text-placeholder": "Kaçış geri alınacak metin girin..."
+  },
+  "nl": {
+    "plain-text": "Platte Tekst",
+    "plain-text-placeholder": "Voer tekst in om te escapen...",
+    "escape-format": "Escape-formaat",
+    "escaped-text": "Ge-escapete Tekst",
+    "escaped-text-placeholder": "Voer ge-escapete tekst in om te unescapen..."
+  },
+  "sv": {
+    "plain-text": "Vanlig Text",
+    "plain-text-placeholder": "Ange text att escapa...",
+    "escape-format": "Escape-format",
+    "escaped-text": "Escapad Text",
+    "escaped-text-placeholder": "Ange escapad text att unescapa..."
+  },
+  "pl": {
+    "plain-text": "Zwykły Tekst",
+    "plain-text-placeholder": "Wprowadź tekst do zakodowania...",
+    "escape-format": "Format kodowania",
+    "escaped-text": "Zakodowany Tekst",
+    "escaped-text-placeholder": "Wprowadź tekst do odkodowania..."
+  },
+  "vi": {
+    "plain-text": "Văn Bản Thô",
+    "plain-text-placeholder": "Nhập văn bản để chuyển đổi...",
+    "escape-format": "Định dạng chuyển đổi",
+    "escaped-text": "Văn Bản Đã Chuyển Đổi",
+    "escaped-text-placeholder": "Nhập văn bản đã chuyển đổi để giải mã..."
+  },
+  "th": {
+    "plain-text": "ข้อความธรรมดา",
+    "plain-text-placeholder": "ป้อนข้อความเพื่อแปลง...",
+    "escape-format": "รูปแบบการแปลง",
+    "escaped-text": "ข้อความที่แปลงแล้ว",
+    "escaped-text-placeholder": "ป้อนข้อความที่แปลงแล้วเพื่อถอดรหัส..."
+  },
+  "id": {
+    "plain-text": "Teks Biasa",
+    "plain-text-placeholder": "Masukkan teks untuk di-escape...",
+    "escape-format": "Format Escape",
+    "escaped-text": "Teks Ter-escape",
+    "escaped-text-placeholder": "Masukkan teks ter-escape untuk di-unescape..."
+  },
+  "he": {
+    "plain-text": "טקסט רגיל",
+    "plain-text-placeholder": "הזן טקסט להמרה...",
+    "escape-format": "פורמט המרה",
+    "escaped-text": "טקסט מומר",
+    "escaped-text-placeholder": "הזן טקסט מומר להמרה חוזרת..."
+  },
+  "ms": {
+    "plain-text": "Teks Biasa",
+    "plain-text-placeholder": "Masukkan teks untuk escape...",
+    "escape-format": "Format Escape",
+    "escaped-text": "Teks Ter-escape",
+    "escaped-text-placeholder": "Masukkan teks ter-escape untuk unescape..."
+  },
+  "no": {
+    "plain-text": "Vanlig Tekst",
+    "plain-text-placeholder": "Skriv inn tekst for escape...",
+    "escape-format": "Escape-format",
+    "escaped-text": "Escapet Tekst",
+    "escaped-text-placeholder": "Skriv inn escapet tekst for unescape..."
+  }
+}
+</i18n>

--- a/tools/web/unicode-escape-unescape/src/index.ts
+++ b/tools/web/unicode-escape-unescape/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/web/unicode-escape-unescape/src/info.ts
+++ b/tools/web/unicode-escape-unescape/src/info.ts
@@ -1,0 +1,134 @@
+export { LanguageOutline as icon } from '@shared/icons/ionicons5'
+
+export const toolID = 'unicode-escape-unescape'
+export const path = '/tools/unicode-escape-unescape'
+export const tags = ['web', 'text', 'encoding']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Escape and unescape Unicode characters in various formats including \\uXXXX, \\u{XXXXX}, HTML entities, and U+XXXX notation',
+  },
+  zh: {
+    name: 'Unicode 转义 / 反转义',
+    description:
+      '将 Unicode 字符转义和反转义为多种格式，包括 \\uXXXX、\\u{XXXXX}、HTML 实体和 U+XXXX 表示法',
+  },
+  'zh-CN': {
+    name: 'Unicode 转义 / 反转义',
+    description:
+      '将 Unicode 字符转义和反转义为多种格式，包括 \\uXXXX、\\u{XXXXX}、HTML 实体和 U+XXXX 表示法',
+  },
+  'zh-TW': {
+    name: 'Unicode 轉義 / 反轉義',
+    description:
+      '將 Unicode 字元轉義和反轉義為多種格式，包括 \\uXXXX、\\u{XXXXX}、HTML 實體和 U+XXXX 表示法',
+  },
+  'zh-HK': {
+    name: 'Unicode 轉義 / 反轉義',
+    description:
+      '將 Unicode 字元轉義和反轉義為多種格式，包括 \\uXXXX、\\u{XXXXX}、HTML 實體和 U+XXXX 表示法',
+  },
+  es: {
+    name: 'Escape / Unescape Unicode',
+    description:
+      'Escapar y desescapar caracteres Unicode en varios formatos incluyendo \\uXXXX, \\u{XXXXX}, entidades HTML y notación U+XXXX',
+  },
+  fr: {
+    name: 'Échappement / Désechappement Unicode',
+    description:
+      'Échapper et désechapper les caractères Unicode dans divers formats incluant \\uXXXX, \\u{XXXXX}, entités HTML et notation U+XXXX',
+  },
+  de: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Unicode-Zeichen in verschiedenen Formaten einschließlich \\uXXXX, \\u{XXXXX}, HTML-Entitäten und U+XXXX-Notation escapen und unescapen',
+  },
+  it: {
+    name: 'Escape / Unescape Unicode',
+    description:
+      'Esegui escape e unescape di caratteri Unicode in vari formati inclusi \\uXXXX, \\u{XXXXX}, entità HTML e notazione U+XXXX',
+  },
+  ja: {
+    name: 'Unicode エスケープ / アンエスケープ',
+    description:
+      '\\uXXXX、\\u{XXXXX}、HTML エンティティ、U+XXXX 表記を含む様々な形式で Unicode 文字をエスケープ・アンエスケープ',
+  },
+  ko: {
+    name: 'Unicode 이스케이프 / 언이스케이프',
+    description:
+      '\\uXXXX, \\u{XXXXX}, HTML 엔티티, U+XXXX 표기법을 포함한 다양한 형식으로 Unicode 문자를 이스케이프 및 언이스케이프',
+  },
+  ru: {
+    name: 'Unicode экранирование / деэкранирование',
+    description:
+      'Экранирование и деэкранирование символов Unicode в различных форматах, включая \\uXXXX, \\u{XXXXX}, HTML-сущности и нотацию U+XXXX',
+  },
+  pt: {
+    name: 'Escape / Unescape Unicode',
+    description:
+      'Escape e unescape de caracteres Unicode em vários formatos incluindo \\uXXXX, \\u{XXXXX}, entidades HTML e notação U+XXXX',
+  },
+  ar: {
+    name: 'تحويل Unicode',
+    description:
+      'تحويل أحرف Unicode من وإلى صيغ متعددة بما في ذلك \\uXXXX و \\u{XXXXX} وكيانات HTML وترميز U+XXXX',
+  },
+  hi: {
+    name: 'Unicode एस्केप / अनएस्केप',
+    description:
+      '\\uXXXX, \\u{XXXXX}, HTML एंटिटी और U+XXXX नोटेशन सहित विभिन्न प्रारूपों में Unicode वर्णों को एस्केप और अनएस्केप करें',
+  },
+  tr: {
+    name: 'Unicode Kaçış / Kaçış Geri Alma',
+    description:
+      '\\uXXXX, \\u{XXXXX}, HTML varlıkları ve U+XXXX gösterimi dahil çeşitli formatlarda Unicode karakterlerini kaçış ve kaçış geri alma',
+  },
+  nl: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Unicode-tekens escapen en unescapen in verschillende formaten waaronder \\uXXXX, \\u{XXXXX}, HTML-entiteiten en U+XXXX-notatie',
+  },
+  sv: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Escape och unescape Unicode-tecken i olika format inklusive \\uXXXX, \\u{XXXXX}, HTML-entiteter och U+XXXX-notation',
+  },
+  pl: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Kodowanie i dekodowanie znaków Unicode w różnych formatach w tym \\uXXXX, \\u{XXXXX}, encje HTML i notacja U+XXXX',
+  },
+  vi: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Chuyển đổi ký tự Unicode sang và từ các định dạng bao gồm \\uXXXX, \\u{XXXXX}, thực thể HTML và ký hiệu U+XXXX',
+  },
+  th: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'แปลงอักขระ Unicode ไปและกลับในรูปแบบต่างๆ รวมถึง \\uXXXX, \\u{XXXXX}, HTML entities และสัญลักษณ์ U+XXXX',
+  },
+  id: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Escape dan unescape karakter Unicode dalam berbagai format termasuk \\uXXXX, \\u{XXXXX}, entitas HTML, dan notasi U+XXXX',
+  },
+  he: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'המרת תווי Unicode לפורמטים שונים כולל \\uXXXX, \\u{XXXXX}, ישויות HTML וסימון U+XXXX',
+  },
+  ms: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Escape dan unescape aksara Unicode dalam pelbagai format termasuk \\uXXXX, \\u{XXXXX}, entiti HTML dan notasi U+XXXX',
+  },
+  no: {
+    name: 'Unicode Escape / Unescape',
+    description:
+      'Escape og unescape Unicode-tegn i ulike formater inkludert \\uXXXX, \\u{XXXXX}, HTML-entiteter og U+XXXX-notasjon',
+  },
+}

--- a/tools/web/unicode-escape-unescape/src/routes.ts
+++ b/tools/web/unicode-escape-unescape/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'unicode-escape-unescape',
+    path: '/tools/unicode-escape-unescape',
+    component: () => import('./UnicodeEscapeUnescapeView.vue'),
+  },
+] as const

--- a/tools/web/unicode-escape-unescape/src/utils.ts
+++ b/tools/web/unicode-escape-unescape/src/utils.ts
@@ -1,0 +1,286 @@
+export type EscapeFormat =
+  | 'js'
+  | 'es6'
+  | 'html-hex'
+  | 'html-dec'
+  | 'unicode'
+  | 'utf8-hex'
+  | 'url'
+  | 'python-u'
+  | 'hex-literal'
+
+export const escapeFormats: { value: EscapeFormat; label: string; example: string }[] = [
+  { value: 'js', label: '\\uXXXX', example: '\\u4F60\\u597D' },
+  { value: 'es6', label: '\\u{XXXXX}', example: '\\u{4F60}\\u{597D}' },
+  { value: 'html-hex', label: '&#xXXXX;', example: '&#x4F60;&#x597D;' },
+  { value: 'html-dec', label: '&#DDDD;', example: '&#20320;&#22909;' },
+  { value: 'unicode', label: 'U+XXXX', example: 'U+4F60 U+597D' },
+  { value: 'utf8-hex', label: '\\xXX', example: '\\xE4\\xBD\\xA0' },
+  { value: 'url', label: '%XX', example: '%E4%BD%A0' },
+  { value: 'python-u', label: '\\UXXXXXXXX', example: '\\U00004F60' },
+  { value: 'hex-literal', label: '0xXXXX', example: '0x4F60 0x597D' },
+]
+
+function toHex(codePoint: number, padLength: number = 4): string {
+  return codePoint.toString(16).toUpperCase().padStart(padLength, '0')
+}
+
+// Encode a string to UTF-8 bytes
+function encodeToUtf8Bytes(text: string): number[] {
+  const encoder = new TextEncoder()
+  return Array.from(encoder.encode(text))
+}
+
+function escapeCodePoint(codePoint: number, format: EscapeFormat): string {
+  switch (format) {
+    case 'js':
+      // For BMP characters, use \uXXXX
+      // For supplementary characters, use surrogate pairs
+      if (codePoint <= 0xffff) {
+        return `\\u${toHex(codePoint)}`
+      } else {
+        // Convert to surrogate pair
+        const highSurrogate = Math.floor((codePoint - 0x10000) / 0x400) + 0xd800
+        const lowSurrogate = ((codePoint - 0x10000) % 0x400) + 0xdc00
+        return `\\u${toHex(highSurrogate)}\\u${toHex(lowSurrogate)}`
+      }
+    case 'es6':
+      return `\\u{${toHex(codePoint, codePoint > 0xffff ? 5 : 4)}}`
+    case 'html-hex':
+      return `&#x${toHex(codePoint, codePoint > 0xffff ? 5 : 4)};`
+    case 'html-dec':
+      return `&#${codePoint};`
+    case 'unicode':
+      return `U+${toHex(codePoint, codePoint > 0xffff ? 5 : 4)}`
+    case 'python-u':
+      return `\\U${toHex(codePoint, 8)}`
+    case 'hex-literal':
+      return `0x${toHex(codePoint, codePoint > 0xffff ? 5 : 4)}`
+    // These are handled specially in escapeUnicode since they work on bytes
+    case 'utf8-hex':
+    case 'url':
+      return '' // Will be handled by escapeUnicode
+  }
+}
+
+// Escape a single character to UTF-8 byte format
+function escapeCharToUtf8(char: string, format: 'utf8-hex' | 'url'): string {
+  const bytes = encodeToUtf8Bytes(char)
+  if (format === 'utf8-hex') {
+    return bytes.map((b) => `\\x${b.toString(16).toUpperCase().padStart(2, '0')}`).join('')
+  } else {
+    return bytes.map((b) => `%${b.toString(16).toUpperCase().padStart(2, '0')}`).join('')
+  }
+}
+
+export function escapeUnicode(text: string, format: EscapeFormat): string {
+  let result = ''
+
+  // Handle byte-based formats specially
+  if (format === 'utf8-hex' || format === 'url') {
+    for (const char of text) {
+      const codePoint = char.codePointAt(0)!
+      // Keep ASCII printable characters as-is
+      if (codePoint >= 0x20 && codePoint <= 0x7e) {
+        result += char
+      } else {
+        result += escapeCharToUtf8(char, format)
+      }
+    }
+    return result
+  }
+
+  // Handle code point-based formats
+  for (const char of text) {
+    const codePoint = char.codePointAt(0)!
+    // Keep ASCII printable characters as-is (except for certain formats)
+    if (codePoint >= 0x20 && codePoint <= 0x7e) {
+      result += char
+    } else {
+      result += escapeCodePoint(codePoint, format)
+    }
+  }
+  return result
+}
+
+export function escapeAllUnicode(text: string, format: EscapeFormat): string {
+  let result = ''
+
+  // Handle byte-based formats specially
+  if (format === 'utf8-hex' || format === 'url') {
+    for (const char of text) {
+      result += escapeCharToUtf8(char, format)
+    }
+    return result
+  }
+
+  for (const char of text) {
+    const codePoint = char.codePointAt(0)!
+    result += escapeCodePoint(codePoint, format)
+  }
+  return result
+}
+
+// Regex patterns for different escape formats
+const patterns = {
+  // \uXXXX (JavaScript) - including surrogate pairs
+  js: /\\u([0-9A-Fa-f]{4})/g,
+  // \u{XXXXX} (ES6)
+  es6: /\\u\{([0-9A-Fa-f]{1,6})\}/g,
+  // &#xXXXX; (HTML hex)
+  htmlHex: /&#x([0-9A-Fa-f]{1,6});/gi,
+  // &#DDDD; (HTML decimal)
+  htmlDec: /&#(\d{1,7});/g,
+  // U+XXXX (Unicode notation)
+  unicode: /U\+([0-9A-Fa-f]{4,6})/gi,
+  // \xXX (UTF-8 hex bytes)
+  utf8Hex: /\\x([0-9A-Fa-f]{2})/gi,
+  // %XX (URL encoding)
+  url: /%([0-9A-Fa-f]{2})/gi,
+  // \UXXXXXXXX (Python 8-digit)
+  pythonU: /\\U([0-9A-Fa-f]{8})/g,
+  // 0xXXXX (Hex literal)
+  hexLiteral: /0x([0-9A-Fa-f]{4,6})/gi,
+}
+
+function decodeJsEscapes(text: string): string {
+  // First pass: decode surrogate pairs and regular \uXXXX
+  let result = ''
+  const regex = /\\u([0-9A-Fa-f]{4})/g
+  let lastIndex = 0
+  let match
+
+  while ((match = regex.exec(text)) !== null) {
+    result += text.slice(lastIndex, match.index)
+    const codeUnit = parseInt(match[1]!, 16)
+
+    // Check if this is a high surrogate and next is a low surrogate
+    const nextMatch = /^\\u([0-9A-Fa-f]{4})/.exec(text.slice(regex.lastIndex))
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff && nextMatch) {
+      const nextCodeUnit = parseInt(nextMatch[1]!, 16)
+      if (nextCodeUnit >= 0xdc00 && nextCodeUnit <= 0xdfff) {
+        // Valid surrogate pair
+        const codePoint = (codeUnit - 0xd800) * 0x400 + (nextCodeUnit - 0xdc00) + 0x10000
+        result += String.fromCodePoint(codePoint)
+        regex.lastIndex += 6 // Skip the low surrogate
+        lastIndex = regex.lastIndex
+        continue
+      }
+    }
+
+    result += String.fromCodePoint(codeUnit)
+    lastIndex = regex.lastIndex
+  }
+
+  result += text.slice(lastIndex)
+  return result
+}
+
+function decodeEs6Escapes(text: string): string {
+  return text.replace(patterns.es6, (match, hex) => {
+    const codePoint = parseInt(hex, 16)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+function decodeHtmlHexEscapes(text: string): string {
+  return text.replace(patterns.htmlHex, (match, hex) => {
+    const codePoint = parseInt(hex, 16)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+function decodeHtmlDecEscapes(text: string): string {
+  return text.replace(patterns.htmlDec, (match, dec) => {
+    const codePoint = parseInt(dec, 10)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+function decodeUnicodeNotation(text: string): string {
+  return text.replace(patterns.unicode, (match, hex) => {
+    const codePoint = parseInt(hex, 16)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+function decodePythonUEscapes(text: string): string {
+  return text.replace(patterns.pythonU, (match, hex) => {
+    const codePoint = parseInt(hex, 16)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+function decodeHexLiteralEscapes(text: string): string {
+  return text.replace(patterns.hexLiteral, (match, hex) => {
+    const codePoint = parseInt(hex, 16)
+    if (codePoint > 0x10ffff) return match
+    return String.fromCodePoint(codePoint)
+  })
+}
+
+// Decode UTF-8 byte sequences (\xXX or %XX format)
+function decodeUtf8ByteSequence(text: string, _pattern: RegExp, prefix: string): string {
+  // Find all byte escape sequences and group consecutive ones
+  const decoder = new TextDecoder('utf-8', { fatal: false })
+  let result = ''
+  let i = 0
+
+  while (i < text.length) {
+    // Try to match a byte sequence
+    const remaining = text.slice(i)
+    const match = remaining.match(new RegExp(`^((?:${prefix}[0-9A-Fa-f]{2})+)`, 'i'))
+
+    if (match && match[1]) {
+      // Extract all bytes from the sequence
+      const byteStr = match[1]
+      const bytes: number[] = []
+      const bytePattern = new RegExp(`${prefix}([0-9A-Fa-f]{2})`, 'gi')
+      let byteMatch
+
+      while ((byteMatch = bytePattern.exec(byteStr)) !== null) {
+        bytes.push(parseInt(byteMatch[1]!, 16))
+      }
+
+      // Decode bytes as UTF-8
+      const decoded = decoder.decode(new Uint8Array(bytes))
+      result += decoded
+      i += byteStr.length
+    } else {
+      result += text[i]
+      i++
+    }
+  }
+
+  return result
+}
+
+function decodeUtf8HexEscapes(text: string): string {
+  return decodeUtf8ByteSequence(text, patterns.utf8Hex, '\\\\x')
+}
+
+function decodeUrlEscapes(text: string): string {
+  return decodeUtf8ByteSequence(text, patterns.url, '%')
+}
+
+export function unescapeUnicode(text: string): string {
+  // Apply all decoders in sequence
+  let result = text
+  // Decode code-point based escapes first
+  result = decodeJsEscapes(result)
+  result = decodeEs6Escapes(result)
+  result = decodeHtmlHexEscapes(result)
+  result = decodeHtmlDecEscapes(result)
+  result = decodeUnicodeNotation(result)
+  result = decodePythonUEscapes(result)
+  result = decodeHexLiteralEscapes(result)
+  // Decode byte-based escapes
+  result = decodeUtf8HexEscapes(result)
+  result = decodeUrlEscapes(result)
+  return result
+}


### PR DESCRIPTION
## Summary

- Add a new Unicode escape/unescape tool with support for 9 formats:
  - `\uXXXX` (JavaScript/JSON)
  - `\u{XXXXX}` (ES6)
  - `&#xXXXX;` (HTML hex entity)
  - `&#DDDD;` (HTML decimal entity)
  - `U+XXXX` (Unicode standard notation)
  - `\xXX` (UTF-8 hex bytes - C/Python)
  - `%XX` (URL encoding)
  - `\UXXXXXXXX` (Python 8-digit)
  - `0xXXXX` (Hex literal)
- Bidirectional conversion with auto-detect for unescaping
- Proper surrogate pair handling for emoji and supplementary characters
- Full i18n support (25 languages)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm type-check` passes
- [x] `pnpm test:unit` passes
- [x] `pnpm build` passes
- [ ] Manual testing in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)