### PR TITLE
feat(tools): add HTML Entity Encoder & Decoder tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -564,6 +564,9 @@ importers:
       '@tools/hash-tools':
         specifier: workspace:*
         version: link:../../tools/hash/hash-tools
+      '@tools/html-entity-encoder-decoder':
+        specifier: workspace:*
+        version: link:../../tools/web/html-entity-encoder-decoder
       '@tools/html-to-markdown-converter':
         specifier: workspace:*
         version: link:../../tools/document/html-to-markdown-converter
@@ -2980,6 +2983,30 @@ importers:
       '@types/color-convert':
         specifier: 'catalog:'
         version: 2.0.4
+
+  tools/web/html-entity-encoder-decoder:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.7(vue@3.5.26(typescript@5.9.3))
 
   tools/web/jwt-decoder-verifier:
     dependencies:

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -31,6 +31,7 @@
     "@tools/dns-lookup": "workspace:*",
     "@tools/favicon-assets-generator": "workspace:*",
     "@tools/hash-tools": "workspace:*",
+    "@tools/html-entity-encoder-decoder": "workspace:*",
     "@tools/html-to-markdown-converter": "workspace:*",
     "@tools/image-tools": "workspace:*",
     "@tools/ip-cidr-normalizer": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -70,6 +70,7 @@ import { toolInfo as numberBaseConverterToolInfo } from '@tools/number-base-conv
 import { toolInfo as unicodeEscapeUnescapeToolInfo } from '@tools/unicode-escape-unescape'
 import { toolInfo as morseCodeConverterToolInfo } from '@tools/morse-code-converter'
 import { toolInfo as rotCipherToolInfo } from '@tools/rot-cipher'
+import { toolInfo as htmlEntityEncoderDecoderToolInfo } from '@tools/html-entity-encoder-decoder'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -169,4 +170,5 @@ export const tools: ToolInfo[] = [
   // Misc Tools
   morseCodeConverterToolInfo,
   rotCipherToolInfo,
+  htmlEntityEncoderDecoderToolInfo,
 ]

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -68,6 +68,7 @@ import { routes as numberBaseConverterRoutes } from '@tools/number-base-converte
 import { routes as unicodeEscapeUnescapeRoutes } from '@tools/unicode-escape-unescape/routes'
 import { routes as morseCodeConverterRoutes } from '@tools/morse-code-converter/routes'
 import { routes as rotCipherRoutes } from '@tools/rot-cipher/routes'
+import { routes as htmlEntityEncoderDecoderRoutes } from '@tools/html-entity-encoder-decoder/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -139,4 +140,5 @@ export const routes: ToolRoute[] = [
   ...unicodeEscapeUnescapeRoutes,
   ...morseCodeConverterRoutes,
   ...rotCipherRoutes,
+  ...htmlEntityEncoderDecoderRoutes,
 ]

--- a/tools/web/html-entity-encoder-decoder/package.json
+++ b/tools/web/html-entity-encoder-decoder/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/html-entity-encoder-decoder",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/web/html-entity-encoder-decoder/src/HtmlEntityEncoderDecoderView.vue
+++ b/tools/web/html-entity-encoder-decoder/src/HtmlEntityEncoderDecoderView.vue
@@ -1,0 +1,11 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <HtmlEntityConverter />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import HtmlEntityConverter from './components/HtmlEntityConverter.vue'
+</script>

