### PR TITLE
feat(tools): add Chmod Calculator tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -531,6 +531,9 @@ importers:
       '@tools/case-converter':
         specifier: workspace:*
         version: link:../../tools/web/case-converter
+      '@tools/chmod-calculator':
+        specifier: workspace:*
+        version: link:../../tools/misc/chmod-calculator
       '@tools/cidr-parser':
         specifier: workspace:*
         version: link:../../tools/network/cidr-parser
@@ -2087,6 +2090,30 @@ importers:
       '@types/qrcode':
         specifier: 'catalog:'
         version: 1.5.6
+
+  tools/misc/chmod-calculator:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.7(vue@3.5.26(typescript@5.9.3))
 
   tools/misc/device-information:
     dependencies:

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -20,6 +20,7 @@
     "@tools/blake2b-hash-text-or-file": "workspace:*",
     "@tools/blake2s-hash-text-or-file": "workspace:*",
     "@tools/case-converter": "workspace:*",
+    "@tools/chmod-calculator": "workspace:*",
     "@tools/cidr-parser": "workspace:*",
     "@tools/cidrs-merger-excluder": "workspace:*",
     "@tools/color-converter": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -71,6 +71,7 @@ import { toolInfo as unicodeEscapeUnescapeToolInfo } from '@tools/unicode-escape
 import { toolInfo as morseCodeConverterToolInfo } from '@tools/morse-code-converter'
 import { toolInfo as rotCipherToolInfo } from '@tools/rot-cipher'
 import { toolInfo as htmlEntityEncoderDecoderToolInfo } from '@tools/html-entity-encoder-decoder'
+import { toolInfo as chmodCalculatorToolInfo } from '@tools/chmod-calculator'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -171,4 +172,5 @@ export const tools: ToolInfo[] = [
   morseCodeConverterToolInfo,
   rotCipherToolInfo,
   htmlEntityEncoderDecoderToolInfo,
+  chmodCalculatorToolInfo,
 ]

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -69,6 +69,7 @@ import { routes as unicodeEscapeUnescapeRoutes } from '@tools/unicode-escape-une
 import { routes as morseCodeConverterRoutes } from '@tools/morse-code-converter/routes'
 import { routes as rotCipherRoutes } from '@tools/rot-cipher/routes'
 import { routes as htmlEntityEncoderDecoderRoutes } from '@tools/html-entity-encoder-decoder/routes'
+import { routes as chmodCalculatorRoutes } from '@tools/chmod-calculator/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -141,4 +142,5 @@ export const routes: ToolRoute[] = [
   ...morseCodeConverterRoutes,
   ...rotCipherRoutes,
   ...htmlEntityEncoderDecoderRoutes,
+  ...chmodCalculatorRoutes,
 ]

--- a/tools/misc/chmod-calculator/package.json
+++ b/tools/misc/chmod-calculator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/chmod-calculator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/misc/chmod-calculator/src/ChmodCalculatorView.vue
+++ b/tools/misc/chmod-calculator/src/ChmodCalculatorView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <ChmodCalculator />
+    <WhatIsChmod />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import ChmodCalculator from './components/ChmodCalculator.vue'
+import WhatIsChmod from './components/WhatIsChmod.vue'
+</script>

--- a/tools/misc/chmod-calculator/src/components/ChmodCalculator.vue
+++ b/tools/misc/chmod-calculator/src/components/ChmodCalculator.vue
@@ -1,0 +1,40 @@
+<template>
+  <CommonPresets @select="updateFromNumeric" />
+
+  <NumericInput
+    :model-value="numericInput"
+    :is-valid="isValidNumericInput"
+    @update:model-value="updateFromNumeric"
+  />
+
+  <SymbolicInput
+    :model-value="symbolicInput"
+    :is-valid="isValidSymbolicInput"
+    @update:model-value="updateFromSymbolic"
+  />
+
+  <PermissionMatrix :permissions="permissions" @update="handleMatrixUpdate" />
+
+  <ChmodCommand :command="chmodCommand" />
+</template>
+
+<script setup lang="ts">
+import CommonPresets from './CommonPresets.vue'
+import NumericInput from './NumericInput.vue'
+import SymbolicInput from './SymbolicInput.vue'
+import PermissionMatrix from './PermissionMatrix.vue'
+import ChmodCommand from './ChmodCommand.vue'
+import { useChmodState } from '../composables/useChmodState'
+
+const {
+  numericInput,
+  symbolicInput,
+  permissions,
+  isValidNumericInput,
+  isValidSymbolicInput,
+  chmodCommand,
+  updateFromNumeric,
+  updateFromSymbolic,
+  updateFromMatrix: handleMatrixUpdate,
+} = useChmodState()
+</script>

