### PR TITLE
chore(ci): add security audit check with high level threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: TypeScript Check
         run: pnpm run type-check
 
+      - name: Security Audit
+        run: pnpm audit --audit-level=high
+
   build-web:
     name: Build Web
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a security audit check to CI workflow.

Changes:
- Add pnpm audit step in code-check job
- Set audit level to high (only high/critical vulnerabilities will fail CI)
- Low and moderate vulnerabilities will be reported but won't block CI