--- a/tools/web/html-entity-encoder-decoder/src/components/HtmlEntityConverter.vue
+++ b/tools/web/html-entity-encoder-decoder/src/components/HtmlEntityConverter.vue
@@ -1,0 +1,488 @@
+<template>
+  <div>
+    <ToolSectionHeader>{{ t('options') }}</ToolSectionHeader>
+    <ToolSection>
+      <n-flex :size="16">
+        <n-form-item :label="t('format')" label-placement="left">
+          <n-select v-model:value="format" :options="formatOptions" style="width: 180px" />
+        </n-form-item>
+        <n-form-item :label="t('range')" label-placement="left">
+          <n-select v-model:value="range" :options="rangeOptions" style="width: 220px" />
+        </n-form-item>
+      </n-flex>
+    </ToolSection>
+
+    <n-grid cols="1 s:2" :x-gap="24" :y-gap="16" responsive="screen">
+      <n-gi>
+        <ToolSectionHeader>{{ t('plain-text') }}</ToolSectionHeader>
+        <ToolSection>
+          <n-input
+            v-model:value="plainText"
+            type="textarea"
+            :placeholder="t('plain-text-placeholder')"
+            :autosize="{ minRows: 6, maxRows: 16 }"
+            style="font-family: monospace"
+          />
+        </ToolSection>
+        <ToolSection>
+          <CopyToClipboardButton :content="plainText" />
+        </ToolSection>
+      </n-gi>
+      <n-gi>
+        <ToolSectionHeader>{{ t('encoded-text') }}</ToolSectionHeader>
+        <ToolSection>
+          <n-input
+            v-model:value="encodedText"
+            type="textarea"
+            :placeholder="t('encoded-text-placeholder')"
+            :autosize="{ minRows: 6, maxRows: 16 }"
+            style="font-family: monospace"
+          />
+        </ToolSection>
+        <ToolSection>
+          <CopyToClipboardButton :content="encodedText" />
+        </ToolSection>
+      </n-gi>
+    </n-grid>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed, watch } from 'vue'
+import { NInput, NSelect, NGrid, NGi, NFlex, NFormItem } from 'naive-ui'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import { useI18n } from 'vue-i18n'
+import { CopyToClipboardButton } from '@shared/ui/base'
+import { useStorage } from '@vueuse/core'
+import {
+  encodeHtmlEntities,
+  decodeHtmlEntities,
+  type EntityFormat,
+  type EncodeRange,
+} from '../utils'
+
+const { t } = useI18n()
+
+const formatOptions = computed(() => [
+  { label: t('format-named'), value: 'named' as EntityFormat },
+  { label: t('format-decimal'), value: 'decimal' as EntityFormat },
+  { label: t('format-hex'), value: 'hex' as EntityFormat },
+])
+
+const rangeOptions = computed(() => [
+  { label: t('range-minimal'), value: 'minimal' as EncodeRange },
+  { label: t('range-non-ascii'), value: 'non-ascii' as EncodeRange },
+  { label: t('range-all-special'), value: 'all-special' as EncodeRange },
+])
+
+const format = useStorage<EntityFormat>('tools:html-entity:format', 'named')
+const range = useStorage<EncodeRange>('tools:html-entity:range', 'minimal')
+const plainText = useStorage<string>(
+  'tools:html-entity:plain',
+  '<div class="hello">Hello & World</div>',
+)
+const encodedText = useStorage<string>('tools:html-entity:encoded', '')
+
+let isUpdatingFromPlain = false
+let isUpdatingFromEncoded = false
+
+// Update encoded when plain text, format, or range changes
+watch(
+  [plainText, format, range],
+  ([newPlain, newFormat, newRange]) => {
+    if (isUpdatingFromEncoded) return
+    isUpdatingFromPlain = true
+    encodedText.value = encodeHtmlEntities(newPlain, newFormat, newRange)
+    isUpdatingFromPlain = false
+  },
+  { immediate: true },
+)
+
+// Update plain when encoded text changes
+watch(encodedText, (newEncoded) => {
+  if (isUpdatingFromPlain) return
+  isUpdatingFromEncoded = true
+  plainText.value = decodeHtmlEntities(newEncoded)
+  isUpdatingFromEncoded = false
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "options": "Encoding Options",
+    "format": "Format",
+    "range": "Range",
+    "format-named": "Named (&lt;)",
+    "format-decimal": "Decimal (&#60;)",
+    "format-hex": "Hexadecimal (&#x3C;)",
+    "range-minimal": "Minimal (HTML required)",
+    "range-non-ascii": "All Non-ASCII",
+    "range-all-special": "All Special Characters",
+    "plain-text": "Plain Text",
+    "plain-text-placeholder": "Enter text to encode...",
+    "encoded-text": "Encoded Text",
+    "encoded-text-placeholder": "Enter HTML entities to decode..."
+  },
+  "zh": {
+    "options": "编码选项",
+    "format": "格式",
+    "range": "范围",
+    "format-named": "命名实体 (&lt;)",
+    "format-decimal": "十进制 (&#60;)",
+    "format-hex": "十六进制 (&#x3C;)",
+    "range-minimal": "最小 (HTML 必需)",
+    "range-non-ascii": "所有非 ASCII",
+    "range-all-special": "所有特殊字符",
+    "plain-text": "纯文本",
+    "plain-text-placeholder": "输入要编码的文本...",
+    "encoded-text": "编码文本",
+    "encoded-text-placeholder": "输入要解码的 HTML 实体..."
+  },
+  "zh-CN": {
+    "options": "编码选项",
+    "format": "格式",
+    "range": "范围",
+    "format-named": "命名实体 (&lt;)",
+    "format-decimal": "十进制 (&#60;)",
+    "format-hex": "十六进制 (&#x3C;)",
+    "range-minimal": "最小 (HTML 必需)",
+    "range-non-ascii": "所有非 ASCII",
+    "range-all-special": "所有特殊字符",
+    "plain-text": "纯文本",
+    "plain-text-placeholder": "输入要编码的文本...",
+    "encoded-text": "编码文本",
+    "encoded-text-placeholder": "输入要解码的 HTML 实体..."
+  },
+  "zh-TW": {
+    "options": "編碼選項",
+    "format": "格式",
+    "range": "範圍",
+    "format-named": "命名實體 (&lt;)",
+    "format-decimal": "十進位 (&#60;)",
+    "format-hex": "十六進位 (&#x3C;)",
+    "range-minimal": "最小 (HTML 必需)",
+    "range-non-ascii": "所有非 ASCII",
+    "range-all-special": "所有特殊字元",
+    "plain-text": "純文字",
+    "plain-text-placeholder": "輸入要編碼的文字...",
+    "encoded-text": "編碼文字",
+    "encoded-text-placeholder": "輸入要解碼的 HTML 實體..."
+  },
+  "zh-HK": {
+    "options": "編碼選項",
+    "format": "格式",
+    "range": "範圍",
+    "format-named": "命名實體 (&lt;)",
+    "format-decimal": "十進位 (&#60;)",
+    "format-hex": "十六進位 (&#x3C;)",
+    "range-minimal": "最小 (HTML 必需)",
+    "range-non-ascii": "所有非 ASCII",
+    "range-all-special": "所有特殊字元",
+    "plain-text": "純文字",
+    "plain-text-placeholder": "輸入要編碼的文字...",
+    "encoded-text": "編碼文字",
+    "encoded-text-placeholder": "輸入要解碼的 HTML 實體..."
+  },
+  "es": {
+    "options": "Opciones de codificación",
+    "format": "Formato",
+    "range": "Rango",
+    "format-named": "Nombrada (&lt;)",
+    "format-decimal": "Decimal (&#60;)",
+    "format-hex": "Hexadecimal (&#x3C;)",
+    "range-minimal": "Mínimo (requerido por HTML)",
+    "range-non-ascii": "Todo no ASCII",
+    "range-all-special": "Todos los caracteres especiales",
+    "plain-text": "Texto plano",
+    "plain-text-placeholder": "Ingrese texto para codificar...",
+    "encoded-text": "Texto codificado",
+    "encoded-text-placeholder": "Ingrese entidades HTML para decodificar..."
+  },
+  "fr": {
+    "options": "Options d'encodage",
+    "format": "Format",
+    "range": "Plage",
+    "format-named": "Nommée (&lt;)",
+    "format-decimal": "Décimale (&#60;)",
+    "format-hex": "Hexadécimale (&#x3C;)",
+    "range-minimal": "Minimal (requis par HTML)",
+    "range-non-ascii": "Tout non-ASCII",
+    "range-all-special": "Tous les caractères spéciaux",
+    "plain-text": "Texte brut",
+    "plain-text-placeholder": "Entrez le texte à encoder...",
+    "encoded-text": "Texte encodé",
+    "encoded-text-placeholder": "Entrez les entités HTML à décoder..."
+  },
+  "de": {
+    "options": "Kodierungsoptionen",
+    "format": "Format",
+    "range": "Bereich",
+    "format-named": "Benannt (&lt;)",
+    "format-decimal": "Dezimal (&#60;)",
+    "format-hex": "Hexadezimal (&#x3C;)",
+    "range-minimal": "Minimal (HTML-erforderlich)",
+    "range-non-ascii": "Alle Nicht-ASCII",
+    "range-all-special": "Alle Sonderzeichen",
+    "plain-text": "Klartext",
+    "plain-text-placeholder": "Text zum Kodieren eingeben...",
+    "encoded-text": "Kodierter Text",
+    "encoded-text-placeholder": "HTML-Entitäten zum Dekodieren eingeben..."
+  },
+  "it": {
+    "options": "Opzioni di codifica",
+    "format": "Formato",
+    "range": "Intervallo",
+    "format-named": "Nominata (&lt;)",
+    "format-decimal": "Decimale (&#60;)",
+    "format-hex": "Esadecimale (&#x3C;)",
+    "range-minimal": "Minimo (richiesto da HTML)",
+    "range-non-ascii": "Tutto non-ASCII",
+    "range-all-special": "Tutti i caratteri speciali",
+    "plain-text": "Testo normale",
+    "plain-text-placeholder": "Inserisci il testo da codificare...",
+    "encoded-text": "Testo codificato",
+    "encoded-text-placeholder": "Inserisci entità HTML da decodificare..."
+  },
+  "ja": {
+    "options": "エンコードオプション",
+    "format": "形式",
+    "range": "範囲",
+    "format-named": "名前付き (&lt;)",
+    "format-decimal": "10進数 (&#60;)",
+    "format-hex": "16進数 (&#x3C;)",
+    "range-minimal": "最小 (HTML 必須)",
+    "range-non-ascii": "すべての非 ASCII",
+    "range-all-special": "すべての特殊文字",
+    "plain-text": "プレーンテキスト",
+    "plain-text-placeholder": "エンコードするテキストを入力...",
+    "encoded-text": "エンコード済みテキスト",
+    "encoded-text-placeholder": "デコードする HTML エンティティを入力..."
+  },
+  "ko": {
+    "options": "인코딩 옵션",
+    "format": "형식",
+    "range": "범위",
+    "format-named": "명명됨 (&lt;)",
+    "format-decimal": "10진수 (&#60;)",
+    "format-hex": "16진수 (&#x3C;)",
+    "range-minimal": "최소 (HTML 필수)",
+    "range-non-ascii": "모든 비 ASCII",
+    "range-all-special": "모든 특수 문자",
+    "plain-text": "일반 텍스트",
+    "plain-text-placeholder": "인코딩할 텍스트 입력...",
+    "encoded-text": "인코딩된 텍스트",
+    "encoded-text-placeholder": "디코딩할 HTML 엔티티 입력..."
+  },
+  "ru": {
+    "options": "Параметры кодирования",
+    "format": "Формат",
+    "range": "Диапазон",
+    "format-named": "Именованная (&lt;)",
+    "format-decimal": "Десятичная (&#60;)",
+    "format-hex": "Шестнадцатеричная (&#x3C;)",
+    "range-minimal": "Минимум (требуется HTML)",
+    "range-non-ascii": "Все не-ASCII",
+    "range-all-special": "Все специальные символы",
+    "plain-text": "Обычный текст",
+    "plain-text-placeholder": "Введите текст для кодирования...",
+    "encoded-text": "Закодированный текст",
+    "encoded-text-placeholder": "Введите HTML-сущности для декодирования..."
+  },
+  "pt": {
+    "options": "Opções de codificação",
+    "format": "Formato",
+    "range": "Intervalo",
+    "format-named": "Nomeada (&lt;)",
+    "format-decimal": "Decimal (&#60;)",
+    "format-hex": "Hexadecimal (&#x3C;)",
+    "range-minimal": "Mínimo (requerido por HTML)",
+    "range-non-ascii": "Todos não-ASCII",
+    "range-all-special": "Todos os caracteres especiais",
+    "plain-text": "Texto simples",
+    "plain-text-placeholder": "Digite o texto para codificar...",
+    "encoded-text": "Texto codificado",
+    "encoded-text-placeholder": "Digite entidades HTML para decodificar..."
+  },
+  "ar": {
+    "options": "خيارات الترميز",
+    "format": "التنسيق",
+    "range": "النطاق",
+    "format-named": "مسمى (&lt;)",
+    "format-decimal": "عشري (&#60;)",
+    "format-hex": "سداسي عشري (&#x3C;)",
+    "range-minimal": "الحد الأدنى (مطلوب لـ HTML)",
+    "range-non-ascii": "كل غير ASCII",
+    "range-all-special": "جميع الأحرف الخاصة",
+    "plain-text": "نص عادي",
+    "plain-text-placeholder": "أدخل النص للترميز...",
+    "encoded-text": "نص مرمز",
+    "encoded-text-placeholder": "أدخل كيانات HTML لفك الترميز..."
+  },
+  "hi": {
+    "options": "एन्कोडिंग विकल्प",
+    "format": "प्रारूप",
+    "range": "सीमा",
+    "format-named": "नामित (&lt;)",
+    "format-decimal": "दशमलव (&#60;)",
+    "format-hex": "हेक्साडेसिमल (&#x3C;)",
+    "range-minimal": "न्यूनतम (HTML आवश्यक)",
+    "range-non-ascii": "सभी गैर-ASCII",
+    "range-all-special": "सभी विशेष वर्ण",
+    "plain-text": "सादा पाठ",
+    "plain-text-placeholder": "एन्कोड करने के लिए टेक्स्ट दर्ज करें...",
+    "encoded-text": "एन्कोडेड टेक्स्ट",
+    "encoded-text-placeholder": "डिकोड करने के लिए HTML एंटिटीज़ दर्ज करें..."
+  },
+  "tr": {
+    "options": "Kodlama Seçenekleri",
+    "format": "Format",
+    "range": "Aralık",
+    "format-named": "Adlandırılmış (&lt;)",
+    "format-decimal": "Ondalık (&#60;)",
+    "format-hex": "Onaltılık (&#x3C;)",
+    "range-minimal": "Minimum (HTML gerekli)",
+    "range-non-ascii": "Tüm ASCII olmayan",
+    "range-all-special": "Tüm özel karakterler",
+    "plain-text": "Düz Metin",
+    "plain-text-placeholder": "Kodlanacak metni girin...",
+    "encoded-text": "Kodlanmış Metin",
+    "encoded-text-placeholder": "Çözülecek HTML varlıklarını girin..."
+  },
+  "nl": {
+    "options": "Coderingsopties",
+    "format": "Formaat",
+    "range": "Bereik",
+    "format-named": "Benoemd (&lt;)",
+    "format-decimal": "Decimaal (&#60;)",
+    "format-hex": "Hexadecimaal (&#x3C;)",
+    "range-minimal": "Minimaal (HTML vereist)",
+    "range-non-ascii": "Alle niet-ASCII",
+    "range-all-special": "Alle speciale tekens",
+    "plain-text": "Platte tekst",
+    "plain-text-placeholder": "Voer tekst in om te coderen...",
+    "encoded-text": "Gecodeerde tekst",
+    "encoded-text-placeholder": "Voer HTML-entiteiten in om te decoderen..."
+  },
+  "sv": {
+    "options": "Kodningsalternativ",
+    "format": "Format",
+    "range": "Intervall",
+    "format-named": "Namngiven (&lt;)",
+    "format-decimal": "Decimal (&#60;)",
+    "format-hex": "Hexadecimal (&#x3C;)",
+    "range-minimal": "Minimal (HTML krävs)",
+    "range-non-ascii": "Alla icke-ASCII",
+    "range-all-special": "Alla specialtecken",
+    "plain-text": "Klartext",
+    "plain-text-placeholder": "Ange text att koda...",
+    "encoded-text": "Kodad text",
+    "encoded-text-placeholder": "Ange HTML-entiteter att avkoda..."
+  },
+  "pl": {
+    "options": "Opcje kodowania",
+    "format": "Format",
+    "range": "Zakres",
+    "format-named": "Nazwana (&lt;)",
+    "format-decimal": "Dziesiętna (&#60;)",
+    "format-hex": "Szesnastkowa (&#x3C;)",
+    "range-minimal": "Minimalna (wymagana przez HTML)",
+    "range-non-ascii": "Wszystkie nie-ASCII",
+    "range-all-special": "Wszystkie znaki specjalne",
+    "plain-text": "Zwykły tekst",
+    "plain-text-placeholder": "Wprowadź tekst do zakodowania...",
+    "encoded-text": "Zakodowany tekst",
+    "encoded-text-placeholder": "Wprowadź encje HTML do zdekodowania..."
+  },
+  "vi": {
+    "options": "Tùy chọn mã hóa",
+    "format": "Định dạng",
+    "range": "Phạm vi",
+    "format-named": "Đặt tên (&lt;)",
+    "format-decimal": "Thập phân (&#60;)",
+    "format-hex": "Thập lục phân (&#x3C;)",
+    "range-minimal": "Tối thiểu (HTML bắt buộc)",
+    "range-non-ascii": "Tất cả không phải ASCII",
+    "range-all-special": "Tất cả ký tự đặc biệt",
+    "plain-text": "Văn bản thuần",
+    "plain-text-placeholder": "Nhập văn bản để mã hóa...",
+    "encoded-text": "Văn bản đã mã hóa",
+    "encoded-text-placeholder": "Nhập thực thể HTML để giải mã..."
+  },
+  "th": {
+    "options": "ตัวเลือกการเข้ารหัส",
+    "format": "รูปแบบ",
+    "range": "ช่วง",
+    "format-named": "ตั้งชื่อ (&lt;)",
+    "format-decimal": "ทศนิยม (&#60;)",
+    "format-hex": "เลขฐานสิบหก (&#x3C;)",
+    "range-minimal": "น้อยที่สุด (HTML จำเป็น)",
+    "range-non-ascii": "ทั้งหมดที่ไม่ใช่ ASCII",
+    "range-all-special": "อักขระพิเศษทั้งหมด",
+    "plain-text": "ข้อความธรรมดา",
+    "plain-text-placeholder": "ป้อนข้อความเพื่อเข้ารหัส...",
+    "encoded-text": "ข้อความที่เข้ารหัส",
+    "encoded-text-placeholder": "ป้อนเอนทิตี HTML เพื่อถอดรหัส..."
+  },
+  "id": {
+    "options": "Opsi Pengkodean",
+    "format": "Format",
+    "range": "Rentang",
+    "format-named": "Bernama (&lt;)",
+    "format-decimal": "Desimal (&#60;)",
+    "format-hex": "Heksadesimal (&#x3C;)",
+    "range-minimal": "Minimal (diperlukan HTML)",
+    "range-non-ascii": "Semua non-ASCII",
+    "range-all-special": "Semua karakter khusus",
+    "plain-text": "Teks Biasa",
+    "plain-text-placeholder": "Masukkan teks untuk dikodekan...",
+    "encoded-text": "Teks Terkode",
+    "encoded-text-placeholder": "Masukkan entitas HTML untuk didekodekan..."
+  },
+  "he": {
+    "options": "אפשרויות קידוד",
+    "format": "פורמט",
+    "range": "טווח",
+    "format-named": "בעלת שם (&lt;)",
+    "format-decimal": "עשרונית (&#60;)",
+    "format-hex": "הקסדצימלית (&#x3C;)",
+    "range-minimal": "מינימלי (נדרש ל-HTML)",
+    "range-non-ascii": "כל הלא-ASCII",
+    "range-all-special": "כל התווים המיוחדים",
+    "plain-text": "טקסט רגיל",
+    "plain-text-placeholder": "הזן טקסט לקידוד...",
+    "encoded-text": "טקסט מקודד",
+    "encoded-text-placeholder": "הזן ישויות HTML לפענוח..."
+  },
+  "ms": {
+    "options": "Pilihan Pengekodan",
+    "format": "Format",
+    "range": "Julat",
+    "format-named": "Dinamakan (&lt;)",
+    "format-decimal": "Perpuluhan (&#60;)",
+    "format-hex": "Heksadesimal (&#x3C;)",
+    "range-minimal": "Minimum (HTML diperlukan)",
+    "range-non-ascii": "Semua bukan ASCII",
+    "range-all-special": "Semua aksara khas",
+    "plain-text": "Teks Biasa",
+    "plain-text-placeholder": "Masukkan teks untuk dikodkan...",
+    "encoded-text": "Teks Dikodkan",
+    "encoded-text-placeholder": "Masukkan entiti HTML untuk dinyahkod..."
+  },
+  "no": {
+    "options": "Kodingsalternativer",
+    "format": "Format",
+    "range": "Område",
+    "format-named": "Navngitt (&lt;)",
+    "format-decimal": "Desimal (&#60;)",
+    "format-hex": "Heksadesimal (&#x3C;)",
+    "range-minimal": "Minimal (HTML påkrevd)",
+    "range-non-ascii": "Alle ikke-ASCII",
+    "range-all-special": "Alle spesialtegn",
+    "plain-text": "Ren tekst",
+    "plain-text-placeholder": "Skriv inn tekst for koding...",
+    "encoded-text": "Kodet tekst",
+    "encoded-text-placeholder": "Skriv inn HTML-entiteter for dekoding..."
+  }
+}
+</i18n>