--- a/tools/misc/chmod-calculator/src/components/ChmodCommand.vue
+++ b/tools/misc/chmod-calculator/src/components/ChmodCommand.vue
@@ -1,0 +1,102 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-flex align="center">
+      <n-text code style="font-size: 1.1rem">{{ command }}</n-text>
+      <CopyToClipboardButton :content="command" />
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NFlex, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+defineProps<{
+  command: string
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Chmod Command"
+  },
+  "zh": {
+    "title": "Chmod 命令"
+  },
+  "zh-CN": {
+    "title": "Chmod 命令"
+  },
+  "zh-TW": {
+    "title": "Chmod 指令"
+  },
+  "zh-HK": {
+    "title": "Chmod 指令"
+  },
+  "es": {
+    "title": "Comando Chmod"
+  },
+  "fr": {
+    "title": "Commande Chmod"
+  },
+  "de": {
+    "title": "Chmod-Befehl"
+  },
+  "it": {
+    "title": "Comando Chmod"
+  },
+  "ja": {
+    "title": "Chmod コマンド"
+  },
+  "ko": {
+    "title": "Chmod 명령어"
+  },
+  "ru": {
+    "title": "Команда Chmod"
+  },
+  "pt": {
+    "title": "Comando Chmod"
+  },
+  "ar": {
+    "title": "أمر Chmod"
+  },
+  "hi": {
+    "title": "Chmod कमांड"
+  },
+  "tr": {
+    "title": "Chmod Komutu"
+  },
+  "nl": {
+    "title": "Chmod-opdracht"
+  },
+  "sv": {
+    "title": "Chmod-kommando"
+  },
+  "pl": {
+    "title": "Polecenie Chmod"
+  },
+  "vi": {
+    "title": "Lệnh Chmod"
+  },
+  "th": {
+    "title": "คำสั่ง Chmod"
+  },
+  "id": {
+    "title": "Perintah Chmod"
+  },
+  "he": {
+    "title": "פקודת Chmod"
+  },
+  "ms": {
+    "title": "Perintah Chmod"
+  },
+  "no": {
+    "title": "Chmod-kommando"
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/components/CommonPresets.vue
+++ b/tools/misc/chmod-calculator/src/components/CommonPresets.vue
@@ -1,0 +1,266 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-flex>
+      <n-button
+        v-for="preset in presets"
+        :key="preset.value"
+        secondary
+        @click="$emit('select', preset.value)"
+      >
+        {{ preset.value }} - {{ t(preset.labelKey) }}
+      </n-button>
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NFlex, NButton } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+
+defineEmits<{
+  select: [value: string]
+}>()
+
+const { t } = useI18n()
+
+const presets = [
+  { value: '755', labelKey: 'executable' },
+  { value: '644', labelKey: 'readOnly' },
+  { value: '777', labelKey: 'fullAccess' },
+  { value: '700', labelKey: 'ownerOnly' },
+  { value: '600', labelKey: 'privateFile' },
+  { value: '775', labelKey: 'sharedDir' },
+]
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Common Presets",
+    "executable": "Executable",
+    "readOnly": "Read Only",
+    "fullAccess": "Full Access",
+    "ownerOnly": "Owner Only",
+    "privateFile": "Private File",
+    "sharedDir": "Shared Directory"
+  },
+  "zh": {
+    "title": "常用预设",
+    "executable": "可执行文件",
+    "readOnly": "只读文件",
+    "fullAccess": "完全访问",
+    "ownerOnly": "仅所有者",
+    "privateFile": "私有文件",
+    "sharedDir": "共享目录"
+  },
+  "zh-CN": {
+    "title": "常用预设",
+    "executable": "可执行文件",
+    "readOnly": "只读文件",
+    "fullAccess": "完全访问",
+    "ownerOnly": "仅所有者",
+    "privateFile": "私有文件",
+    "sharedDir": "共享目录"
+  },
+  "zh-TW": {
+    "title": "常用預設",
+    "executable": "可執行檔",
+    "readOnly": "唯讀檔案",
+    "fullAccess": "完全存取",
+    "ownerOnly": "僅擁有者",
+    "privateFile": "私有檔案",
+    "sharedDir": "共享目錄"
+  },
+  "zh-HK": {
+    "title": "常用預設",
+    "executable": "可執行檔",
+    "readOnly": "唯讀檔案",
+    "fullAccess": "完全存取",
+    "ownerOnly": "僅擁有者",
+    "privateFile": "私有檔案",
+    "sharedDir": "共享目錄"
+  },
+  "es": {
+    "title": "Preajustes comunes",
+    "executable": "Ejecutable",
+    "readOnly": "Solo lectura",
+    "fullAccess": "Acceso completo",
+    "ownerOnly": "Solo propietario",
+    "privateFile": "Archivo privado",
+    "sharedDir": "Directorio compartido"
+  },
+  "fr": {
+    "title": "Préréglages courants",
+    "executable": "Exécutable",
+    "readOnly": "Lecture seule",
+    "fullAccess": "Accès complet",
+    "ownerOnly": "Propriétaire seul",
+    "privateFile": "Fichier privé",
+    "sharedDir": "Répertoire partagé"
+  },
+  "de": {
+    "title": "Häufige Voreinstellungen",
+    "executable": "Ausführbar",
+    "readOnly": "Nur lesen",
+    "fullAccess": "Vollzugriff",
+    "ownerOnly": "Nur Eigentümer",
+    "privateFile": "Private Datei",
+    "sharedDir": "Freigegebenes Verzeichnis"
+  },
+  "it": {
+    "title": "Preset comuni",
+    "executable": "Eseguibile",
+    "readOnly": "Sola lettura",
+    "fullAccess": "Accesso completo",
+    "ownerOnly": "Solo proprietario",
+    "privateFile": "File privato",
+    "sharedDir": "Directory condivisa"
+  },
+  "ja": {
+    "title": "一般的なプリセット",
+    "executable": "実行可能",
+    "readOnly": "読み取り専用",
+    "fullAccess": "フルアクセス",
+    "ownerOnly": "所有者のみ",
+    "privateFile": "プライベートファイル",
+    "sharedDir": "共有ディレクトリ"
+  },
+  "ko": {
+    "title": "일반 프리셋",
+    "executable": "실행 가능",
+    "readOnly": "읽기 전용",
+    "fullAccess": "전체 액세스",
+    "ownerOnly": "소유자만",
+    "privateFile": "비공개 파일",
+    "sharedDir": "공유 디렉토리"
+  },
+  "ru": {
+    "title": "Общие пресеты",
+    "executable": "Исполняемый",
+    "readOnly": "Только чтение",
+    "fullAccess": "Полный доступ",
+    "ownerOnly": "Только владелец",
+    "privateFile": "Приватный файл",
+    "sharedDir": "Общий каталог"
+  },
+  "pt": {
+    "title": "Predefinições comuns",
+    "executable": "Executável",
+    "readOnly": "Somente leitura",
+    "fullAccess": "Acesso total",
+    "ownerOnly": "Apenas proprietário",
+    "privateFile": "Arquivo privado",
+    "sharedDir": "Diretório compartilhado"
+  },
+  "ar": {
+    "title": "إعدادات مسبقة شائعة",
+    "executable": "قابل للتنفيذ",
+    "readOnly": "للقراءة فقط",
+    "fullAccess": "وصول كامل",
+    "ownerOnly": "المالك فقط",
+    "privateFile": "ملف خاص",
+    "sharedDir": "مجلد مشترك"
+  },
+  "hi": {
+    "title": "सामान्य प्रीसेट",
+    "executable": "निष्पादन योग्य",
+    "readOnly": "केवल पढ़ने के लिए",
+    "fullAccess": "पूर्ण पहुँच",
+    "ownerOnly": "केवल स्वामी",
+    "privateFile": "निजी फ़ाइल",
+    "sharedDir": "साझा निर्देशिका"
+  },
+  "tr": {
+    "title": "Yaygın Ön Ayarlar",
+    "executable": "Çalıştırılabilir",
+    "readOnly": "Salt Okunur",
+    "fullAccess": "Tam Erişim",
+    "ownerOnly": "Yalnızca Sahip",
+    "privateFile": "Özel Dosya",
+    "sharedDir": "Paylaşılan Dizin"
+  },
+  "nl": {
+    "title": "Veelgebruikte presets",
+    "executable": "Uitvoerbaar",
+    "readOnly": "Alleen-lezen",
+    "fullAccess": "Volledige toegang",
+    "ownerOnly": "Alleen eigenaar",
+    "privateFile": "Privébestand",
+    "sharedDir": "Gedeelde map"
+  },
+  "sv": {
+    "title": "Vanliga förinställningar",
+    "executable": "Körbar",
+    "readOnly": "Skrivskyddad",
+    "fullAccess": "Full åtkomst",
+    "ownerOnly": "Endast ägare",
+    "privateFile": "Privat fil",
+    "sharedDir": "Delad katalog"
+  },
+  "pl": {
+    "title": "Typowe ustawienia",
+    "executable": "Wykonywalny",
+    "readOnly": "Tylko odczyt",
+    "fullAccess": "Pełny dostęp",
+    "ownerOnly": "Tylko właściciel",
+    "privateFile": "Plik prywatny",
+    "sharedDir": "Katalog współdzielony"
+  },
+  "vi": {
+    "title": "Cài đặt phổ biến",
+    "executable": "Thực thi được",
+    "readOnly": "Chỉ đọc",
+    "fullAccess": "Toàn quyền",
+    "ownerOnly": "Chỉ chủ sở hữu",
+    "privateFile": "Tệp riêng tư",
+    "sharedDir": "Thư mục chia sẻ"
+  },
+  "th": {
+    "title": "ค่าที่ตั้งไว้ทั่วไป",
+    "executable": "ไฟล์รันได้",
+    "readOnly": "อ่านอย่างเดียว",
+    "fullAccess": "เข้าถึงเต็มที่",
+    "ownerOnly": "เจ้าของเท่านั้น",
+    "privateFile": "ไฟล์ส่วนตัว",
+    "sharedDir": "ไดเรกทอรีแชร์"
+  },
+  "id": {
+    "title": "Preset Umum",
+    "executable": "Dapat dieksekusi",
+    "readOnly": "Hanya baca",
+    "fullAccess": "Akses penuh",
+    "ownerOnly": "Hanya pemilik",
+    "privateFile": "File pribadi",
+    "sharedDir": "Direktori bersama"
+  },
+  "he": {
+    "title": "הגדרות נפוצות",
+    "executable": "ניתן להרצה",
+    "readOnly": "קריאה בלבד",
+    "fullAccess": "גישה מלאה",
+    "ownerOnly": "בעלים בלבד",
+    "privateFile": "קובץ פרטי",
+    "sharedDir": "ספרייה משותפת"
+  },
+  "ms": {
+    "title": "Pratetap Biasa",
+    "executable": "Boleh dilaksanakan",
+    "readOnly": "Baca sahaja",
+    "fullAccess": "Akses penuh",
+    "ownerOnly": "Pemilik sahaja",
+    "privateFile": "Fail peribadi",
+    "sharedDir": "Direktori kongsi"
+  },
+  "no": {
+    "title": "Vanlige forhåndsinnstillinger",
+    "executable": "Kjørbar",
+    "readOnly": "Skrivebeskyttet",
+    "fullAccess": "Full tilgang",
+    "ownerOnly": "Kun eier",
+    "privateFile": "Privat fil",
+    "sharedDir": "Delt katalog"
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/components/NumericInput.vue
+++ b/tools/misc/chmod-calculator/src/components/NumericInput.vue
@@ -1,0 +1,139 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-flex align="center">
+      <n-input
+        :value="modelValue"
+        :placeholder="t('placeholder')"
+        size="large"
+        style="max-width: 200px"
+        :status="isValid ? undefined : 'error'"
+        @update:value="$emit('update:modelValue', $event)"
+      />
+      <CopyToClipboardButton :content="modelValue" />
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NInput, NFlex } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+defineProps<{
+  modelValue: string
+  isValid: boolean
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Numeric Permission",
+    "placeholder": "e.g., 755"
+  },
+  "zh": {
+    "title": "数字权限",
+    "placeholder": "例如 755"
+  },
+  "zh-CN": {
+    "title": "数字权限",
+    "placeholder": "例如 755"
+  },
+  "zh-TW": {
+    "title": "數字權限",
+    "placeholder": "例如 755"
+  },
+  "zh-HK": {
+    "title": "數字權限",
+    "placeholder": "例如 755"
+  },
+  "es": {
+    "title": "Permiso numérico",
+    "placeholder": "ej., 755"
+  },
+  "fr": {
+    "title": "Permission numérique",
+    "placeholder": "ex., 755"
+  },
+  "de": {
+    "title": "Numerische Berechtigung",
+    "placeholder": "z.B. 755"
+  },
+  "it": {
+    "title": "Permesso numerico",
+    "placeholder": "es., 755"
+  },
+  "ja": {
+    "title": "数値パーミッション",
+    "placeholder": "例: 755"
+  },
+  "ko": {
+    "title": "숫자 권한",
+    "placeholder": "예: 755"
+  },
+  "ru": {
+    "title": "Числовое разрешение",
+    "placeholder": "напр., 755"
+  },
+  "pt": {
+    "title": "Permissão numérica",
+    "placeholder": "ex., 755"
+  },
+  "ar": {
+    "title": "الإذن الرقمي",
+    "placeholder": "مثال: 755"
+  },
+  "hi": {
+    "title": "संख्यात्मक अनुमति",
+    "placeholder": "उदा., 755"
+  },
+  "tr": {
+    "title": "Sayısal İzin",
+    "placeholder": "örn., 755"
+  },
+  "nl": {
+    "title": "Numerieke machtiging",
+    "placeholder": "bijv. 755"
+  },
+  "sv": {
+    "title": "Numerisk behörighet",
+    "placeholder": "t.ex. 755"
+  },
+  "pl": {
+    "title": "Uprawnienie numeryczne",
+    "placeholder": "np. 755"
+  },
+  "vi": {
+    "title": "Quyền dạng số",
+    "placeholder": "ví dụ: 755"
+  },
+  "th": {
+    "title": "สิทธิ์แบบตัวเลข",
+    "placeholder": "เช่น 755"
+  },
+  "id": {
+    "title": "Izin Numerik",
+    "placeholder": "mis., 755"
+  },
+  "he": {
+    "title": "הרשאה מספרית",
+    "placeholder": "לדוגמה, 755"
+  },
+  "ms": {
+    "title": "Kebenaran Numerik",
+    "placeholder": "cth., 755"
+  },
+  "no": {
+    "title": "Numerisk tillatelse",
+    "placeholder": "f.eks. 755"
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/components/PermissionMatrix.vue
+++ b/tools/misc/chmod-calculator/src/components/PermissionMatrix.vue
@@ -1,0 +1,341 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-table :bordered="false" :single-line="false" size="small">
+      <thead>
+        <tr>
+          <th></th>
+          <th style="text-align: center">{{ t('read') }} (r)</th>
+          <th style="text-align: center">{{ t('write') }} (w)</th>
+          <th style="text-align: center">{{ t('execute') }} (x)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <strong>{{ t('owner') }}</strong>
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.owner.read"
+              @update:checked="update('owner', 'read', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.owner.write"
+              @update:checked="update('owner', 'write', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.owner.execute"
+              @update:checked="update('owner', 'execute', $event)"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <strong>{{ t('group') }}</strong>
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.group.read"
+              @update:checked="update('group', 'read', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.group.write"
+              @update:checked="update('group', 'write', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.group.execute"
+              @update:checked="update('group', 'execute', $event)"
+            />
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <strong>{{ t('others') }}</strong>
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.others.read"
+              @update:checked="update('others', 'read', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.others.write"
+              @update:checked="update('others', 'write', $event)"
+            />
+          </td>
+          <td style="text-align: center">
+            <n-checkbox
+              :checked="permissions.others.execute"
+              @update:checked="update('others', 'execute', $event)"
+            />
+          </td>
+        </tr>
+      </tbody>
+    </n-table>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NCheckbox, NTable } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import type { Permissions } from '../composables/useChmodState'
+
+defineProps<{
+  permissions: Permissions
+}>()
+
+const emit = defineEmits<{
+  update: [role: 'owner' | 'group' | 'others', perm: 'read' | 'write' | 'execute', value: boolean]
+}>()
+
+const { t } = useI18n()
+
+function update(
+  role: 'owner' | 'group' | 'others',
+  perm: 'read' | 'write' | 'execute',
+  value: boolean,
+) {
+  emit('update', role, perm, value)
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Permission Matrix",
+    "read": "Read",
+    "write": "Write",
+    "execute": "Execute",
+    "owner": "Owner",
+    "group": "Group",
+    "others": "Others"
+  },
+  "zh": {
+    "title": "权限矩阵",
+    "read": "读取",
+    "write": "写入",
+    "execute": "执行",
+    "owner": "所有者",
+    "group": "用户组",
+    "others": "其他用户"
+  },
+  "zh-CN": {
+    "title": "权限矩阵",
+    "read": "读取",
+    "write": "写入",
+    "execute": "执行",
+    "owner": "所有者",
+    "group": "用户组",
+    "others": "其他用户"
+  },
+  "zh-TW": {
+    "title": "權限矩陣",
+    "read": "讀取",
+    "write": "寫入",
+    "execute": "執行",
+    "owner": "擁有者",
+    "group": "群組",
+    "others": "其他使用者"
+  },
+  "zh-HK": {
+    "title": "權限矩陣",
+    "read": "讀取",
+    "write": "寫入",
+    "execute": "執行",
+    "owner": "擁有者",
+    "group": "群組",
+    "others": "其他使用者"
+  },
+  "es": {
+    "title": "Matriz de permisos",
+    "read": "Lectura",
+    "write": "Escritura",
+    "execute": "Ejecución",
+    "owner": "Propietario",
+    "group": "Grupo",
+    "others": "Otros"
+  },
+  "fr": {
+    "title": "Matrice des permissions",
+    "read": "Lecture",
+    "write": "Écriture",
+    "execute": "Exécution",
+    "owner": "Propriétaire",
+    "group": "Groupe",
+    "others": "Autres"
+  },
+  "de": {
+    "title": "Berechtigungsmatrix",
+    "read": "Lesen",
+    "write": "Schreiben",
+    "execute": "Ausführen",
+    "owner": "Eigentümer",
+    "group": "Gruppe",
+    "others": "Andere"
+  },
+  "it": {
+    "title": "Matrice dei permessi",
+    "read": "Lettura",
+    "write": "Scrittura",
+    "execute": "Esecuzione",
+    "owner": "Proprietario",
+    "group": "Gruppo",
+    "others": "Altri"
+  },
+  "ja": {
+    "title": "パーミッションマトリックス",
+    "read": "読み取り",
+    "write": "書き込み",
+    "execute": "実行",
+    "owner": "所有者",
+    "group": "グループ",
+    "others": "その他"
+  },
+  "ko": {
+    "title": "권한 매트릭스",
+    "read": "읽기",
+    "write": "쓰기",
+    "execute": "실행",
+    "owner": "소유자",
+    "group": "그룹",
+    "others": "기타"
+  },
+  "ru": {
+    "title": "Матрица разрешений",
+    "read": "Чтение",
+    "write": "Запись",
+    "execute": "Выполнение",
+    "owner": "Владелец",
+    "group": "Группа",
+    "others": "Другие"
+  },
+  "pt": {
+    "title": "Matriz de permissões",
+    "read": "Leitura",
+    "write": "Escrita",
+    "execute": "Execução",
+    "owner": "Proprietário",
+    "group": "Grupo",
+    "others": "Outros"
+  },
+  "ar": {
+    "title": "مصفوفة الأذونات",
+    "read": "قراءة",
+    "write": "كتابة",
+    "execute": "تنفيذ",
+    "owner": "المالك",
+    "group": "المجموعة",
+    "others": "الآخرون"
+  },
+  "hi": {
+    "title": "अनुमति मैट्रिक्स",
+    "read": "पढ़ें",
+    "write": "लिखें",
+    "execute": "निष्पादित करें",
+    "owner": "स्वामी",
+    "group": "समूह",
+    "others": "अन्य"
+  },
+  "tr": {
+    "title": "İzin Matrisi",
+    "read": "Okuma",
+    "write": "Yazma",
+    "execute": "Çalıştırma",
+    "owner": "Sahip",
+    "group": "Grup",
+    "others": "Diğerleri"
+  },
+  "nl": {
+    "title": "Machtigingsmatrix",
+    "read": "Lezen",
+    "write": "Schrijven",
+    "execute": "Uitvoeren",
+    "owner": "Eigenaar",
+    "group": "Groep",
+    "others": "Anderen"
+  },
+  "sv": {
+    "title": "Behörighetsmatris",
+    "read": "Läsa",
+    "write": "Skriva",
+    "execute": "Köra",
+    "owner": "Ägare",
+    "group": "Grupp",
+    "others": "Andra"
+  },
+  "pl": {
+    "title": "Macierz uprawnień",
+    "read": "Odczyt",
+    "write": "Zapis",
+    "execute": "Wykonanie",
+    "owner": "Właściciel",
+    "group": "Grupa",
+    "others": "Inni"
+  },
+  "vi": {
+    "title": "Ma trận quyền",
+    "read": "Đọc",
+    "write": "Ghi",
+    "execute": "Thực thi",
+    "owner": "Chủ sở hữu",
+    "group": "Nhóm",
+    "others": "Người khác"
+  },
+  "th": {
+    "title": "ตารางสิทธิ์",
+    "read": "อ่าน",
+    "write": "เขียน",
+    "execute": "รัน",
+    "owner": "เจ้าของ",
+    "group": "กลุ่ม",
+    "others": "ผู้อื่น"
+  },
+  "id": {
+    "title": "Matriks Izin",
+    "read": "Baca",
+    "write": "Tulis",
+    "execute": "Eksekusi",
+    "owner": "Pemilik",
+    "group": "Grup",
+    "others": "Lainnya"
+  },
+  "he": {
+    "title": "מטריצת הרשאות",
+    "read": "קריאה",
+    "write": "כתיבה",
+    "execute": "הרצה",
+    "owner": "בעלים",
+    "group": "קבוצה",
+    "others": "אחרים"
+  },
+  "ms": {
+    "title": "Matriks Kebenaran",
+    "read": "Baca",
+    "write": "Tulis",
+    "execute": "Laksana",
+    "owner": "Pemilik",
+    "group": "Kumpulan",
+    "others": "Lain-lain"
+  },
+  "no": {
+    "title": "Tillatelsesmatrise",
+    "read": "Les",
+    "write": "Skriv",
+    "execute": "Kjør",
+    "owner": "Eier",
+    "group": "Gruppe",
+    "others": "Andre"
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/components/SymbolicInput.vue
+++ b/tools/misc/chmod-calculator/src/components/SymbolicInput.vue
@@ -1,0 +1,139 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-flex align="center">
+      <n-input
+        :value="modelValue"
+        :placeholder="t('placeholder')"
+        size="large"
+        style="max-width: 200px; font-family: monospace"
+        :status="isValid ? undefined : 'error'"
+        @update:value="$emit('update:modelValue', $event)"
+      />
+      <CopyToClipboardButton :content="modelValue" />
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NInput, NFlex } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+defineProps<{
+  modelValue: string
+  isValid: boolean
+}>()
+
+defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Symbolic Permission",
+    "placeholder": "e.g., rwxr-xr-x"
+  },
+  "zh": {
+    "title": "符号权限",
+    "placeholder": "例如 rwxr-xr-x"
+  },
+  "zh-CN": {
+    "title": "符号权限",
+    "placeholder": "例如 rwxr-xr-x"
+  },
+  "zh-TW": {
+    "title": "符號權限",
+    "placeholder": "例如 rwxr-xr-x"
+  },
+  "zh-HK": {
+    "title": "符號權限",
+    "placeholder": "例如 rwxr-xr-x"
+  },
+  "es": {
+    "title": "Permiso simbólico",
+    "placeholder": "ej., rwxr-xr-x"
+  },
+  "fr": {
+    "title": "Permission symbolique",
+    "placeholder": "ex., rwxr-xr-x"
+  },
+  "de": {
+    "title": "Symbolische Berechtigung",
+    "placeholder": "z.B. rwxr-xr-x"
+  },
+  "it": {
+    "title": "Permesso simbolico",
+    "placeholder": "es., rwxr-xr-x"
+  },
+  "ja": {
+    "title": "シンボリックパーミッション",
+    "placeholder": "例: rwxr-xr-x"
+  },
+  "ko": {
+    "title": "기호 권한",
+    "placeholder": "예: rwxr-xr-x"
+  },
+  "ru": {
+    "title": "Символьное разрешение",
+    "placeholder": "напр., rwxr-xr-x"
+  },
+  "pt": {
+    "title": "Permissão simbólica",
+    "placeholder": "ex., rwxr-xr-x"
+  },
+  "ar": {
+    "title": "الإذن الرمزي",
+    "placeholder": "مثال: rwxr-xr-x"
+  },
+  "hi": {
+    "title": "प्रतीकात्मक अनुमति",
+    "placeholder": "उदा., rwxr-xr-x"
+  },
+  "tr": {
+    "title": "Sembolik İzin",
+    "placeholder": "örn., rwxr-xr-x"
+  },
+  "nl": {
+    "title": "Symbolische machtiging",
+    "placeholder": "bijv. rwxr-xr-x"
+  },
+  "sv": {
+    "title": "Symbolisk behörighet",
+    "placeholder": "t.ex. rwxr-xr-x"
+  },
+  "pl": {
+    "title": "Uprawnienie symboliczne",
+    "placeholder": "np. rwxr-xr-x"
+  },
+  "vi": {
+    "title": "Quyền dạng ký hiệu",
+    "placeholder": "ví dụ: rwxr-xr-x"
+  },
+  "th": {
+    "title": "สิทธิ์แบบสัญลักษณ์",
+    "placeholder": "เช่น rwxr-xr-x"
+  },
+  "id": {
+    "title": "Izin Simbolik",
+    "placeholder": "mis., rwxr-xr-x"
+  },
+  "he": {
+    "title": "הרשאה סימבולית",
+    "placeholder": "לדוגמה, rwxr-xr-x"
+  },
+  "ms": {
+    "title": "Kebenaran Simbolik",
+    "placeholder": "cth., rwxr-xr-x"
+  },
+  "no": {
+    "title": "Symbolsk tillatelse",
+    "placeholder": "f.eks. rwxr-xr-x"
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/components/WhatIsChmod.vue
+++ b/tools/misc/chmod-calculator/src/components/WhatIsChmod.vue
@@ -1,0 +1,125 @@
+<template>
+  <ToolSectionHeader>
+    {{ t('title') }}
+  </ToolSectionHeader>
+  <ToolSection>
+    <i18n-t keypath="description">
+      <template #example>
+        <n-text code>chmod 755 script.sh</n-text>
+      </template>
+    </i18n-t>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is chmod?",
+    "description": "chmod (change mode) is a Unix/Linux command used to change file and directory permissions. Permissions are represented in two formats: numeric (octal) notation like 755, or symbolic notation like rwxr-xr-x. Each digit in the numeric format represents permissions for owner, group, and others respectively, where 4 = read (r), 2 = write (w), and 1 = execute (x). These values are added together: 7 (4+2+1) means full access, 5 (4+1) means read and execute, 4 means read-only. For example, {example} gives the owner full permissions while allowing others to read and execute the file."
+  },
+  "zh": {
+    "title": "什么是 chmod？",
+    "description": "chmod（change mode）是一个用于更改文件和目录权限的 Unix/Linux 命令。权限有两种表示格式：数字（八进制）表示法（如 755）或符号表示法（如 rwxr-xr-x）。数字格式中的每一位分别代表所有者、用户组和其他用户的权限，其中 4 = 读取（r），2 = 写入（w），1 = 执行（x）。这些值相加：7（4+2+1）表示完全访问权限，5（4+1）表示读取和执行权限，4 表示只读权限。例如，{example} 给予所有者完全权限，同时允许其他人读取和执行该文件。"
+  },
+  "zh-CN": {
+    "title": "什么是 chmod？",
+    "description": "chmod（change mode）是一个用于更改文件和目录权限的 Unix/Linux 命令。权限有两种表示格式：数字（八进制）表示法（如 755）或符号表示法（如 rwxr-xr-x）。数字格式中的每一位分别代表所有者、用户组和其他用户的权限，其中 4 = 读取（r），2 = 写入（w），1 = 执行（x）。这些值相加：7（4+2+1）表示完全访问权限，5（4+1）表示读取和执行权限，4 表示只读权限。例如，{example} 给予所有者完全权限，同时允许其他人读取和执行该文件。"
+  },
+  "zh-TW": {
+    "title": "什麼是 chmod？",
+    "description": "chmod（change mode）是一個用於更改檔案和目錄權限的 Unix/Linux 指令。權限有兩種表示格式：數字（八進位）表示法（如 755）或符號表示法（如 rwxr-xr-x）。數字格式中的每一位分別代表擁有者、群組和其他使用者的權限，其中 4 = 讀取（r），2 = 寫入（w），1 = 執行（x）。這些值相加：7（4+2+1）表示完全存取權限，5（4+1）表示讀取和執行權限，4 表示唯讀權限。例如，{example} 給予擁有者完全權限，同時允許其他人讀取和執行該檔案。"
+  },
+  "zh-HK": {
+    "title": "什麼是 chmod？",
+    "description": "chmod（change mode）是一個用於更改檔案和目錄權限的 Unix/Linux 指令。權限有兩種表示格式：數字（八進制）表示法（如 755）或符號表示法（如 rwxr-xr-x）。數字格式中的每一位分別代表擁有者、群組和其他使用者的權限，其中 4 = 讀取（r），2 = 寫入（w），1 = 執行（x）。這些值相加：7（4+2+1）表示完全存取權限，5（4+1）表示讀取和執行權限，4 表示唯讀權限。例如，{example} 給予擁有者完全權限，同時允許其他人讀取和執行該檔案。"
+  },
+  "es": {
+    "title": "Que es chmod?",
+    "description": "chmod (change mode) es un comando de Unix/Linux utilizado para cambiar los permisos de archivos y directorios. Los permisos se representan en dos formatos: notacion numerica (octal) como 755, o notacion simbolica como rwxr-xr-x. Cada digito en el formato numerico representa los permisos para el propietario, grupo y otros respectivamente, donde 4 = lectura (r), 2 = escritura (w) y 1 = ejecucion (x). Estos valores se suman: 7 (4+2+1) significa acceso completo, 5 (4+1) significa lectura y ejecucion, 4 significa solo lectura. Por ejemplo, {example} otorga al propietario permisos completos mientras permite a otros leer y ejecutar el archivo."
+  },
+  "fr": {
+    "title": "Qu'est-ce que chmod ?",
+    "description": "chmod (change mode) est une commande Unix/Linux utilisee pour modifier les permissions des fichiers et repertoires. Les permissions sont representees sous deux formats : notation numerique (octale) comme 755, ou notation symbolique comme rwxr-xr-x. Chaque chiffre dans le format numerique represente les permissions pour le proprietaire, le groupe et les autres respectivement, ou 4 = lecture (r), 2 = ecriture (w) et 1 = execution (x). Ces valeurs s'additionnent : 7 (4+2+1) signifie acces complet, 5 (4+1) signifie lecture et execution, 4 signifie lecture seule. Par exemple, {example} donne au proprietaire tous les droits tout en permettant aux autres de lire et d'executer le fichier."
+  },
+  "de": {
+    "title": "Was ist chmod?",
+    "description": "chmod (change mode) ist ein Unix/Linux-Befehl zum Andern von Datei- und Verzeichnisberechtigungen. Berechtigungen werden in zwei Formaten dargestellt: numerische (oktale) Notation wie 755 oder symbolische Notation wie rwxr-xr-x. Jede Ziffer im numerischen Format reprasentiert die Berechtigungen fur Eigentumer, Gruppe und Andere, wobei 4 = Lesen (r), 2 = Schreiben (w) und 1 = Ausfuhren (x). Diese Werte werden addiert: 7 (4+2+1) bedeutet Vollzugriff, 5 (4+1) bedeutet Lesen und Ausfuhren, 4 bedeutet nur Lesen. Zum Beispiel gibt {example} dem Eigentumer volle Berechtigungen, wahrend andere die Datei lesen und ausfuhren konnen."
+  },
+  "it": {
+    "title": "Cos'e chmod?",
+    "description": "chmod (change mode) e un comando Unix/Linux utilizzato per modificare i permessi di file e directory. I permessi sono rappresentati in due formati: notazione numerica (ottale) come 755, o notazione simbolica come rwxr-xr-x. Ogni cifra nel formato numerico rappresenta i permessi per proprietario, gruppo e altri rispettivamente, dove 4 = lettura (r), 2 = scrittura (w) e 1 = esecuzione (x). Questi valori si sommano: 7 (4+2+1) significa accesso completo, 5 (4+1) significa lettura ed esecuzione, 4 significa sola lettura. Ad esempio, {example} concede al proprietario i permessi completi consentendo agli altri di leggere ed eseguire il file."
+  },
+  "ja": {
+    "title": "chmod とは？",
+    "description": "chmod（change mode）は、ファイルやディレクトリのパーミッションを変更するための Unix/Linux コマンドです。パーミッションは 2 つの形式で表されます：755 のような数値（8進数）表記、または rwxr-xr-x のような記号表記です。数値形式の各桁は、それぞれ所有者、グループ、その他のユーザーのパーミッションを表し、4 = 読み取り（r）、2 = 書き込み（w）、1 = 実行（x）です。これらの値を合計します：7（4+2+1）はフルアクセス、5（4+1）は読み取りと実行、4 は読み取り専用を意味します。例えば、{example} は所有者にフルパーミッションを与え、他のユーザーにはファイルの読み取りと実行を許可します。"
+  },
+  "ko": {
+    "title": "chmod란 무엇인가요?",
+    "description": "chmod(change mode)는 파일 및 디렉토리 권한을 변경하는 데 사용되는 Unix/Linux 명령어입니다. 권한은 755와 같은 숫자(8진수) 표기법 또는 rwxr-xr-x와 같은 기호 표기법의 두 가지 형식으로 표현됩니다. 숫자 형식의 각 자릿수는 각각 소유자, 그룹, 기타 사용자의 권한을 나타내며, 4 = 읽기(r), 2 = 쓰기(w), 1 = 실행(x)입니다. 이 값들을 합산합니다: 7(4+2+1)은 전체 액세스, 5(4+1)는 읽기 및 실행, 4는 읽기 전용을 의미합니다. 예를 들어, {example}은 소유자에게 전체 권한을 부여하고 다른 사용자에게는 파일을 읽고 실행할 수 있도록 허용합니다."
+  },
+  "ru": {
+    "title": "Что такое chmod?",
+    "description": "chmod (change mode) — это команда Unix/Linux, используемая для изменения прав доступа к файлам и каталогам. Права представляются в двух форматах: числовая (восьмеричная) запись, например 755, или символьная запись, например rwxr-xr-x. Каждая цифра в числовом формате представляет права для владельца, группы и остальных соответственно, где 4 = чтение (r), 2 = запись (w) и 1 = выполнение (x). Эти значения складываются: 7 (4+2+1) означает полный доступ, 5 (4+1) — чтение и выполнение, 4 — только чтение. Например, {example} дает владельцу полные права, позволяя остальным читать и выполнять файл."
+  },
+  "pt": {
+    "title": "O que e chmod?",
+    "description": "chmod (change mode) e um comando Unix/Linux usado para alterar permissoes de arquivos e diretorios. As permissoes sao representadas em dois formatos: notacao numerica (octal) como 755, ou notacao simbolica como rwxr-xr-x. Cada digito no formato numerico representa as permissoes para proprietario, grupo e outros respectivamente, onde 4 = leitura (r), 2 = escrita (w) e 1 = execucao (x). Esses valores sao somados: 7 (4+2+1) significa acesso total, 5 (4+1) significa leitura e execucao, 4 significa somente leitura. Por exemplo, {example} da ao proprietario permissoes totais enquanto permite que outros leiam e executem o arquivo."
+  },
+  "ar": {
+    "title": "ما هو chmod؟",
+    "description": "chmod (تغيير الوضع) هو أمر Unix/Linux يُستخدم لتغيير صلاحيات الملفات والمجلدات. تُمثَّل الصلاحيات بصيغتين: الترميز الرقمي (الثماني) مثل 755، أو الترميز الرمزي مثل rwxr-xr-x. كل رقم في الصيغة الرقمية يمثل الصلاحيات للمالك والمجموعة والآخرين على التوالي، حيث 4 = قراءة (r)، 2 = كتابة (w)، و 1 = تنفيذ (x). تُجمع هذه القيم: 7 (4+2+1) تعني وصول كامل، 5 (4+1) تعني قراءة وتنفيذ، 4 تعني قراءة فقط. على سبيل المثال، {example} يمنح المالك صلاحيات كاملة بينما يسمح للآخرين بقراءة وتنفيذ الملف."
+  },
+  "hi": {
+    "title": "chmod क्या है?",
+    "description": "chmod (change mode) एक Unix/Linux कमांड है जिसका उपयोग फ़ाइल और डायरेक्टरी अनुमतियों को बदलने के लिए किया जाता है। अनुमतियाँ दो प्रारूपों में दर्शाई जाती हैं: संख्यात्मक (ऑक्टल) नोटेशन जैसे 755, या सांकेतिक नोटेशन जैसे rwxr-xr-x। संख्यात्मक प्रारूप में प्रत्येक अंक क्रमशः स्वामी, समूह और अन्य के लिए अनुमतियों को दर्शाता है, जहाँ 4 = पढ़ना (r), 2 = लिखना (w), और 1 = निष्पादित करना (x)। ये मान जोड़े जाते हैं: 7 (4+2+1) का अर्थ है पूर्ण पहुँच, 5 (4+1) का अर्थ है पढ़ना और निष्पादित करना, 4 का अर्थ है केवल पढ़ना। उदाहरण के लिए, {example} स्वामी को पूर्ण अनुमतियाँ देता है जबकि अन्य को फ़ाइल पढ़ने और निष्पादित करने की अनुमति देता है।"
+  },
+  "tr": {
+    "title": "chmod nedir?",
+    "description": "chmod (change mode), dosya ve dizin izinlerini degistirmek icin kullanilan bir Unix/Linux komutudur. Izinler iki formatta temsil edilir: 755 gibi sayisal (sekizlik) gosterim veya rwxr-xr-x gibi sembolik gosterim. Sayisal formattaki her rakam sirasiyla sahip, grup ve diger kullanicilar icin izinleri temsil eder; burada 4 = okuma (r), 2 = yazma (w) ve 1 = calistirma (x). Bu degerler toplanir: 7 (4+2+1) tam erisim, 5 (4+1) okuma ve calistirma, 4 yalnizca okuma anlamina gelir. Ornegin, {example} sahibine tam izinler verirken digerlerinin dosyayi okumasina ve calistirmasina izin verir."
+  },
+  "nl": {
+    "title": "Wat is chmod?",
+    "description": "chmod (change mode) is een Unix/Linux-opdracht die wordt gebruikt om bestands- en maprechten te wijzigen. Rechten worden weergegeven in twee formaten: numerieke (octale) notatie zoals 755, of symbolische notatie zoals rwxr-xr-x. Elk cijfer in het numerieke formaat vertegenwoordigt de rechten voor eigenaar, groep en anderen respectievelijk, waarbij 4 = lezen (r), 2 = schrijven (w) en 1 = uitvoeren (x). Deze waarden worden opgeteld: 7 (4+2+1) betekent volledige toegang, 5 (4+1) betekent lezen en uitvoeren, 4 betekent alleen-lezen. Bijvoorbeeld, {example} geeft de eigenaar volledige rechten terwijl anderen het bestand mogen lezen en uitvoeren."
+  },
+  "sv": {
+    "title": "Vad ar chmod?",
+    "description": "chmod (change mode) ar ett Unix/Linux-kommando som anvands for att andra fil- och katalogbehorigheter. Behorigheter representeras i tva format: numerisk (oktal) notation som 755, eller symbolisk notation som rwxr-xr-x. Varje siffra i det numeriska formatet representerar behorigheter for agare, grupp och andra respektive, dar 4 = lasa (r), 2 = skriva (w) och 1 = kora (x). Dessa varden laggs ihop: 7 (4+2+1) innebar full atkomst, 5 (4+1) innebar lasa och kora, 4 innebar endast lasa. Till exempel ger {example} agaren fulla behorigheter medan andra far lasa och kora filen."
+  },
+  "pl": {
+    "title": "Czym jest chmod?",
+    "description": "chmod (change mode) to polecenie Unix/Linux uzywane do zmiany uprawnien plikow i katalogow. Uprawnienia sa reprezentowane w dwoch formatach: notacja numeryczna (osemkowa) jak 755 lub notacja symboliczna jak rwxr-xr-x. Kazda cyfra w formacie numerycznym reprezentuje uprawnienia odpowiednio dla wlasciciela, grupy i innych, gdzie 4 = odczyt (r), 2 = zapis (w) i 1 = wykonanie (x). Te wartosci sa sumowane: 7 (4+2+1) oznacza pelny dostep, 5 (4+1) oznacza odczyt i wykonanie, 4 oznacza tylko odczyt. Na przyklad {example} daje wlascicielowi pelne uprawnienia, pozwalajac innym czytac i uruchamiac plik."
+  },
+  "vi": {
+    "title": "chmod la gi?",
+    "description": "chmod (change mode) la mot lenh Unix/Linux duoc su dung de thay doi quyen truy cap tep va thu muc. Quyen duoc bieu dien o hai dinh dang: ky hieu so (bat phan) nhu 755, hoac ky hieu ky tu nhu rwxr-xr-x. Moi chu so trong dinh dang so dai dien cho quyen cua chu so huu, nhom va nguoi khac tuong ung, trong do 4 = doc (r), 2 = ghi (w) va 1 = thuc thi (x). Cac gia tri nay duoc cong lai: 7 (4+2+1) nghia la toan quyen, 5 (4+1) nghia la doc va thuc thi, 4 nghia la chi doc. Vi du, {example} cap cho chu so huu toan quyen trong khi cho phep nguoi khac doc va thuc thi tep."
+  },
+  "th": {
+    "title": "chmod คืออะไร?",
+    "description": "chmod (change mode) เป็นคำสั่ง Unix/Linux ที่ใช้เปลี่ยนสิทธิ์การเข้าถึงไฟล์และไดเรกทอรี สิทธิ์จะแสดงในสองรูปแบบ: รูปแบบตัวเลข (ฐานแปด) เช่น 755 หรือรูปแบบสัญลักษณ์ เช่น rwxr-xr-x ตัวเลขแต่ละหลักในรูปแบบตัวเลขแสดงถึงสิทธิ์ของเจ้าของ กลุ่ม และผู้อื่นตามลำดับ โดย 4 = อ่าน (r), 2 = เขียน (w) และ 1 = รัน (x) ค่าเหล่านี้จะถูกรวมกัน: 7 (4+2+1) หมายถึงสิทธิ์เต็ม, 5 (4+1) หมายถึงอ่านและรัน, 4 หมายถึงอ่านอย่างเดียว ตัวอย่างเช่น {example} ให้สิทธิ์เต็มแก่เจ้าของในขณะที่อนุญาตให้ผู้อื่นอ่านและรันไฟล์"
+  },
+  "id": {
+    "title": "Apa itu chmod?",
+    "description": "chmod (change mode) adalah perintah Unix/Linux yang digunakan untuk mengubah izin file dan direktori. Izin direpresentasikan dalam dua format: notasi numerik (oktal) seperti 755, atau notasi simbolik seperti rwxr-xr-x. Setiap digit dalam format numerik mewakili izin untuk pemilik, grup, dan lainnya masing-masing, di mana 4 = baca (r), 2 = tulis (w), dan 1 = eksekusi (x). Nilai-nilai ini dijumlahkan: 7 (4+2+1) berarti akses penuh, 5 (4+1) berarti baca dan eksekusi, 4 berarti hanya baca. Misalnya, {example} memberikan pemilik izin penuh sementara mengizinkan yang lain untuk membaca dan mengeksekusi file."
+  },
+  "he": {
+    "title": "מה זה chmod?",
+    "description": "chmod (change mode) היא פקודת Unix/Linux המשמשת לשינוי הרשאות קבצים ותיקיות. הרשאות מיוצגות בשני פורמטים: סימון מספרי (אוקטלי) כמו 755, או סימון סמלי כמו rwxr-xr-x. כל ספרה בפורמט המספרי מייצגת הרשאות לבעלים, לקבוצה ולאחרים בהתאמה, כאשר 4 = קריאה (r), 2 = כתיבה (w) ו-1 = הרצה (x). ערכים אלה מסוכמים: 7 (4+2+1) פירושו גישה מלאה, 5 (4+1) פירושו קריאה והרצה, 4 פירושו קריאה בלבד. לדוגמה, {example} נותן לבעלים הרשאות מלאות תוך שהוא מאפשר לאחרים לקרוא ולהריץ את הקובץ."
+  },
+  "ms": {
+    "title": "Apa itu chmod?",
+    "description": "chmod (change mode) adalah arahan Unix/Linux yang digunakan untuk menukar kebenaran fail dan direktori. Kebenaran diwakili dalam dua format: notasi numerik (oktal) seperti 755, atau notasi simbolik seperti rwxr-xr-x. Setiap digit dalam format numerik mewakili kebenaran untuk pemilik, kumpulan, dan lain-lain masing-masing, di mana 4 = baca (r), 2 = tulis (w), dan 1 = laksana (x). Nilai-nilai ini dijumlahkan: 7 (4+2+1) bermaksud akses penuh, 5 (4+1) bermaksud baca dan laksana, 4 bermaksud baca sahaja. Contohnya, {example} memberikan pemilik kebenaran penuh sambil membenarkan yang lain membaca dan melaksanakan fail."
+  },
+  "no": {
+    "title": "Hva er chmod?",
+    "description": "chmod (change mode) er en Unix/Linux-kommando som brukes til a endre fil- og katalogrettigheter. Rettigheter representeres i to formater: numerisk (oktal) notasjon som 755, eller symbolsk notasjon som rwxr-xr-x. Hvert siffer i det numeriske formatet representerer rettigheter for eier, gruppe og andre henholdsvis, der 4 = les (r), 2 = skriv (w) og 1 = kjor (x). Disse verdiene legges sammen: 7 (4+2+1) betyr full tilgang, 5 (4+1) betyr les og kjor, 4 betyr kun lesing. For eksempel gir {example} eieren fulle rettigheter mens andre far lese og kjore filen."
+  }
+}
+</i18n>

