### PR TITLE
chore(lint): add vue/no-undef-components rule

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -21,6 +21,16 @@ export default defineConfigWithVueTs(
 
   pluginVue.configs['flat/essential'],
   vueTsConfigs.recommended,
+  {
+    rules: {
+      'vue/no-undef-components': [
+        'error',
+        {
+          ignorePatterns: ['router-link', 'router-view', 'i18n-t'],
+        },
+      ],
+    },
+  },
 
   {
     ...pluginVitest.configs.recommended,


### PR DESCRIPTION
## Summary
- Add `vue/no-undef-components` ESLint rule to enforce explicit component imports
- Ignore global components: `router-link`, `router-view`, `i18n-t`

## Test plan
- [x] `pnpm lint-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)