--- a/tools/web/html-entity-encoder-decoder/src/index.ts
+++ b/tools/web/html-entity-encoder-decoder/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/web/html-entity-encoder-decoder/src/info.ts
+++ b/tools/web/html-entity-encoder-decoder/src/info.ts
@@ -1,0 +1,134 @@
+export { Code20Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'html-entity-encoder-decoder'
+export const path = '/tools/html-entity-encoder-decoder'
+export const tags = ['html', 'entity', 'encoding', 'web', 'escape']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'HTML Entity Encoder & Decoder',
+    description:
+      'Encode and decode HTML entities. Convert special characters to named, decimal, or hexadecimal HTML entities and vice versa',
+  },
+  zh: {
+    name: 'HTML 实体编码 & 解码',
+    description:
+      '编码和解码 HTML 实体。将特殊字符转换为命名、十进制或十六进制 HTML 实体，或将实体解码为原始字符',
+  },
+  'zh-CN': {
+    name: 'HTML 实体编码 & 解码',
+    description:
+      '编码和解码 HTML 实体。将特殊字符转换为命名、十进制或十六进制 HTML 实体，或将实体解码为原始字符',
+  },
+  'zh-TW': {
+    name: 'HTML 實體編碼 & 解碼',
+    description:
+      '編碼和解碼 HTML 實體。將特殊字元轉換為命名、十進制或十六進制 HTML 實體，或將實體解碼為原始字元',
+  },
+  'zh-HK': {
+    name: 'HTML 實體編碼 & 解碼',
+    description:
+      '編碼和解碼 HTML 實體。將特殊字元轉換為命名、十進制或十六進制 HTML 實體，或將實體解碼為原始字元',
+  },
+  es: {
+    name: 'Codificador y Decodificador de Entidades HTML',
+    description:
+      'Codifica y decodifica entidades HTML. Convierte caracteres especiales a entidades HTML con nombre, decimales o hexadecimales y viceversa',
+  },
+  fr: {
+    name: "Encodeur et Décodeur d'Entités HTML",
+    description:
+      'Encode et décode les entités HTML. Convertit les caractères spéciaux en entités HTML nommées, décimales ou hexadécimales et vice versa',
+  },
+  de: {
+    name: 'HTML-Entitäten Encoder & Decoder',
+    description:
+      'Kodiert und dekodiert HTML-Entitäten. Konvertiert Sonderzeichen in benannte, dezimale oder hexadezimale HTML-Entitäten und umgekehrt',
+  },
+  it: {
+    name: 'Codificatore e Decodificatore Entità HTML',
+    description:
+      'Codifica e decodifica entità HTML. Converte caratteri speciali in entità HTML con nome, decimali o esadecimali e viceversa',
+  },
+  ja: {
+    name: 'HTML エンティティ エンコーダ & デコーダ',
+    description:
+      'HTML エンティティのエンコードとデコード。特殊文字を名前付き、10 進数、または 16 進数の HTML エンティティに変換、またはその逆を行います',
+  },
+  ko: {
+    name: 'HTML 엔티티 인코더 & 디코더',
+    description:
+      'HTML 엔티티를 인코딩 및 디코딩합니다. 특수 문자를 이름, 10진수 또는 16진수 HTML 엔티티로 변환하거나 그 반대로 변환합니다',
+  },
+  ru: {
+    name: 'Кодировщик и декодировщик HTML-сущностей',
+    description:
+      'Кодирование и декодирование HTML-сущностей. Преобразование специальных символов в именованные, десятичные или шестнадцатеричные HTML-сущности и обратно',
+  },
+  pt: {
+    name: 'Codificador e Decodificador de Entidades HTML',
+    description:
+      'Codifica e decodifica entidades HTML. Converte caracteres especiais em entidades HTML nomeadas, decimais ou hexadecimais e vice-versa',
+  },
+  ar: {
+    name: 'مشفر ومفكك كيانات HTML',
+    description:
+      'تشفير وفك تشفير كيانات HTML. تحويل الأحرف الخاصة إلى كيانات HTML مسماة أو عشرية أو سداسية عشرية والعكس',
+  },
+  hi: {
+    name: 'HTML एंटिटी एनकोडर और डिकोडर',
+    description:
+      'HTML एंटिटी को एनकोड और डिकोड करें। विशेष वर्णों को नामित, दशमलव या हेक्साडेसिमल HTML एंटिटी में बदलें और इसके विपरीत',
+  },
+  tr: {
+    name: 'HTML Varlık Kodlayıcı ve Çözücü',
+    description:
+      'HTML varlıklarını kodlayın ve çözün. Özel karakterleri adlandırılmış, ondalık veya onaltılık HTML varlıklarına dönüştürün veya tersini yapın',
+  },
+  nl: {
+    name: 'HTML-entiteit Encoder & Decoder',
+    description:
+      'Codeer en decodeer HTML-entiteiten. Converteer speciale tekens naar benoemde, decimale of hexadecimale HTML-entiteiten en vice versa',
+  },
+  sv: {
+    name: 'HTML-entitet Kodare & Avkodare',
+    description:
+      'Koda och avkoda HTML-entiteter. Konvertera specialtecken till namngivna, decimala eller hexadecimala HTML-entiteter och vice versa',
+  },
+  pl: {
+    name: 'Koder i Dekoder Encji HTML',
+    description:
+      'Koduj i dekoduj encje HTML. Konwertuj znaki specjalne na nazwane, dziesiętne lub szesnastkowe encje HTML i odwrotnie',
+  },
+  vi: {
+    name: 'Bộ Mã Hóa & Giải Mã Thực Thể HTML',
+    description:
+      'Mã hóa và giải mã thực thể HTML. Chuyển đổi các ký tự đặc biệt thành thực thể HTML có tên, thập phân hoặc thập lục phân và ngược lại',
+  },
+  th: {
+    name: 'ตัวเข้ารหัสและถอดรหัส HTML Entity',
+    description:
+      'เข้ารหัสและถอดรหัส HTML entity แปลงอักขระพิเศษเป็น HTML entity แบบชื่อ ทศนิยม หรือเลขฐานสิบหก และในทางกลับกัน',
+  },
+  id: {
+    name: 'Encoder & Decoder Entitas HTML',
+    description:
+      'Encode dan decode entitas HTML. Konversi karakter khusus ke entitas HTML bernama, desimal, atau heksadesimal dan sebaliknya',
+  },
+  he: {
+    name: 'מקודד ומפענח ישויות HTML',
+    description:
+      'קידוד ופענוח ישויות HTML. המרת תווים מיוחדים לישויות HTML בשם, עשרוניות או הקסדצימליות ולהיפך',
+  },
+  ms: {
+    name: 'Pengekod & Penyahkod Entiti HTML',
+    description:
+      'Mengekod dan menyahkod entiti HTML. Tukar aksara khas kepada entiti HTML bernama, perpuluhan atau perenambelasan dan sebaliknya',
+  },
+  no: {
+    name: 'HTML-entitet Koder & Dekoder',
+    description:
+      'Kod og dekod HTML-entiteter. Konverter spesialtegn til navngitte, desimale eller heksadesimale HTML-entiteter og omvendt',
+  },
+}