--- a/tools/misc/chmod-calculator/src/composables/useChmodState.ts
+++ b/tools/misc/chmod-calculator/src/composables/useChmodState.ts
@@ -1,0 +1,123 @@
+import { ref, reactive, computed } from 'vue'
+import { useStorage } from '@vueuse/core'
+import {
+  numericToSymbolic,
+  symbolicToNumeric,
+  numericToPermissions,
+  permissionsToNumeric,
+  isValidNumeric,
+  isValidSymbolic,
+} from '../utils/chmod'
+
+export interface PermissionSet {
+  read: boolean
+  write: boolean
+  execute: boolean
+}
+
+export interface Permissions {
+  owner: PermissionSet
+  group: PermissionSet
+  others: PermissionSet
+}
+
+export function useChmodState() {
+  const numericInput = useStorage('tools:chmod-calculator:numeric', '755')
+  const symbolicInput = ref(numericToSymbolic(numericInput.value))
+
+  const permissions = reactive<Permissions>({
+    owner: { read: true, write: true, execute: true },
+    group: { read: true, write: false, execute: true },
+    others: { read: true, write: false, execute: true },
+  })
+
+  // Track which input is currently being edited to prevent circular updates
+  const updateSource = ref<'numeric' | 'symbolic' | 'matrix' | null>(null)
+
+  const isValidNumericInput = computed(() => {
+    return numericInput.value === '' || isValidNumeric(numericInput.value)
+  })
+
+  const isValidSymbolicInput = computed(() => {
+    return symbolicInput.value === '' || isValidSymbolic(symbolicInput.value)
+  })
+
+  const chmodCommand = computed(() => {
+    return `chmod ${numericInput.value || '000'} <filename>`
+  })
+
+  // Initialize permissions from stored numeric value
+  function initFromNumeric() {
+    if (isValidNumeric(numericInput.value)) {
+      const parsed = numericToPermissions(numericInput.value)
+      Object.assign(permissions.owner, parsed.owner)
+      Object.assign(permissions.group, parsed.group)
+      Object.assign(permissions.others, parsed.others)
+      symbolicInput.value = numericToSymbolic(numericInput.value)
+    }
+  }
+
+  // Called when numeric input changes
+  function updateFromNumeric(value: string) {
+    if (updateSource.value && updateSource.value !== 'numeric') return
+
+    numericInput.value = value
+    if (isValidNumeric(value)) {
+      updateSource.value = 'numeric'
+      const parsed = numericToPermissions(value)
+      Object.assign(permissions.owner, parsed.owner)
+      Object.assign(permissions.group, parsed.group)
+      Object.assign(permissions.others, parsed.others)
+      symbolicInput.value = numericToSymbolic(value)
+      updateSource.value = null
+    }
+  }
+
+  // Called when symbolic input changes
+  function updateFromSymbolic(value: string) {
+    if (updateSource.value && updateSource.value !== 'symbolic') return
+
+    symbolicInput.value = value
+    if (isValidSymbolic(value)) {
+      updateSource.value = 'symbolic'
+      const numeric = symbolicToNumeric(value)
+      numericInput.value = numeric
+      const parsed = numericToPermissions(numeric)
+      Object.assign(permissions.owner, parsed.owner)
+      Object.assign(permissions.group, parsed.group)
+      Object.assign(permissions.others, parsed.others)
+      updateSource.value = null
+    }
+  }
+
+  // Called when matrix checkboxes change
+  function updateFromMatrix(
+    role: 'owner' | 'group' | 'others',
+    perm: 'read' | 'write' | 'execute',
+    value: boolean,
+  ) {
+    if (updateSource.value && updateSource.value !== 'matrix') return
+
+    updateSource.value = 'matrix'
+    permissions[role][perm] = value
+    const numeric = permissionsToNumeric(permissions)
+    numericInput.value = numeric
+    symbolicInput.value = numericToSymbolic(numeric)
+    updateSource.value = null
+  }
+
+  // Initialize on creation
+  initFromNumeric()
+
+  return {
+    numericInput,
+    symbolicInput,
+    permissions,
+    isValidNumericInput,
+    isValidSymbolicInput,
+    chmodCommand,
+    updateFromNumeric,
+    updateFromSymbolic,
+    updateFromMatrix,
+  }
+}

