### PR TITLE
chore(ci): optimize test runs and add /test command

### DIFF
--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,29 @@
+---
+description: Run all checks and tests before committing
+allowed-tools: Bash(pnpm:*), Read
+---
+
+Help me run all checks and tests before committing:
+
+## Steps
+
+1. **Lint check**: Run `pnpm run lint-check`
+   - If it fails, run `pnpm run lint` to auto-fix, then re-run `lint-check`
+
+2. **Format check**: Run `pnpm run format-check`
+   - If it fails, run `pnpm run format` to auto-fix, then re-run `format-check`
+
+3. **Type check**: Run `pnpm run type-check`
+
+4. **Unit tests**: Run `pnpm run test:unit --run --silent passed-only --changed HEAD~1`
+
+5. **Build**: Run `pnpm run build` to verify the build works
+
+## On Failure
+
+If any step fails (after auto-fix attempts):
+- Analyze the error output
+- Suggest fixes or automatically fix the issues if possible
+- Re-run the failed step to verify the fix
+
+Report the final status of all checks.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: pnpm install
 
       - name: Run unit tests
-        run: pnpm run test:unit --run --coverage
+        run: pnpm run test:unit --coverage --silent passed-only ${{ github.event_name == 'pull_request' && format('--changed origin/{0}', github.base_ref) || '' }}
 
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@v2


### PR DESCRIPTION
## Summary

- Optimize CI test runs: only run changed tests for PRs, full tests for main branch
- Add `--silent passed-only` flag for cleaner test output
- Add `/test` Claude command for running pre-commit checks locally

## Test plan

- [ ] CI runs correctly for PRs (changed tests only)
- [ ] CI runs correctly for main branch (full tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)