--- a/tools/web/html-entity-encoder-decoder/src/routes.ts
+++ b/tools/web/html-entity-encoder-decoder/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'html-entity-encoder-decoder',
+    path: '/tools/html-entity-encoder-decoder',
+    component: () => import('./HtmlEntityEncoderDecoderView.vue'),
+  },
+] as const

--- a/tools/web/html-entity-encoder-decoder/src/utils.dom.test.ts
+++ b/tools/web/html-entity-encoder-decoder/src/utils.dom.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+import { encodeHtmlEntities, decodeHtmlEntities } from './utils'
+
+describe('encodeHtmlEntities', () => {
+  describe('named format', () => {
+    it('encodes basic HTML characters with named entities', () => {
+      expect(encodeHtmlEntities('<div>', 'named', 'minimal')).toBe('&lt;div&gt;')
+      expect(encodeHtmlEntities('&', 'named', 'minimal')).toBe('&amp;')
+      expect(encodeHtmlEntities('"test"', 'named', 'minimal')).toBe('&quot;test&quot;')
+      expect(encodeHtmlEntities("it's", 'named', 'minimal')).toBe('it&apos;s')
+    })
+
+    it('preserves regular text with minimal range', () => {
+      expect(encodeHtmlEntities('Hello World', 'named', 'minimal')).toBe('Hello World')
+      expect(encodeHtmlEntities('123', 'named', 'minimal')).toBe('123')
+    })
+
+    it('encodes non-ASCII with non-ascii range', () => {
+      expect(encodeHtmlEntities('Hello 中文', 'named', 'non-ascii')).toBe('Hello &#20013;&#25991;')
+      expect(encodeHtmlEntities('café', 'named', 'non-ascii')).toBe('caf&#233;')
+    })
+
+    it('uses named entities for common symbols', () => {
+      expect(encodeHtmlEntities('©', 'named', 'non-ascii')).toBe('&copy;')
+      expect(encodeHtmlEntities('®', 'named', 'non-ascii')).toBe('&reg;')
+      expect(encodeHtmlEntities('™', 'named', 'non-ascii')).toBe('&trade;')
+      expect(encodeHtmlEntities('€', 'named', 'non-ascii')).toBe('&euro;')
+    })
+  })
+
+  describe('decimal format', () => {
+    it('encodes with decimal entities', () => {
+      expect(encodeHtmlEntities('<', 'decimal', 'minimal')).toBe('&#60;')
+      expect(encodeHtmlEntities('>', 'decimal', 'minimal')).toBe('&#62;')
+      expect(encodeHtmlEntities('&', 'decimal', 'minimal')).toBe('&#38;')
+    })
+
+    it('encodes Unicode characters', () => {
+      expect(encodeHtmlEntities('中', 'decimal', 'non-ascii')).toBe('&#20013;')
+      expect(encodeHtmlEntities('日本語', 'decimal', 'non-ascii')).toBe('&#26085;&#26412;&#35486;')
+    })
+  })
+
+  describe('hex format', () => {
+    it('encodes with hexadecimal entities', () => {
+      expect(encodeHtmlEntities('<', 'hex', 'minimal')).toBe('&#x3C;')
+      expect(encodeHtmlEntities('>', 'hex', 'minimal')).toBe('&#x3E;')
+      expect(encodeHtmlEntities('&', 'hex', 'minimal')).toBe('&#x26;')
+    })
+
+    it('encodes Unicode characters in hex', () => {
+      expect(encodeHtmlEntities('中', 'hex', 'non-ascii')).toBe('&#x4E2D;')
+    })
+  })
+
+  describe('all-special range', () => {
+    it('encodes all non-alphanumeric characters', () => {
+      expect(encodeHtmlEntities('Hello!', 'named', 'all-special')).toBe('Hello&#33;')
+      expect(encodeHtmlEntities('a@b.c', 'decimal', 'all-special')).toBe('a&#64;b&#46;c')
+    })
+
+    it('preserves alphanumeric and space', () => {
+      expect(encodeHtmlEntities('Hello World 123', 'named', 'all-special')).toBe('Hello World 123')
+    })
+  })
+
+  it('handles empty string', () => {
+    expect(encodeHtmlEntities('', 'named', 'minimal')).toBe('')
+  })
+})
+
+describe('decodeHtmlEntities', () => {
+  describe('named entities', () => {
+    it('decodes common named entities', () => {
+      expect(decodeHtmlEntities('&lt;')).toBe('<')
+      expect(decodeHtmlEntities('&gt;')).toBe('>')
+      expect(decodeHtmlEntities('&amp;')).toBe('&')
+      expect(decodeHtmlEntities('&quot;')).toBe('"')
+      expect(decodeHtmlEntities('&apos;')).toBe("'")
+    })
+
+    it('decodes symbol entities', () => {
+      expect(decodeHtmlEntities('&copy;')).toBe('©')
+      expect(decodeHtmlEntities('&reg;')).toBe('®')
+      expect(decodeHtmlEntities('&trade;')).toBe('™')
+      expect(decodeHtmlEntities('&euro;')).toBe('€')
+      expect(decodeHtmlEntities('&nbsp;')).toBe('\u00A0')
+    })
+
+    it('preserves unknown named entities', () => {
+      expect(decodeHtmlEntities('&unknown;')).toBe('&unknown;')
+    })
+  })
+
+  describe('decimal entities', () => {
+    it('decodes decimal entities', () => {
+      expect(decodeHtmlEntities('&#60;')).toBe('<')
+      expect(decodeHtmlEntities('&#62;')).toBe('>')
+      expect(decodeHtmlEntities('&#38;')).toBe('&')
+    })
+
+    it('decodes Unicode decimal entities', () => {
+      expect(decodeHtmlEntities('&#20013;')).toBe('中')
+      expect(decodeHtmlEntities('&#128512;')).toBe('😀')
+    })
+  })
+
+  describe('hexadecimal entities', () => {
+    it('decodes hex entities (lowercase)', () => {
+      expect(decodeHtmlEntities('&#x3c;')).toBe('<')
+      expect(decodeHtmlEntities('&#x3e;')).toBe('>')
+    })
+
+    it('decodes hex entities (uppercase)', () => {
+      expect(decodeHtmlEntities('&#x3C;')).toBe('<')
+      expect(decodeHtmlEntities('&#x3E;')).toBe('>')
+    })
+
+    it('decodes Unicode hex entities', () => {
+      expect(decodeHtmlEntities('&#x4E2D;')).toBe('中')
+      expect(decodeHtmlEntities('&#x1F600;')).toBe('😀')
+    })
+  })
+
+  describe('mixed content', () => {
+    it('decodes mixed entity types', () => {
+      expect(decodeHtmlEntities('&lt;div&gt;&#60;span&#x3E;')).toBe('<div><span>')
+    })
+
+    it('preserves regular text', () => {
+      expect(decodeHtmlEntities('Hello World')).toBe('Hello World')
+    })
+
+    it('handles complex HTML', () => {
+      expect(decodeHtmlEntities('&lt;div class=&quot;test&quot;&gt;')).toBe('<div class="test">')
+    })
+  })
+
+  it('handles empty string', () => {
+    expect(decodeHtmlEntities('')).toBe('')
+  })
+})
+
+describe('round-trip encoding/decoding', () => {
+  it('decode(encode(text)) returns original for minimal', () => {
+    const testCases = ['<div>', 'Hello & World', '"quotes"', "it's ok"]
+    for (const text of testCases) {
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'named', 'minimal'))).toBe(text)
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'decimal', 'minimal'))).toBe(text)
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'hex', 'minimal'))).toBe(text)
+    }
+  })
+
+  it('decode(encode(text)) returns original for non-ascii', () => {
+    const testCases = ['Hello 中文', '日本語テスト', 'Café © 2024']
+    for (const text of testCases) {
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'named', 'non-ascii'))).toBe(text)
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'decimal', 'non-ascii'))).toBe(text)
+      expect(decodeHtmlEntities(encodeHtmlEntities(text, 'hex', 'non-ascii'))).toBe(text)
+    }
+  })
+})