--- a/tools/misc/chmod-calculator/src/index.ts
+++ b/tools/misc/chmod-calculator/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/misc/chmod-calculator/src/info.ts
+++ b/tools/misc/chmod-calculator/src/info.ts
@@ -1,0 +1,122 @@
+export { PersonLock20Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'chmod-calculator'
+export const path = '/tools/chmod-calculator'
+export const tags = ['chmod', 'permission', 'unix', 'linux', 'file', 'calculator']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Chmod Calculator',
+    description:
+      'Calculate Unix file permissions between numeric (755) and symbolic (rwxr-xr-x) notation',
+  },
+  zh: {
+    name: 'Chmod 计算器',
+    description: '在数字 (755) 和符号 (rwxr-xr-x) 表示法之间转换 Unix 文件权限',
+  },
+  'zh-CN': {
+    name: 'Chmod 计算器',
+    description: '在数字 (755) 和符号 (rwxr-xr-x) 表示法之间转换 Unix 文件权限',
+  },
+  'zh-TW': {
+    name: 'Chmod 計算器',
+    description: '在數字 (755) 和符號 (rwxr-xr-x) 表示法之間轉換 Unix 檔案權限',
+  },
+  'zh-HK': {
+    name: 'Chmod 計算器',
+    description: '在數字 (755) 和符號 (rwxr-xr-x) 表示法之間轉換 Unix 檔案權限',
+  },
+  es: {
+    name: 'Calculadora Chmod',
+    description:
+      'Calcula permisos de archivos Unix entre notación numérica (755) y simbólica (rwxr-xr-x)',
+  },
+  fr: {
+    name: 'Calculateur Chmod',
+    description:
+      'Convertir les permissions de fichiers Unix entre notation numérique (755) et symbolique (rwxr-xr-x)',
+  },
+  de: {
+    name: 'Chmod-Rechner',
+    description:
+      'Unix-Dateiberechtigungen zwischen numerischer (755) und symbolischer (rwxr-xr-x) Notation umrechnen',
+  },
+  it: {
+    name: 'Calcolatore Chmod',
+    description:
+      'Calcola i permessi dei file Unix tra notazione numerica (755) e simbolica (rwxr-xr-x)',
+  },
+  ja: {
+    name: 'Chmod 計算機',
+    description: 'Unix ファイル権限を数値 (755) と記号 (rwxr-xr-x) 表記の間で変換',
+  },
+  ko: {
+    name: 'Chmod 계산기',
+    description: 'Unix 파일 권한을 숫자 (755)와 기호 (rwxr-xr-x) 표기법 간에 변환',
+  },
+  ru: {
+    name: 'Калькулятор Chmod',
+    description:
+      'Конвертация прав доступа Unix между числовой (755) и символьной (rwxr-xr-x) нотацией',
+  },
+  pt: {
+    name: 'Calculadora Chmod',
+    description:
+      'Calcular permissões de arquivos Unix entre notação numérica (755) e simbólica (rwxr-xr-x)',
+  },
+  ar: {
+    name: 'حاسبة Chmod',
+    description: 'حساب أذونات ملفات Unix بين الترميز الرقمي (755) والرمزي (rwxr-xr-x)',
+  },
+  hi: {
+    name: 'Chmod कैलकुलेटर',
+    description:
+      'संख्यात्मक (755) और प्रतीकात्मक (rwxr-xr-x) नोटेशन के बीच Unix फ़ाइल अनुमतियों की गणना करें',
+  },
+  tr: {
+    name: 'Chmod Hesaplayıcı',
+    description:
+      'Unix dosya izinlerini sayısal (755) ve sembolik (rwxr-xr-x) gösterim arasında dönüştür',
+  },
+  nl: {
+    name: 'Chmod-calculator',
+    description:
+      'Unix-bestandsrechten converteren tussen numerieke (755) en symbolische (rwxr-xr-x) notatie',
+  },
+  sv: {
+    name: 'Chmod-kalkylator',
+    description:
+      'Konvertera Unix-filrättigheter mellan numerisk (755) och symbolisk (rwxr-xr-x) notation',
+  },
+  pl: {
+    name: 'Kalkulator Chmod',
+    description:
+      'Konwertuj uprawnienia plików Unix między notacją numeryczną (755) a symboliczną (rwxr-xr-x)',
+  },
+  vi: {
+    name: 'Máy tính Chmod',
+    description: 'Chuyển đổi quyền tệp Unix giữa ký hiệu số (755) và ký hiệu (rwxr-xr-x)',
+  },
+  th: {
+    name: 'เครื่องคำนวณ Chmod',
+    description: 'แปลงสิทธิ์ไฟล์ Unix ระหว่างรูปแบบตัวเลข (755) และสัญลักษณ์ (rwxr-xr-x)',
+  },
+  id: {
+    name: 'Kalkulator Chmod',
+    description: 'Konversi izin file Unix antara notasi numerik (755) dan simbolik (rwxr-xr-x)',
+  },
+  he: {
+    name: 'מחשבון Chmod',
+    description: 'המרת הרשאות קבצים ב-Unix בין סימון מספרי (755) לסימון סמלי (rwxr-xr-x)',
+  },
+  ms: {
+    name: 'Kalkulator Chmod',
+    description: 'Tukar kebenaran fail Unix antara notasi angka (755) dan simbolik (rwxr-xr-x)',
+  },
+  no: {
+    name: 'Chmod-kalkulator',
+    description:
+      'Konverter Unix-filtillatelser mellom numerisk (755) og symbolsk (rwxr-xr-x) notasjon',
+  },
+}

--- a/tools/misc/chmod-calculator/src/routes.ts
+++ b/tools/misc/chmod-calculator/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'chmod-calculator',
+    path: '/tools/chmod-calculator',
+    component: () => import('./ChmodCalculatorView.vue'),
+  },
+] as const

--- a/tools/misc/chmod-calculator/src/utils/chmod.dom.test.ts
+++ b/tools/misc/chmod-calculator/src/utils/chmod.dom.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from 'vitest'
+import {
+  numericToSymbolic,
+  symbolicToNumeric,
+  isValidNumeric,
+  isValidSymbolic,
+  permissionsToNumeric,
+  numericToPermissions,
+} from './chmod'
+
+describe('numericToSymbolic', () => {
+  it('converts common permission values', () => {
+    expect(numericToSymbolic('755')).toBe('rwxr-xr-x')
+    expect(numericToSymbolic('644')).toBe('rw-r--r--')
+    expect(numericToSymbolic('777')).toBe('rwxrwxrwx')
+    expect(numericToSymbolic('700')).toBe('rwx------')
+    expect(numericToSymbolic('600')).toBe('rw-------')
+    expect(numericToSymbolic('400')).toBe('r--------')
+  })
+
+  it('converts edge cases', () => {
+    expect(numericToSymbolic('000')).toBe('---------')
+    expect(numericToSymbolic('111')).toBe('--x--x--x')
+    expect(numericToSymbolic('222')).toBe('-w--w--w-')
+    expect(numericToSymbolic('444')).toBe('r--r--r--')
+  })
+
+  it('handles short input by padding', () => {
+    expect(numericToSymbolic('55')).toBe('---r-xr-x')
+    expect(numericToSymbolic('5')).toBe('------r-x')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(numericToSymbolic('')).toBe('')
+    expect(numericToSymbolic('888')).toBe('')
+    expect(numericToSymbolic('abc')).toBe('')
+    expect(numericToSymbolic('7755')).toBe('')
+  })
+})
+
+describe('symbolicToNumeric', () => {
+  it('converts common permission values', () => {
+    expect(symbolicToNumeric('rwxr-xr-x')).toBe('755')
+    expect(symbolicToNumeric('rw-r--r--')).toBe('644')
+    expect(symbolicToNumeric('rwxrwxrwx')).toBe('777')
+    expect(symbolicToNumeric('rwx------')).toBe('700')
+    expect(symbolicToNumeric('rw-------')).toBe('600')
+    expect(symbolicToNumeric('r--------')).toBe('400')
+  })
+
+  it('converts edge cases', () => {
+    expect(symbolicToNumeric('---------')).toBe('000')
+    expect(symbolicToNumeric('--x--x--x')).toBe('111')
+    expect(symbolicToNumeric('-w--w--w-')).toBe('222')
+    expect(symbolicToNumeric('r--r--r--')).toBe('444')
+  })
+
+  it('returns empty string for invalid input', () => {
+    expect(symbolicToNumeric('')).toBe('')
+    expect(symbolicToNumeric('rwx')).toBe('')
+    expect(symbolicToNumeric('rwxr-x')).toBe('')
+    expect(symbolicToNumeric('abc123def')).toBe('')
+    expect(symbolicToNumeric('rwxr-xr-xr')).toBe('')
+  })
+})
+
+describe('isValidNumeric', () => {
+  it('returns true for valid numeric permissions', () => {
+    expect(isValidNumeric('755')).toBe(true)
+    expect(isValidNumeric('644')).toBe(true)
+    expect(isValidNumeric('777')).toBe(true)
+    expect(isValidNumeric('000')).toBe(true)
+    expect(isValidNumeric('0')).toBe(true)
+    expect(isValidNumeric('77')).toBe(true)
+  })
+
+  it('returns false for invalid numeric permissions', () => {
+    expect(isValidNumeric('')).toBe(false)
+    expect(isValidNumeric('888')).toBe(false)
+    expect(isValidNumeric('7755')).toBe(false)
+    expect(isValidNumeric('abc')).toBe(false)
+    expect(isValidNumeric('7a5')).toBe(false)
+  })
+
+  it('handles whitespace', () => {
+    expect(isValidNumeric('  755  ')).toBe(true)
+  })
+})
+
+describe('isValidSymbolic', () => {
+  it('returns true for valid symbolic permissions', () => {
+    expect(isValidSymbolic('rwxr-xr-x')).toBe(true)
+    expect(isValidSymbolic('rw-r--r--')).toBe(true)
+    expect(isValidSymbolic('rwxrwxrwx')).toBe(true)
+    expect(isValidSymbolic('---------')).toBe(true)
+  })
+
+  it('returns false for invalid symbolic permissions', () => {
+    expect(isValidSymbolic('')).toBe(false)
+    expect(isValidSymbolic('rwx')).toBe(false)
+    expect(isValidSymbolic('rwxrwxrwxr')).toBe(false)
+    expect(isValidSymbolic('abcdefghi')).toBe(false)
+    expect(isValidSymbolic('rwxr-xr-a')).toBe(false)
+  })
+})
+
+describe('permissionsToNumeric', () => {
+  it('converts full permissions', () => {
+    expect(
+      permissionsToNumeric({
+        owner: { read: true, write: true, execute: true },
+        group: { read: true, write: true, execute: true },
+        others: { read: true, write: true, execute: true },
+      }),
+    ).toBe('777')
+  })
+
+  it('converts no permissions', () => {
+    expect(
+      permissionsToNumeric({
+        owner: { read: false, write: false, execute: false },
+        group: { read: false, write: false, execute: false },
+        others: { read: false, write: false, execute: false },
+      }),
+    ).toBe('000')
+  })
+
+  it('converts common permission patterns', () => {
+    expect(
+      permissionsToNumeric({
+        owner: { read: true, write: true, execute: true },
+        group: { read: true, write: false, execute: true },
+        others: { read: true, write: false, execute: true },
+      }),
+    ).toBe('755')
+
+    expect(
+      permissionsToNumeric({
+        owner: { read: true, write: true, execute: false },
+        group: { read: true, write: false, execute: false },
+        others: { read: true, write: false, execute: false },
+      }),
+    ).toBe('644')
+  })
+})
+
+describe('numericToPermissions', () => {
+  it('converts 777 to all permissions', () => {
+    const result = numericToPermissions('777')
+    expect(result.owner).toEqual({ read: true, write: true, execute: true })
+    expect(result.group).toEqual({ read: true, write: true, execute: true })
+    expect(result.others).toEqual({ read: true, write: true, execute: true })
+  })
+
+  it('converts 000 to no permissions', () => {
+    const result = numericToPermissions('000')
+    expect(result.owner).toEqual({ read: false, write: false, execute: false })
+    expect(result.group).toEqual({ read: false, write: false, execute: false })
+    expect(result.others).toEqual({ read: false, write: false, execute: false })
+  })
+
+  it('converts common permission patterns', () => {
+    const result755 = numericToPermissions('755')
+    expect(result755.owner).toEqual({ read: true, write: true, execute: true })
+    expect(result755.group).toEqual({ read: true, write: false, execute: true })
+    expect(result755.others).toEqual({ read: true, write: false, execute: true })
+
+    const result644 = numericToPermissions('644')
+    expect(result644.owner).toEqual({ read: true, write: true, execute: false })
+    expect(result644.group).toEqual({ read: true, write: false, execute: false })
+    expect(result644.others).toEqual({ read: true, write: false, execute: false })
+  })
+
+  it('returns default for invalid input', () => {
+    const result = numericToPermissions('abc')
+    expect(result.owner).toEqual({ read: false, write: false, execute: false })
+    expect(result.group).toEqual({ read: false, write: false, execute: false })
+    expect(result.others).toEqual({ read: false, write: false, execute: false })
+  })
+})
+
+describe('round-trip conversion', () => {
+  it('numeric -> symbolic -> numeric preserves value', () => {
+    const testCases = ['755', '644', '777', '700', '600', '400', '000', '111', '222', '444']
+    for (const numeric of testCases) {
+      expect(symbolicToNumeric(numericToSymbolic(numeric))).toBe(numeric)
+    }
+  })
+
+  it('symbolic -> numeric -> symbolic preserves value', () => {
+    const testCases = [
+      'rwxr-xr-x',
+      'rw-r--r--',
+      'rwxrwxrwx',
+      'rwx------',
+      'rw-------',
+      'r--------',
+      '---------',
+    ]
+    for (const symbolic of testCases) {
+      expect(numericToSymbolic(symbolicToNumeric(symbolic))).toBe(symbolic)
+    }
+  })
+
+  it('permissions -> numeric -> permissions preserves value', () => {
+    const testPerms = {
+      owner: { read: true, write: true, execute: true },
+      group: { read: true, write: false, execute: true },
+      others: { read: true, write: false, execute: true },
+    }
+    const numeric = permissionsToNumeric(testPerms)
+    const result = numericToPermissions(numeric)
+    expect(result).toEqual(testPerms)
+  })
+})