--- a/tools/web/html-entity-encoder-decoder/src/utils.ts
+++ b/tools/web/html-entity-encoder-decoder/src/utils.ts
@@ -1,0 +1,126 @@
+export type EntityFormat = 'named' | 'decimal' | 'hex'
+export type EncodeRange = 'minimal' | 'non-ascii' | 'all-special'
+
+// Named HTML entities mapping (char -> entity name without & and ;)
+const CHAR_TO_NAMED_ENTITY: Record<string, string> = {
+  '&': 'amp',
+  '<': 'lt',
+  '>': 'gt',
+  '"': 'quot',
+  "'": 'apos',
+  '\u00A0': 'nbsp',
+  '\u00A9': 'copy',
+  '\u00AE': 'reg',
+  '\u2122': 'trade',
+  '\u20AC': 'euro',
+  '\u00A3': 'pound',
+  '\u00A5': 'yen',
+  '\u00A2': 'cent',
+  '\u00B0': 'deg',
+  '\u00B1': 'plusmn',
+  '\u00D7': 'times',
+  '\u00F7': 'divide',
+  '\u2260': 'ne',
+  '\u2264': 'le',
+  '\u2265': 'ge',
+  '\u221E': 'infin',
+  '\u2190': 'larr',
+  '\u2192': 'rarr',
+  '\u2191': 'uarr',
+  '\u2193': 'darr',
+  '\u2194': 'harr',
+  '\u2022': 'bull',
+  '\u2026': 'hellip',
+  '\u2013': 'ndash',
+  '\u2014': 'mdash',
+  '\u2018': 'lsquo',
+  '\u2019': 'rsquo',
+  '\u201C': 'ldquo',
+  '\u201D': 'rdquo',
+}
+
+// Reverse mapping for decoding (entity name -> char)
+const NAMED_ENTITY_TO_CHAR: Record<string, string> = {}
+for (const [char, name] of Object.entries(CHAR_TO_NAMED_ENTITY)) {
+  NAMED_ENTITY_TO_CHAR[name] = char
+}
+
+// Characters that must be encoded for HTML safety
+const MINIMAL_ENCODE_CHARS = new Set(['&', '<', '>', '"', "'"])
+
+function shouldEncode(char: string, range: EncodeRange): boolean {
+  const code = char.charCodeAt(0)
+
+  switch (range) {
+    case 'minimal':
+      return MINIMAL_ENCODE_CHARS.has(char)
+    case 'non-ascii':
+      return MINIMAL_ENCODE_CHARS.has(char) || code > 127
+    case 'all-special':
+      // Encode everything except alphanumeric and space
+      return !(
+        (code >= 48 && code <= 57) || // 0-9
+        (code >= 65 && code <= 90) || // A-Z
+        (code >= 97 && code <= 122) || // a-z
+        code === 32 // space
+      )
+  }
+}
+
+function encodeChar(char: string, format: EntityFormat): string {
+  const code = char.charCodeAt(0)
+
+  switch (format) {
+    case 'named':
+      // Use named entity if available, otherwise fall back to decimal
+      const namedEntity = CHAR_TO_NAMED_ENTITY[char]
+      if (namedEntity) {
+        return `&${namedEntity};`
+      }
+      return `&#${code};`
+    case 'decimal':
+      return `&#${code};`
+    case 'hex':
+      return `&#x${code.toString(16).toUpperCase()};`
+  }
+}
+
+export function encodeHtmlEntities(text: string, format: EntityFormat, range: EncodeRange): string {
+  let result = ''
+  for (const char of text) {
+    if (shouldEncode(char, range)) {
+      result += encodeChar(char, format)
+    } else {
+      result += char
+    }
+  }
+  return result
+}
+
+export function decodeHtmlEntities(text: string): string {
+  // First, decode named entities
+  let result = text.replace(/&([a-zA-Z]+);/g, (match, name) => {
+    const char = NAMED_ENTITY_TO_CHAR[name.toLowerCase()]
+    return char !== undefined ? char : match
+  })
+
+  // Decode decimal entities (&#123;)
+  result = result.replace(/&#(\d+);/g, (match, code) => {
+    const num = parseInt(code, 10)
+    if (num >= 0 && num <= 0x10ffff) {
+      return String.fromCodePoint(num)
+    }
+    return match
+  })
+
+  // Decode hexadecimal entities (&#x1A2B;)
+  result = result.replace(/&#x([0-9a-fA-F]+);/g, (match, code) => {
+    const num = parseInt(code, 16)
+    if (num >= 0 && num <= 0x10ffff) {
+      return String.fromCodePoint(num)
+    }
+    return match
+  })
+
+  return result
+}


### PR DESCRIPTION
## Summary

- Add a new HTML Entity Encoder & Decoder tool for converting between plain text and HTML entities
- Support three entity formats: Named (`&lt;`), Decimal (`&#60;`), and Hexadecimal (`&#x3C;`)
- Support three encoding ranges: Minimal (HTML required), All Non-ASCII, and All Special Characters
- Bidirectional real-time conversion between plain text and encoded text
- Full i18n support for all 25 languages

## Test plan

- [x] Unit tests pass (25 tests)
- [x] TypeScript type check passes
- [ ] Verify tool appears in the tools list
- [ ] Test encoding with different formats and ranges
- [ ] Test decoding various HTML entity types
- [ ] Verify translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)