--- a/tools/misc/chmod-calculator/src/utils/chmod.ts
+++ b/tools/misc/chmod-calculator/src/utils/chmod.ts
@@ -1,0 +1,128 @@
+/**
+ * Convert numeric permission (e.g., "755") to symbolic notation (e.g., "rwxr-xr-x")
+ */
+export function numericToSymbolic(numeric: string): string {
+  if (!isValidNumeric(numeric)) {
+    return ''
+  }
+
+  const digits = numeric.padStart(3, '0').slice(-3)
+  return digits
+    .split('')
+    .map((digit) => {
+      const num = parseInt(digit, 10)
+      const r = num & 4 ? 'r' : '-'
+      const w = num & 2 ? 'w' : '-'
+      const x = num & 1 ? 'x' : '-'
+      return r + w + x
+    })
+    .join('')
+}
+
+/**
+ * Convert symbolic notation (e.g., "rwxr-xr-x") to numeric permission (e.g., "755")
+ */
+export function symbolicToNumeric(symbolic: string): string {
+  if (!isValidSymbolic(symbolic)) {
+    return ''
+  }
+
+  const normalized = symbolic.replace(/\s/g, '')
+  const result: number[] = []
+
+  for (let i = 0; i < 3; i++) {
+    const triplet = normalized.slice(i * 3, i * 3 + 3)
+    let num = 0
+    if (triplet[0] === 'r') num += 4
+    if (triplet[1] === 'w') num += 2
+    if (triplet[2] === 'x') num += 1
+    result.push(num)
+  }
+
+  return result.join('')
+}
+
+/**
+ * Validate numeric permission format (1-3 digits, each 0-7)
+ */
+export function isValidNumeric(value: string): boolean {
+  if (!value || typeof value !== 'string') {
+    return false
+  }
+  const trimmed = value.trim()
+  if (!/^[0-7]{1,3}$/.test(trimmed)) {
+    return false
+  }
+  return true
+}
+
+/**
+ * Validate symbolic permission format (9 characters: rwx pattern × 3)
+ */
+export function isValidSymbolic(value: string): boolean {
+  if (!value || typeof value !== 'string') {
+    return false
+  }
+  const trimmed = value.trim().replace(/\s/g, '')
+  if (trimmed.length !== 9) {
+    return false
+  }
+  // Check pattern: [r-][w-][x-] repeated 3 times
+  const pattern = /^[r-][w-][x-][r-][w-][x-][r-][w-][x-]$/
+  return pattern.test(trimmed)
+}
+
+/**
+ * Convert permissions object to numeric string
+ */
+export function permissionsToNumeric(permissions: {
+  owner: { read: boolean; write: boolean; execute: boolean }
+  group: { read: boolean; write: boolean; execute: boolean }
+  others: { read: boolean; write: boolean; execute: boolean }
+}): string {
+  const calculate = (perm: { read: boolean; write: boolean; execute: boolean }) => {
+    let num = 0
+    if (perm.read) num += 4
+    if (perm.write) num += 2
+    if (perm.execute) num += 1
+    return num
+  }
+
+  return `${calculate(permissions.owner)}${calculate(permissions.group)}${calculate(permissions.others)}`
+}
+
+/**
+ * Convert numeric string to permissions object
+ */
+export function numericToPermissions(numeric: string): {
+  owner: { read: boolean; write: boolean; execute: boolean }
+  group: { read: boolean; write: boolean; execute: boolean }
+  others: { read: boolean; write: boolean; execute: boolean }
+} {
+  const defaultPerm = { read: false, write: false, execute: false }
+  const defaultResult = {
+    owner: { ...defaultPerm },
+    group: { ...defaultPerm },
+    others: { ...defaultPerm },
+  }
+
+  if (!isValidNumeric(numeric)) {
+    return defaultResult
+  }
+
+  const digits = numeric.padStart(3, '0').slice(-3).split('')
+  const parse = (digit: string) => {
+    const num = parseInt(digit, 10)
+    return {
+      read: (num & 4) !== 0,
+      write: (num & 2) !== 0,
+      execute: (num & 1) !== 0,
+    }
+  }
+
+  return {
+    owner: parse(digits[0] ?? '0'),
+    group: parse(digits[1] ?? '0'),
+    others: parse(digits[2] ?? '0'),
+  }
+}


### PR DESCRIPTION
## Summary

- Add a new tool to convert Unix file permissions between numeric (755) and symbolic (rwxr-xr-x) notation
- Bidirectional sync between numeric input, symbolic input, and permission checkboxes
- Common presets for quick selection (755, 644, 777, 700, 600, 775)
- Permission matrix with Owner/Group/Others checkboxes
- Generated chmod command output with copy button
- Full i18n support (25 languages)
- Comprehensive unit tests (22 test cases)

## Test plan

- [x] All unit tests pass (`pnpm test:unit`)
- [x] Lint and type-check pass (`pnpm lint && pnpm type-check`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual testing: verify numeric/symbolic/checkbox sync works correctly
- [ ] Manual testing: verify presets apply correctly
- [ ] Manual testing: verify localStorage persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)