### PR TITLE
feat(tools): add AES Encryptor and Decryptor tools

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ catalogs:
     jiti:
       specifier: ^2.6.1
       version: 2.6.1
+    jose:
+      specifier: ^6.1.3
+      version: 6.1.3
     js-yaml:
       specifier: ^4.1.1
       version: 4.1.1
@@ -504,6 +507,12 @@ importers:
       '@shared/tools':
         specifier: workspace:*
         version: link:../../shared/tools
+      '@tools/aes-decryptor':
+        specifier: workspace:*
+        version: link:../../tools/web/aes-decryptor
+      '@tools/aes-encryptor':
+        specifier: workspace:*
+        version: link:../../tools/web/aes-encryptor
       '@tools/ascii-art-generator':
         specifier: workspace:*
         version: link:../../tools/text/ascii-art-generator
@@ -2906,6 +2915,60 @@ importers:
         specifier: 'catalog:'
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
 
+  tools/web/aes-decryptor:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@utils/aes':
+        specifier: workspace:*
+        version: link:../../../utils/aes
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
+
+  tools/web/aes-encryptor:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@utils/aes':
+        specifier: workspace:*
+        version: link:../../../utils/aes
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
+
   tools/web/base64-encoder-decoder:
     dependencies:
       '@shared/icons':
@@ -3257,6 +3320,12 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
+
+  utils/aes:
+    dependencies:
+      jose:
+        specifier: 'catalog:'
+        version: 6.1.3
 
   utils/airplane-mode:
     dependencies:
@@ -6772,6 +6841,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-beautify@1.15.4:
     resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
@@ -11867,6 +11939,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.1.3: {}
 
   js-beautify@1.15.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ catalog:
   is-cidr: ^6.0.1
   is-ip: ^5.0.1
   jiti: ^2.6.1
+  jose: ^6.1.3
   js-yaml: ^4.1.1
   jsbarcode: ^3.12.1
   jsdom: ^27.4.0

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -11,6 +11,8 @@
   "dependencies": {
     "@shared/locale": "workspace:*",
     "@shared/tools": "workspace:*",
+    "@tools/aes-decryptor": "workspace:*",
+    "@tools/aes-encryptor": "workspace:*",
     "@tools/ascii-art-generator": "workspace:*",
     "@tools/barcode-generator": "workspace:*",
     "@tools/base64-encoder-decoder": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -73,6 +73,8 @@ import { toolInfo as rotCipherToolInfo } from '@tools/rot-cipher'
 import { toolInfo as htmlEntityEncoderDecoderToolInfo } from '@tools/html-entity-encoder-decoder'
 import { toolInfo as chmodCalculatorToolInfo } from '@tools/chmod-calculator'
 import { toolInfo as asciiArtGeneratorToolInfo } from '@tools/ascii-art-generator'
+import { toolInfo as aesEncryptorToolInfo } from '@tools/aes-encryptor'
+import { toolInfo as aesDecryptorToolInfo } from '@tools/aes-decryptor'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -177,4 +179,8 @@ export const tools: ToolInfo[] = [
 
   // Text Tools
   asciiArtGeneratorToolInfo,
+
+  // Encryption Tools
+  aesEncryptorToolInfo,
+  aesDecryptorToolInfo,
 ]

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -71,6 +71,8 @@ import { routes as rotCipherRoutes } from '@tools/rot-cipher/routes'
 import { routes as htmlEntityEncoderDecoderRoutes } from '@tools/html-entity-encoder-decoder/routes'
 import { routes as chmodCalculatorRoutes } from '@tools/chmod-calculator/routes'
 import { routes as asciiArtGeneratorRoutes } from '@tools/ascii-art-generator/routes'
+import { routes as aesEncryptorRoutes } from '@tools/aes-encryptor/routes'
+import { routes as aesDecryptorRoutes } from '@tools/aes-decryptor/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -145,4 +147,6 @@ export const routes: ToolRoute[] = [
   ...htmlEntityEncoderDecoderRoutes,
   ...chmodCalculatorRoutes,
   ...asciiArtGeneratorRoutes,
+  ...aesEncryptorRoutes,
+  ...aesDecryptorRoutes,
 ]

--- a/tools/web/aes-decryptor/package.json
+++ b/tools/web/aes-decryptor/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/aes-decryptor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@utils/aes": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/web/aes-decryptor/src/AesDecryptorView.vue
+++ b/tools/web/aes-decryptor/src/AesDecryptorView.vue
@@ -1,0 +1,11 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <DecryptForm />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import DecryptForm from './components/DecryptForm.vue'
+</script>

--- a/tools/web/aes-decryptor/src/components/AdvancedOptions.vue
+++ b/tools/web/aes-decryptor/src/components/AdvancedOptions.vue
@@ -1,0 +1,70 @@
+<template>
+  <ToolSection v-if="!isJweMode">
+    <n-collapse>
+      <n-collapse-item :title="t('advancedOptions')" name="advanced">
+        <n-grid :cols="2" :x-gap="12" :y-gap="12">
+          <n-form-item-gi v-if="keyType === 'password'" :label="t('pbkdf2Iterations')">
+            <n-input-number
+              :value="pbkdf2Iterations"
+              :min="1000"
+              :max="10000000"
+              :step="10000"
+              style="width: 100%"
+              @update:value="$event !== null && $emit('update:pbkdf2Iterations', $event)"
+            />
+          </n-form-item-gi>
+          <n-form-item-gi v-if="keyType === 'password'" :label="t('pbkdf2Hash')">
+            <n-select
+              :value="pbkdf2Hash"
+              :options="pbkdf2HashOptions"
+              @update:value="$emit('update:pbkdf2Hash', $event)"
+            />
+          </n-form-item-gi>
+        </n-grid>
+      </n-collapse-item>
+    </n-collapse>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NGrid, NFormItemGi, NCollapse, NCollapseItem, NInputNumber, NSelect } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection } from '@shared/ui/tool'
+import type { KeyType, Pbkdf2Hash } from '@utils/aes'
+
+defineProps<{
+  isJweMode: boolean
+  keyType: KeyType
+  pbkdf2Iterations: number
+  pbkdf2Hash: Pbkdf2Hash
+}>()
+
+defineEmits<{
+  'update:pbkdf2Iterations': [value: number]
+  'update:pbkdf2Hash': [value: Pbkdf2Hash]
+}>()
+
+const { t } = useI18n()
+
+const pbkdf2HashOptions = [
+  { label: 'SHA-1', value: 'SHA-1' },
+  { label: 'SHA-256', value: 'SHA-256' },
+  { label: 'SHA-384', value: 'SHA-384' },
+  { label: 'SHA-512', value: 'SHA-512' },
+] satisfies Array<{ label: string; value: Pbkdf2Hash }>
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "advancedOptions": "Advanced Options",
+    "pbkdf2Iterations": "PBKDF2 Iterations",
+    "pbkdf2Hash": "PBKDF2 Hash"
+  },
+  "zh": {
+    "advancedOptions": "高级选项",
+    "pbkdf2Iterations": "PBKDF2 迭代次数",
+    "pbkdf2Hash": "PBKDF2 哈希"
+  }
+}
+</i18n>

--- a/tools/web/aes-decryptor/src/components/DecryptForm.vue
+++ b/tools/web/aes-decryptor/src/components/DecryptForm.vue
@@ -1,0 +1,282 @@
+<template>
+  <n-space vertical :size="16">
+    <ToolSection>
+      <ToolSectionHeader>{{ t('input') }}</ToolSectionHeader>
+      <n-text depth="3" style="font-size: 12px; margin-bottom: 8px; display: block">
+        {{ t('supportedFormats') }}
+      </n-text>
+      <TextOrFileInput v-model:value="input" :placeholder="t('inputPlaceholder')" />
+      <n-space v-if="detectedFormat" style="margin-top: 8px" align="center">
+        <n-tag :type="detectedFormat === 'jwe' ? 'success' : 'info'" size="small">
+          {{ t('detected', { format: detectedFormat.toUpperCase() }) }}
+        </n-tag>
+        <n-text v-if="detectedInfo" depth="3" style="font-size: 12px">
+          {{ detectedInfo }}
+        </n-text>
+      </n-space>
+    </ToolSection>
+
+    <KeyInput
+      :key-type="keyType"
+      :password="password"
+      :raw-key="rawKey"
+      :key-length="keyLength"
+      @update:key-type="keyType = $event"
+      @update:password="password = $event"
+      @update:raw-key="rawKey = $event"
+    />
+
+    <DecryptOptions
+      :is-jwe-mode="detectedFormat === 'jwe'"
+      :mode="mode"
+      :key-length="keyLength"
+      :input-format="inputFormat"
+      @update:mode="mode = $event"
+      @update:key-length="keyLength = $event"
+      @update:input-format="inputFormat = $event"
+    />
+
+    <AdvancedOptions
+      :is-jwe-mode="detectedFormat === 'jwe'"
+      :key-type="keyType"
+      :pbkdf2-iterations="pbkdf2Iterations"
+      :pbkdf2-hash="pbkdf2Hash"
+      @update:pbkdf2-iterations="pbkdf2Iterations = $event"
+      @update:pbkdf2-hash="pbkdf2Hash = $event"
+    />
+
+    <n-button type="primary" :loading="decrypting" :disabled="!canDecrypt" @click="handleDecrypt">
+      <template #icon>
+        <n-icon :component="LockOpen16Regular" />
+      </template>
+      {{ t('decrypt') }}
+    </n-button>
+
+    <DecryptResult
+      :result="result"
+      :result-hex="resultHex"
+      :result-binary="resultBinary"
+      :error="error"
+    />
+  </n-space>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { NSpace, NButton, NIcon, NTag, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { useStorage } from '@vueuse/core'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { TextOrFileInput } from '@shared/ui/base'
+import { LockOpen16Regular } from '@shared/icons/fluent'
+import {
+  type AesMode,
+  type KeyLength,
+  type KeyType,
+  type OutputFormat,
+  type Pbkdf2Hash,
+  PBKDF2_HASH,
+  PBKDF2_ITERATIONS,
+  decryptWithPassword,
+  decryptWithRawKey,
+  decryptJweWithPassword,
+  decryptJweWithRawKey,
+  isJweFormat,
+  parseJweHeader,
+  getConfigFromJweEnc,
+  arrayBufferToString,
+  arrayBufferToHex,
+  arrayBufferToBase64,
+  isValidHex,
+} from '@utils/aes'
+import KeyInput from './KeyInput.vue'
+import DecryptOptions from './DecryptOptions.vue'
+import AdvancedOptions from './AdvancedOptions.vue'
+import DecryptResult from './DecryptResult.vue'
+
+const { t } = useI18n()
+
+// Input
+const input = ref<string | File>('')
+
+// Key settings
+const password = useStorage<string>('tools:aes-decryptor:password', '')
+const rawKey = useStorage<string>('tools:aes-decryptor:rawKey', '')
+const keyType = useStorage<KeyType>('tools:aes-decryptor:keyType', 'password')
+
+// Options
+const mode = useStorage<AesMode>('tools:aes-decryptor:mode', 'GCM')
+const keyLength = useStorage<KeyLength>('tools:aes-decryptor:keyLength', 256)
+const inputFormat = useStorage<OutputFormat>('tools:aes-decryptor:inputFormat', 'base64')
+
+// Advanced options
+const pbkdf2Iterations = useStorage<number>(
+  'tools:aes-decryptor:pbkdf2Iterations',
+  PBKDF2_ITERATIONS,
+)
+const pbkdf2Hash = useStorage<Pbkdf2Hash>('tools:aes-decryptor:pbkdf2Hash', PBKDF2_HASH)
+
+// Result
+const result = ref('')
+const resultBinary = ref<ArrayBuffer | null>(null)
+const resultHex = ref('')
+const error = ref('')
+const decrypting = ref(false)
+
+// Computed
+const expectedKeyLength = computed(() => keyLength.value / 4)
+
+const rawKeyStatus = computed(() => {
+  if (!rawKey.value) return undefined
+  if (!isValidHex(rawKey.value)) return 'error'
+  const cleanHex = rawKey.value.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) return 'error'
+  return 'success'
+})
+
+// Auto-detect format
+const inputText = computed(() => {
+  if (typeof input.value === 'string') {
+    return input.value.trim()
+  }
+  return ''
+})
+
+const detectedFormat = computed<'jwe' | 'base64' | 'hex' | null>(() => {
+  if (!inputText.value) return null
+  if (isJweFormat(inputText.value)) return 'jwe'
+  if (isValidHex(inputText.value)) return 'hex'
+  // Try base64
+  try {
+    atob(inputText.value)
+    return 'base64'
+  } catch {
+    return null
+  }
+})
+
+const detectedInfo = computed(() => {
+  if (detectedFormat.value !== 'jwe') return ''
+  const header = parseJweHeader(inputText.value)
+  if (!header) return ''
+  const config = getConfigFromJweEnc(header.enc)
+  const parts: string[] = []
+  if (config) {
+    parts.push(`${config.mode}-${config.keyLength}`)
+  }
+  if (header.p2c) {
+    parts.push(`iterations: ${header.p2c.toLocaleString()}`)
+  }
+  parts.push(`alg: ${header.alg}`)
+  return parts.join(', ')
+})
+
+// Auto-update mode/keyLength from JWE header
+watch(inputText, () => {
+  if (detectedFormat.value === 'jwe') {
+    const header = parseJweHeader(inputText.value)
+    if (header) {
+      const config = getConfigFromJweEnc(header.enc)
+      if (config) {
+        mode.value = config.mode
+        keyLength.value = config.keyLength
+      }
+    }
+  }
+})
+
+const canDecrypt = computed(() => {
+  if (!input.value) return false
+  if (keyType.value === 'password') {
+    return password.value.length > 0
+  } else {
+    return rawKeyStatus.value === 'success'
+  }
+})
+
+// Functions
+async function handleDecrypt() {
+  error.value = ''
+  result.value = ''
+  resultBinary.value = null
+  resultHex.value = ''
+  decrypting.value = true
+
+  try {
+    let data: string
+    if (typeof input.value === 'string') {
+      data = input.value.trim()
+    } else {
+      // File input - read as text for JWE/base64/hex, or as binary
+      const file = input.value
+      if (file.name.endsWith('.bin') || file.type === 'application/octet-stream') {
+        // Binary file - read as ArrayBuffer and convert to appropriate format
+        const buffer = await file.arrayBuffer()
+        data = arrayBufferToBase64(buffer)
+        inputFormat.value = 'base64'
+      } else {
+        data = (await file.text()).trim()
+      }
+    }
+
+    let decrypted: ArrayBuffer
+
+    // Auto-detect and use JWE if detected
+    if (detectedFormat.value === 'jwe' || isJweFormat(data)) {
+      if (keyType.value === 'password') {
+        decrypted = await decryptJweWithPassword(data, password.value)
+      } else {
+        decrypted = await decryptJweWithRawKey(data, rawKey.value)
+      }
+    } else {
+      // Raw mode decryption
+      const format = detectedFormat.value === 'hex' ? 'hex' : inputFormat.value
+
+      if (keyType.value === 'password') {
+        decrypted = await decryptWithPassword(
+          data,
+          password.value,
+          mode.value,
+          keyLength.value,
+          format,
+          {
+            iterations: pbkdf2Iterations.value,
+            hash: pbkdf2Hash.value,
+          },
+        )
+      } else {
+        decrypted = await decryptWithRawKey(data, rawKey.value, mode.value, keyLength.value, format)
+      }
+    }
+
+    resultBinary.value = decrypted
+    result.value = arrayBufferToString(decrypted)
+    resultHex.value = arrayBufferToHex(decrypted)
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : t('decryptionFailed')
+  } finally {
+    decrypting.value = false
+  }
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "input": "Encrypted Data",
+    "supportedFormats": "Supports: JWE (auto-detected), Base64, Hex",
+    "inputPlaceholder": "Paste encrypted data here...",
+    "detected": "Detected: {format}",
+    "decrypt": "Decrypt",
+    "decryptionFailed": "Decryption failed. Check your password/key and settings."
+  },
+  "zh": {
+    "input": "加密数据",
+    "supportedFormats": "支持格式: JWE (自动检测)、Base64、Hex",
+    "inputPlaceholder": "在此粘贴加密数据...",
+    "detected": "检测到: {format}",
+    "decrypt": "解密",
+    "decryptionFailed": "解密失败。请检查密码/密钥和设置。"
+  }
+}
+</i18n>

--- a/tools/web/aes-decryptor/src/components/DecryptOptions.vue
+++ b/tools/web/aes-decryptor/src/components/DecryptOptions.vue
@@ -1,0 +1,80 @@
+<template>
+  <ToolSection v-if="!isJweMode">
+    <ToolSectionHeader>{{ t('options') }}</ToolSectionHeader>
+    <n-grid :cols="3" :x-gap="12" :y-gap="12">
+      <n-form-item-gi :label="t('mode')">
+        <n-radio-group :value="mode" name="mode" @update:value="$emit('update:mode', $event)">
+          <n-space vertical :size="4">
+            <n-radio value="GCM">GCM</n-radio>
+            <n-radio value="CBC">CBC</n-radio>
+            <n-radio value="CTR">CTR</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+      <n-form-item-gi :label="t('keyLength')">
+        <n-radio-group
+          :value="keyLength"
+          name="key-length"
+          @update:value="$emit('update:keyLength', $event)"
+        >
+          <n-space vertical :size="4">
+            <n-radio :value="128">128-bit</n-radio>
+            <n-radio :value="192">192-bit</n-radio>
+            <n-radio :value="256">256-bit</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+      <n-form-item-gi :label="t('inputFormat')">
+        <n-radio-group
+          :value="inputFormat"
+          name="input-format"
+          @update:value="$emit('update:inputFormat', $event)"
+        >
+          <n-space vertical :size="4">
+            <n-radio value="base64">Base64</n-radio>
+            <n-radio value="hex">Hex</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+    </n-grid>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NGrid, NFormItemGi, NRadioGroup, NRadio, NSpace } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import type { AesMode, KeyLength, OutputFormat } from '@utils/aes'
+
+defineProps<{
+  isJweMode: boolean
+  mode: AesMode
+  keyLength: KeyLength
+  inputFormat: OutputFormat
+}>()
+
+defineEmits<{
+  'update:mode': [value: AesMode]
+  'update:keyLength': [value: KeyLength]
+  'update:inputFormat': [value: OutputFormat]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "options": "Options",
+    "mode": "Mode",
+    "keyLength": "Key Length",
+    "inputFormat": "Format"
+  },
+  "zh": {
+    "options": "选项",
+    "mode": "模式",
+    "keyLength": "密钥长度",
+    "inputFormat": "格式"
+  }
+}
+</i18n>

--- a/tools/web/aes-decryptor/src/components/DecryptResult.vue
+++ b/tools/web/aes-decryptor/src/components/DecryptResult.vue
@@ -1,0 +1,111 @@
+<template>
+  <ToolSection v-if="result || resultBinary || error">
+    <ToolSectionHeader>{{ t('result') }}</ToolSectionHeader>
+    <n-alert v-if="error" type="error" :title="t('error')">{{ error }}</n-alert>
+    <template v-else>
+      <n-tabs v-model:value="activeTab" type="line">
+        <n-tab-pane name="text" :tab="t('textTab')">
+          <n-input
+            :value="result"
+            type="textarea"
+            readonly
+            :autosize="{ minRows: 3, maxRows: 10 }"
+          />
+        </n-tab-pane>
+        <n-tab-pane name="hex" :tab="t('hexTab')">
+          <n-input
+            :value="resultHex"
+            type="textarea"
+            readonly
+            :autosize="{ minRows: 3, maxRows: 10 }"
+            style="font-family: monospace"
+          />
+        </n-tab-pane>
+      </n-tabs>
+      <n-space style="margin-top: 8px">
+        <CopyToClipboardButton :content="activeTab === 'text' ? result : resultHex" />
+        <n-popselect
+          v-model:value="downloadType"
+          :options="downloadOptions"
+          trigger="click"
+          @update:value="handleDownload"
+        >
+          <n-button text>
+            <template #icon>
+              <n-icon :component="ArrowDownload16Regular" />
+            </template>
+            {{ t('download') }}
+          </n-button>
+        </n-popselect>
+      </n-space>
+    </template>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { NSpace, NAlert, NInput, NButton, NIcon, NPopselect, NTabs, NTabPane } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+import { ArrowDownload16Regular } from '@shared/icons/fluent'
+
+const props = defineProps<{
+  result: string
+  resultHex: string
+  resultBinary: ArrayBuffer | null
+  error: string
+}>()
+
+const { t } = useI18n()
+
+const activeTab = ref<'text' | 'hex'>('text')
+const downloadType = ref<string | null>(null)
+
+const downloadOptions = [
+  { label: 'Text (.txt)', value: 'text' },
+  { label: 'Binary (.bin)', value: 'binary' },
+]
+
+function handleDownload(value: string) {
+  if (!props.resultBinary) return
+
+  if (value === 'text') {
+    const blob = new Blob([props.result], { type: 'text/plain' })
+    downloadBlob(blob, 'decrypted.txt')
+  } else if (value === 'binary') {
+    const blob = new Blob([props.resultBinary], { type: 'application/octet-stream' })
+    downloadBlob(blob, 'decrypted.bin')
+  }
+  // Reset selection
+  downloadType.value = null
+}
+
+function downloadBlob(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "result": "Result",
+    "textTab": "Text",
+    "hexTab": "Hex",
+    "error": "Error",
+    "download": "Download"
+  },
+  "zh": {
+    "result": "结果",
+    "textTab": "文本",
+    "hexTab": "十六进制",
+    "error": "错误",
+    "download": "下载"
+  }
+}
+</i18n>

--- a/tools/web/aes-decryptor/src/components/KeyInput.vue
+++ b/tools/web/aes-decryptor/src/components/KeyInput.vue
@@ -1,0 +1,108 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('keySettings') }}</ToolSectionHeader>
+    <n-space vertical :size="12">
+      <n-radio-group
+        :value="keyType"
+        name="key-type"
+        @update:value="$emit('update:keyType', $event)"
+      >
+        <n-radio-button value="password">{{ t('password') }}</n-radio-button>
+        <n-radio-button value="raw">{{ t('rawKey') }}</n-radio-button>
+      </n-radio-group>
+
+      <template v-if="keyType === 'password'">
+        <n-input
+          :value="password"
+          type="password"
+          show-password-on="click"
+          :placeholder="t('passwordPlaceholder')"
+          @update:value="$emit('update:password', $event)"
+        />
+      </template>
+
+      <template v-else>
+        <n-input
+          :value="rawKey"
+          :placeholder="t('rawKeyPlaceholder')"
+          :status="rawKeyStatus"
+          style="font-family: monospace"
+          @update:value="$emit('update:rawKey', $event)"
+        />
+        <n-text v-if="rawKeyError" type="error" depth="3">{{ rawKeyError }}</n-text>
+        <n-text depth="3">{{ t('keyLengthHint', { length: expectedKeyLength }) }}</n-text>
+      </template>
+    </n-space>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NSpace, NRadioGroup, NRadioButton, NInput, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { type KeyType, type KeyLength, isValidHex } from '@utils/aes'
+
+const props = defineProps<{
+  keyType: KeyType
+  password: string
+  rawKey: string
+  keyLength: KeyLength
+}>()
+
+defineEmits<{
+  'update:keyType': [value: KeyType]
+  'update:password': [value: string]
+  'update:rawKey': [value: string]
+}>()
+
+const { t } = useI18n()
+
+const expectedKeyLength = computed(() => props.keyLength / 4)
+
+const rawKeyStatus = computed(() => {
+  if (!props.rawKey) return undefined
+  if (!isValidHex(props.rawKey)) return 'error'
+  const cleanHex = props.rawKey.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) return 'error'
+  return 'success'
+})
+
+const rawKeyError = computed(() => {
+  if (!props.rawKey) return ''
+  if (!isValidHex(props.rawKey)) return t('invalidHex')
+  const cleanHex = props.rawKey.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) {
+    return t('wrongKeyLength', {
+      expected: expectedKeyLength.value,
+      actual: cleanHex.length,
+    })
+  }
+  return ''
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "keySettings": "Key Settings",
+    "password": "Password",
+    "rawKey": "Raw Key",
+    "passwordPlaceholder": "Enter password...",
+    "rawKeyPlaceholder": "Enter hex key...",
+    "keyLengthHint": "Expected {length} hex characters",
+    "invalidHex": "Invalid hex format",
+    "wrongKeyLength": "Expected {expected} hex chars, got {actual}"
+  },
+  "zh": {
+    "keySettings": "密钥设置",
+    "password": "密码",
+    "rawKey": "原始密钥",
+    "passwordPlaceholder": "输入密码...",
+    "rawKeyPlaceholder": "输入十六进制密钥...",
+    "keyLengthHint": "需要 {length} 个十六进制字符",
+    "invalidHex": "无效的十六进制格式",
+    "wrongKeyLength": "需要 {expected} 个字符，当前 {actual} 个"
+  }
+}
+</i18n>

--- a/tools/web/aes-decryptor/src/index.ts
+++ b/tools/web/aes-decryptor/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/web/aes-decryptor/src/info.ts
+++ b/tools/web/aes-decryptor/src/info.ts
@@ -1,0 +1,134 @@
+export { LockOpen20Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'aes-decryptor'
+export const path = '/tools/aes-decryptor'
+export const tags = ['decryption', 'aes', 'security', 'cipher', 'crypto']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'AES Decryptor',
+    description:
+      'Decrypt text or files encrypted with AES algorithm. Supports GCM, CBC, and CTR modes with password-based key derivation (PBKDF2) or raw key input',
+  },
+  zh: {
+    name: 'AES 解密器',
+    description:
+      '解密使用 AES 算法加密的文本或文件。支持 GCM、CBC 和 CTR 模式，支持基于密码的密钥派生 (PBKDF2) 或原始密钥输入',
+  },
+  'zh-CN': {
+    name: 'AES 解密器',
+    description:
+      '解密使用 AES 算法加密的文本或文件。支持 GCM、CBC 和 CTR 模式，支持基于密码的密钥派生 (PBKDF2) 或原始密钥输入',
+  },
+  'zh-TW': {
+    name: 'AES 解密器',
+    description:
+      '解密使用 AES 演算法加密的文字或檔案。支援 GCM、CBC 和 CTR 模式，支援基於密碼的金鑰衍生 (PBKDF2) 或原始金鑰輸入',
+  },
+  'zh-HK': {
+    name: 'AES 解密器',
+    description:
+      '解密使用 AES 演算法加密的文字或檔案。支援 GCM、CBC 和 CTR 模式，支援基於密碼的金鑰衍生 (PBKDF2) 或原始金鑰輸入',
+  },
+  es: {
+    name: 'Desencriptador AES',
+    description:
+      'Desencripta texto o archivos cifrados con algoritmo AES. Soporta modos GCM, CBC y CTR con derivación de clave basada en contraseña (PBKDF2) o entrada de clave directa',
+  },
+  fr: {
+    name: 'Déchiffreur AES',
+    description:
+      "Déchiffrez du texte ou des fichiers chiffrés avec l'algorithme AES. Prend en charge les modes GCM, CBC et CTR avec dérivation de clé basée sur mot de passe (PBKDF2) ou entrée de clé brute",
+  },
+  de: {
+    name: 'AES-Entschlüsseler',
+    description:
+      'Entschlüsseln Sie mit dem AES-Algorithmus verschlüsselten Text oder Dateien. Unterstützt GCM-, CBC- und CTR-Modi mit passwortbasierter Schlüsselableitung (PBKDF2) oder direkter Schlüsseleingabe',
+  },
+  it: {
+    name: 'Decrittografatore AES',
+    description:
+      "Decripta testo o file crittografati con l'algoritmo AES. Supporta modalità GCM, CBC e CTR con derivazione della chiave basata su password (PBKDF2) o input della chiave grezza",
+  },
+  ja: {
+    name: 'AES 復号化ツール',
+    description:
+      'AES アルゴリズムで暗号化されたテキストまたはファイルを復号化。GCM、CBC、CTR モードをサポートし、パスワードベースの鍵導出 (PBKDF2) または直接鍵入力に対応',
+  },
+  ko: {
+    name: 'AES 복호화 도구',
+    description:
+      'AES 알고리즘으로 암호화된 텍스트 또는 파일 복호화. GCM, CBC, CTR 모드 지원, 비밀번호 기반 키 파생 (PBKDF2) 또는 원시 키 입력 지원',
+  },
+  ru: {
+    name: 'AES Дешифратор',
+    description:
+      'Дешифруйте текст или файлы, зашифрованные алгоритмом AES. Поддерживает режимы GCM, CBC и CTR с выводом ключа на основе пароля (PBKDF2) или прямым вводом ключа',
+  },
+  pt: {
+    name: 'Desencriptador AES',
+    description:
+      'Desencripte texto ou arquivos criptografados com algoritmo AES. Suporta modos GCM, CBC e CTR com derivação de chave baseada em senha (PBKDF2) ou entrada de chave direta',
+  },
+  ar: {
+    name: 'فك تشفير AES',
+    description:
+      'فك تشفير النص أو الملفات المشفرة بخوارزمية AES. يدعم أوضاع GCM و CBC و CTR مع اشتقاق المفتاح القائم على كلمة المرور (PBKDF2) أو إدخال المفتاح المباشر',
+  },
+  hi: {
+    name: 'AES डिक्रिप्टर',
+    description:
+      'AES एल्गोरिथम से एन्क्रिप्टेड टेक्स्ट या फ़ाइलों को डिक्रिप्ट करें। पासवर्ड-आधारित कुंजी व्युत्पत्ति (PBKDF2) या रॉ कुंजी इनपुट के साथ GCM, CBC और CTR मोड का समर्थन',
+  },
+  tr: {
+    name: 'AES Şifre Çözücü',
+    description:
+      'AES algoritması ile şifrelenmiş metin veya dosyaların şifresini çözün. Parola tabanlı anahtar türetme (PBKDF2) veya ham anahtar girişi ile GCM, CBC ve CTR modlarını destekler',
+  },
+  nl: {
+    name: 'AES-ontsleutelaar',
+    description:
+      'Ontsleutel tekst of bestanden versleuteld met het AES-algoritme. Ondersteunt GCM-, CBC- en CTR-modi met wachtwoordgebaseerde sleutelafleiding (PBKDF2) of directe sleutelinvoer',
+  },
+  sv: {
+    name: 'AES-dekrypterare',
+    description:
+      'Dekryptera text eller filer krypterade med AES-algoritmen. Stöder GCM-, CBC- och CTR-lägen med lösenordsbaserad nyckelderivering (PBKDF2) eller direkt nyckelinmatning',
+  },
+  pl: {
+    name: 'Deszyfrator AES',
+    description:
+      'Odszyfruj tekst lub pliki zaszyfrowane algorytmem AES. Obsługuje tryby GCM, CBC i CTR z wyprowadzaniem klucza opartym na haśle (PBKDF2) lub bezpośrednim wprowadzaniem klucza',
+  },
+  vi: {
+    name: 'Công cụ giải mã AES',
+    description:
+      'Giải mã văn bản hoặc tệp được mã hóa bằng thuật toán AES. Hỗ trợ các chế độ GCM, CBC và CTR với dẫn xuất khóa dựa trên mật khẩu (PBKDF2) hoặc nhập khóa trực tiếp',
+  },
+  th: {
+    name: 'เครื่องมือถอดรหัส AES',
+    description:
+      'ถอดรหัสข้อความหรือไฟล์ที่เข้ารหัสด้วยอัลกอริทึม AES รองรับโหมด GCM, CBC และ CTR พร้อมการสร้างคีย์จากรหัสผ่าน (PBKDF2) หรือการป้อนคีย์โดยตรง',
+  },
+  id: {
+    name: 'Dekriptor AES',
+    description:
+      'Dekripsi teks atau file yang dienkripsi dengan algoritma AES. Mendukung mode GCM, CBC, dan CTR dengan derivasi kunci berbasis kata sandi (PBKDF2) atau input kunci langsung',
+  },
+  he: {
+    name: 'מפענח AES',
+    description:
+      'פענח טקסט או קבצים מוצפנים באלגוריתם AES. תומך במצבי GCM, CBC ו-CTR עם גזירת מפתח מבוססת סיסמה (PBKDF2) או קלט מפתח ישיר',
+  },
+  ms: {
+    name: 'Penyahsulit AES',
+    description:
+      'Nyahsulit teks atau fail yang disulitkan dengan algoritma AES. Menyokong mod GCM, CBC dan CTR dengan terbitan kunci berasaskan kata laluan (PBKDF2) atau input kunci mentah',
+  },
+  no: {
+    name: 'AES-dekrypterer',
+    description:
+      'Dekrypter tekst eller filer kryptert med AES-algoritmen. Støtter GCM-, CBC- og CTR-moduser med passordbasert nøkkelutledning (PBKDF2) eller direkte nøkkelinntasting',
+  },
+}

--- a/tools/web/aes-decryptor/src/routes.ts
+++ b/tools/web/aes-decryptor/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'aes-decryptor',
+    path: '/tools/aes-decryptor',
+    component: () => import('./AesDecryptorView.vue'),
+  },
+] as const

--- a/tools/web/aes-encryptor/package.json
+++ b/tools/web/aes-encryptor/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/aes-encryptor",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@utils/aes": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/web/aes-encryptor/src/AesEncryptorView.vue
+++ b/tools/web/aes-encryptor/src/AesEncryptorView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <EncryptForm />
+    <WhatIsAes />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import EncryptForm from './components/EncryptForm.vue'
+import WhatIsAes from './components/WhatIsAes.vue'
+</script>

--- a/tools/web/aes-encryptor/src/components/AdvancedOptions.vue
+++ b/tools/web/aes-encryptor/src/components/AdvancedOptions.vue
@@ -1,0 +1,151 @@
+<template>
+  <ToolSection>
+    <n-collapse>
+      <n-collapse-item :title="t('advancedOptions')" name="advanced">
+        <n-grid :cols="2" :x-gap="12" :y-gap="12">
+          <n-form-item-gi v-if="keyType === 'password'" :label="t('pbkdf2Iterations')">
+            <n-input-number
+              :value="pbkdf2Iterations"
+              :min="1000"
+              :max="10000000"
+              :step="10000"
+              :status="pbkdf2Iterations < 10000 ? 'warning' : undefined"
+              style="width: 100%"
+              @update:value="$event !== null && $emit('update:pbkdf2Iterations', $event)"
+            />
+            <template v-if="pbkdf2Iterations < 10000" #feedback>
+              <n-text type="warning" style="font-size: 12px">{{
+                t('lowIterationsWarning')
+              }}</n-text>
+            </template>
+          </n-form-item-gi>
+          <n-form-item-gi v-if="keyType === 'password'" :label="t('pbkdf2Hash')">
+            <n-select
+              :value="pbkdf2Hash"
+              :options="pbkdf2HashOptions"
+              :disabled="outputMode === 'jwe'"
+              @update:value="$emit('update:pbkdf2Hash', $event)"
+            />
+            <template v-if="outputMode === 'jwe'" #feedback>
+              {{ t('jweHashNote') }}
+            </template>
+          </n-form-item-gi>
+          <n-form-item-gi v-if="outputMode === 'raw'" label="Salt">
+            <n-space vertical :size="8">
+              <n-radio-group
+                :value="saltMode"
+                name="salt-mode"
+                @update:value="$emit('update:saltMode', $event)"
+              >
+                <n-radio value="auto">{{ t('autoGenerate') }}</n-radio>
+                <n-radio value="manual">{{ t('manual') }}</n-radio>
+              </n-radio-group>
+              <n-input
+                v-if="saltMode === 'manual'"
+                :value="manualSalt"
+                :placeholder="t('saltPlaceholder')"
+                style="font-family: monospace"
+                @update:value="$emit('update:manualSalt', $event)"
+              />
+            </n-space>
+          </n-form-item-gi>
+          <n-form-item-gi v-if="outputMode === 'raw'" label="IV">
+            <n-space vertical :size="8">
+              <n-radio-group
+                :value="ivMode"
+                name="iv-mode"
+                @update:value="$emit('update:ivMode', $event)"
+              >
+                <n-radio value="auto">{{ t('autoGenerate') }}</n-radio>
+                <n-radio value="manual">{{ t('manual') }}</n-radio>
+              </n-radio-group>
+              <n-input
+                v-if="ivMode === 'manual'"
+                :value="manualIv"
+                :placeholder="t('ivPlaceholder', { length: ivLength * 2 })"
+                style="font-family: monospace"
+                @update:value="$emit('update:manualIv', $event)"
+              />
+            </n-space>
+          </n-form-item-gi>
+        </n-grid>
+      </n-collapse-item>
+    </n-collapse>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import {
+  NGrid,
+  NFormItemGi,
+  NCollapse,
+  NCollapseItem,
+  NInputNumber,
+  NSelect,
+  NRadioGroup,
+  NRadio,
+  NInput,
+  NSpace,
+  NText,
+} from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection } from '@shared/ui/tool'
+import type { KeyType, OutputMode, Pbkdf2Hash } from '@utils/aes'
+
+defineProps<{
+  keyType: KeyType
+  outputMode: OutputMode
+  ivLength: number
+  pbkdf2Iterations: number
+  pbkdf2Hash: Pbkdf2Hash
+  saltMode: 'auto' | 'manual'
+  manualSalt: string
+  ivMode: 'auto' | 'manual'
+  manualIv: string
+}>()
+
+defineEmits<{
+  'update:pbkdf2Iterations': [value: number]
+  'update:pbkdf2Hash': [value: Pbkdf2Hash]
+  'update:saltMode': [value: 'auto' | 'manual']
+  'update:manualSalt': [value: string]
+  'update:ivMode': [value: 'auto' | 'manual']
+  'update:manualIv': [value: string]
+}>()
+
+const { t } = useI18n()
+
+const pbkdf2HashOptions = [
+  { label: 'SHA-1', value: 'SHA-1' },
+  { label: 'SHA-256', value: 'SHA-256' },
+  { label: 'SHA-384', value: 'SHA-384' },
+  { label: 'SHA-512', value: 'SHA-512' },
+] satisfies Array<{ label: string; value: Pbkdf2Hash }>
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "advancedOptions": "Advanced Options",
+    "pbkdf2Iterations": "PBKDF2 Iterations",
+    "pbkdf2Hash": "PBKDF2 Hash",
+    "jweHashNote": "JWE uses hash based on key length",
+    "lowIterationsWarning": "Too low - recommend at least 100,000",
+    "autoGenerate": "Auto generate",
+    "manual": "Manual",
+    "saltPlaceholder": "32 hex characters",
+    "ivPlaceholder": "{length} hex characters"
+  },
+  "zh": {
+    "advancedOptions": "高级选项",
+    "pbkdf2Iterations": "PBKDF2 迭代次数",
+    "pbkdf2Hash": "PBKDF2 哈希",
+    "jweHashNote": "JWE 根据密钥长度自动选择哈希",
+    "lowIterationsWarning": "迭代次数过低 - 建议至少 100,000",
+    "autoGenerate": "自动生成",
+    "manual": "手动输入",
+    "saltPlaceholder": "32 个十六进制字符",
+    "ivPlaceholder": "{length} 个十六进制字符"
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/components/EncryptForm.vue
+++ b/tools/web/aes-encryptor/src/components/EncryptForm.vue
@@ -1,0 +1,402 @@
+<template>
+  <n-space vertical :size="16">
+    <ToolSection>
+      <ToolSectionHeader>{{ t('input') }}</ToolSectionHeader>
+      <TextOrFileInput v-model:value="input" :placeholder="t('inputPlaceholder')" />
+    </ToolSection>
+
+    <KeyInput
+      :key-type="keyType"
+      :password="password"
+      :raw-key="rawKey"
+      :key-length="keyLength"
+      @update:key-type="keyType = $event"
+      @update:password="password = $event"
+      @update:raw-key="rawKey = $event"
+    />
+
+    <EncryptOptions
+      :output-mode="outputMode"
+      :mode="mode"
+      :key-length="keyLength"
+      :output-format="outputFormat"
+      :key-type="keyType"
+      @update:output-mode="outputMode = $event"
+      @update:mode="mode = $event"
+      @update:key-length="keyLength = $event"
+      @update:output-format="outputFormat = $event"
+    />
+
+    <AdvancedOptions
+      :key-type="keyType"
+      :output-mode="outputMode"
+      :iv-length="ivLength"
+      :pbkdf2-iterations="pbkdf2Iterations"
+      :pbkdf2-hash="pbkdf2Hash"
+      :salt-mode="saltMode"
+      :manual-salt="manualSalt"
+      :iv-mode="ivMode"
+      :manual-iv="manualIv"
+      @update:pbkdf2-iterations="pbkdf2Iterations = $event"
+      @update:pbkdf2-hash="pbkdf2Hash = $event"
+      @update:salt-mode="saltMode = $event"
+      @update:manual-salt="manualSalt = $event"
+      @update:iv-mode="ivMode = $event"
+      @update:manual-iv="manualIv = $event"
+    />
+
+    <n-button type="primary" :loading="encrypting" :disabled="!canEncrypt" @click="handleEncrypt">
+      <template #icon>
+        <n-icon :component="LockClosed16Regular" />
+      </template>
+      {{ t('encrypt') }}
+    </n-button>
+
+    <EncryptResult
+      :result="result"
+      :error="error"
+      :salt="resultSalt"
+      :iv="resultIv"
+      :binary="resultBinary"
+      :output-mode="outputMode"
+      :output-format="outputFormat"
+    />
+  </n-space>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { NSpace, NButton, NIcon } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { useStorage } from '@vueuse/core'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { TextOrFileInput } from '@shared/ui/base'
+import { LockClosed16Regular } from '@shared/icons/fluent'
+import {
+  type AesMode,
+  type KeyLength,
+  type KeyType,
+  type OutputFormat,
+  type OutputMode,
+  type Pbkdf2Hash,
+  type RawEncryptResult,
+  PBKDF2_ITERATIONS,
+  IV_LENGTH,
+  encryptWithPassword,
+  encryptWithRawKey,
+  encryptJweWithPassword,
+  encryptJweWithRawKey,
+  isValidHex,
+} from '@utils/aes'
+import KeyInput from './KeyInput.vue'
+import EncryptOptions from './EncryptOptions.vue'
+import AdvancedOptions from './AdvancedOptions.vue'
+import EncryptResult from './EncryptResult.vue'
+
+const { t } = useI18n()
+
+// Input
+const input = ref<string | File>('')
+
+// Key settings
+const password = useStorage<string>('tools:aes-encryptor:password', '')
+const rawKey = useStorage<string>('tools:aes-encryptor:rawKey', '')
+const keyType = useStorage<KeyType>('tools:aes-encryptor:keyType', 'password')
+
+// Options
+const outputMode = useStorage<OutputMode>('tools:aes-encryptor:outputMode', 'jwe')
+const mode = useStorage<AesMode>('tools:aes-encryptor:mode', 'GCM')
+const keyLength = useStorage<KeyLength>('tools:aes-encryptor:keyLength', 256)
+const outputFormat = useStorage<OutputFormat>('tools:aes-encryptor:outputFormat', 'base64')
+
+// Advanced options
+const pbkdf2Iterations = useStorage<number>(
+  'tools:aes-encryptor:pbkdf2Iterations',
+  PBKDF2_ITERATIONS,
+)
+const pbkdf2Hash = useStorage<Pbkdf2Hash>('tools:aes-encryptor:pbkdf2Hash', 'SHA-256')
+const saltMode = ref<'auto' | 'manual'>('auto')
+const ivMode = ref<'auto' | 'manual'>('auto')
+const manualSalt = ref('')
+const manualIv = ref('')
+
+// Result
+const result = ref('')
+const resultSalt = ref('')
+const resultIv = ref('')
+const resultBinary = ref<ArrayBuffer | null>(null)
+const error = ref('')
+const encrypting = ref(false)
+
+// Computed
+const expectedKeyLength = computed(() => keyLength.value / 4)
+const ivLength = computed(() => IV_LENGTH[mode.value])
+
+const rawKeyStatus = computed(() => {
+  if (!rawKey.value) return undefined
+  if (!isValidHex(rawKey.value)) return 'error'
+  const cleanHex = rawKey.value.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) return 'error'
+  return 'success'
+})
+
+const canEncrypt = computed(() => {
+  if (!input.value) return false
+  if (keyType.value === 'password') {
+    return password.value.length > 0
+  } else {
+    return rawKeyStatus.value === 'success'
+  }
+})
+
+// Watch CTR mode - force raw output
+watch(mode, (newMode) => {
+  if (newMode === 'CTR' && outputMode.value === 'jwe') {
+    outputMode.value = 'raw'
+  }
+})
+
+// Functions
+async function handleEncrypt() {
+  error.value = ''
+  result.value = ''
+  resultSalt.value = ''
+  resultIv.value = ''
+  resultBinary.value = null
+  encrypting.value = true
+
+  try {
+    let data: string | ArrayBuffer
+    if (typeof input.value === 'string') {
+      data = input.value
+    } else {
+      data = await input.value.arrayBuffer()
+    }
+
+    if (outputMode.value === 'jwe') {
+      // JWE mode
+      if (keyType.value === 'password') {
+        result.value = await encryptJweWithPassword(
+          data,
+          password.value,
+          mode.value,
+          keyLength.value,
+          {
+            iterations: pbkdf2Iterations.value,
+          },
+        )
+      } else {
+        result.value = await encryptJweWithRawKey(data, rawKey.value, mode.value, keyLength.value)
+      }
+      resultSalt.value = t('embeddedInJwe')
+      resultIv.value = t('embeddedInJwe')
+    } else {
+      // Raw mode
+      const options = {
+        iterations: pbkdf2Iterations.value,
+        hash: pbkdf2Hash.value,
+        salt:
+          saltMode.value === 'manual' && manualSalt.value
+            ? hexToUint8Array(manualSalt.value)
+            : undefined,
+        iv:
+          ivMode.value === 'manual' && manualIv.value ? hexToUint8Array(manualIv.value) : undefined,
+      }
+
+      let encryptResult: RawEncryptResult
+      if (keyType.value === 'password') {
+        encryptResult = await encryptWithPassword(
+          data,
+          password.value,
+          mode.value,
+          keyLength.value,
+          outputFormat.value,
+          options,
+        )
+      } else {
+        encryptResult = await encryptWithRawKey(
+          data,
+          rawKey.value,
+          mode.value,
+          keyLength.value,
+          outputFormat.value,
+          { iv: options.iv },
+        )
+      }
+
+      result.value = encryptResult.output
+      resultSalt.value = encryptResult.salt
+      resultIv.value = encryptResult.iv
+      resultBinary.value = encryptResult.binary
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    encrypting.value = false
+  }
+}
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const cleanHex = hex.replace(/\s/g, '')
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = parseInt(cleanHex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "input": "Input",
+    "inputPlaceholder": "Enter text to encrypt or drop a file...",
+    "encrypt": "Encrypt",
+    "embeddedInJwe": "(embedded in JWE)"
+  },
+  "zh": {
+    "input": "输入",
+    "inputPlaceholder": "输入要加密的文本或拖放文件...",
+    "encrypt": "加密",
+    "embeddedInJwe": "（嵌入在 JWE 中）"
+  },
+  "zh-CN": {
+    "input": "输入",
+    "inputPlaceholder": "输入要加密的文本或拖放文件...",
+    "encrypt": "加密",
+    "embeddedInJwe": "（嵌入在 JWE 中）"
+  },
+  "zh-TW": {
+    "input": "輸入",
+    "inputPlaceholder": "輸入要加密的文字或拖放檔案...",
+    "encrypt": "加密",
+    "embeddedInJwe": "（嵌入在 JWE 中）"
+  },
+  "zh-HK": {
+    "input": "輸入",
+    "inputPlaceholder": "輸入要加密的文字或拖放檔案...",
+    "encrypt": "加密",
+    "embeddedInJwe": "（嵌入在 JWE 中）"
+  },
+  "es": {
+    "input": "Entrada",
+    "inputPlaceholder": "Ingrese texto para cifrar o arrastre un archivo...",
+    "encrypt": "Cifrar",
+    "embeddedInJwe": "(incrustado en JWE)"
+  },
+  "fr": {
+    "input": "Entrée",
+    "inputPlaceholder": "Entrez le texte à chiffrer ou déposez un fichier...",
+    "encrypt": "Chiffrer",
+    "embeddedInJwe": "(intégré dans JWE)"
+  },
+  "de": {
+    "input": "Eingabe",
+    "inputPlaceholder": "Text zum Verschlüsseln eingeben oder Datei ablegen...",
+    "encrypt": "Verschlüsseln",
+    "embeddedInJwe": "(eingebettet in JWE)"
+  },
+  "it": {
+    "input": "Input",
+    "inputPlaceholder": "Inserisci il testo da cifrare o trascina un file...",
+    "encrypt": "Cifra",
+    "embeddedInJwe": "(incorporato in JWE)"
+  },
+  "ja": {
+    "input": "入力",
+    "inputPlaceholder": "暗号化するテキストを入力またはファイルをドロップ...",
+    "encrypt": "暗号化",
+    "embeddedInJwe": "（JWE に埋め込み）"
+  },
+  "ko": {
+    "input": "입력",
+    "inputPlaceholder": "암호화할 텍스트를 입력하거나 파일을 드롭하세요...",
+    "encrypt": "암호화",
+    "embeddedInJwe": "(JWE에 포함됨)"
+  },
+  "ru": {
+    "input": "Ввод",
+    "inputPlaceholder": "Введите текст для шифрования или перетащите файл...",
+    "encrypt": "Зашифровать",
+    "embeddedInJwe": "(встроено в JWE)"
+  },
+  "pt": {
+    "input": "Entrada",
+    "inputPlaceholder": "Digite o texto para criptografar ou solte um arquivo...",
+    "encrypt": "Criptografar",
+    "embeddedInJwe": "(incorporado no JWE)"
+  },
+  "ar": {
+    "input": "الإدخال",
+    "inputPlaceholder": "أدخل النص للتشفير أو أسقط ملفًا...",
+    "encrypt": "تشفير",
+    "embeddedInJwe": "(مضمن في JWE)"
+  },
+  "hi": {
+    "input": "इनपुट",
+    "inputPlaceholder": "एन्क्रिप्ट करने के लिए टेक्स्ट दर्ज करें या फ़ाइल ड्रॉप करें...",
+    "encrypt": "एन्क्रिप्ट करें",
+    "embeddedInJwe": "(JWE में एम्बेडेड)"
+  },
+  "tr": {
+    "input": "Giriş",
+    "inputPlaceholder": "Şifrelenecek metni girin veya dosya bırakın...",
+    "encrypt": "Şifrele",
+    "embeddedInJwe": "(JWE'ye gömülü)"
+  },
+  "nl": {
+    "input": "Invoer",
+    "inputPlaceholder": "Voer tekst in om te versleutelen of sleep een bestand...",
+    "encrypt": "Versleutelen",
+    "embeddedInJwe": "(ingebed in JWE)"
+  },
+  "sv": {
+    "input": "Inmatning",
+    "inputPlaceholder": "Ange text att kryptera eller släpp en fil...",
+    "encrypt": "Kryptera",
+    "embeddedInJwe": "(inbäddad i JWE)"
+  },
+  "pl": {
+    "input": "Dane wejściowe",
+    "inputPlaceholder": "Wprowadź tekst do zaszyfrowania lub upuść plik...",
+    "encrypt": "Zaszyfruj",
+    "embeddedInJwe": "(osadzony w JWE)"
+  },
+  "vi": {
+    "input": "Đầu vào",
+    "inputPlaceholder": "Nhập văn bản để mã hóa hoặc kéo thả tệp...",
+    "encrypt": "Mã hóa",
+    "embeddedInJwe": "(nhúng trong JWE)"
+  },
+  "th": {
+    "input": "อินพุต",
+    "inputPlaceholder": "ป้อนข้อความที่จะเข้ารหัสหรือวางไฟล์...",
+    "encrypt": "เข้ารหัส",
+    "embeddedInJwe": "(ฝังใน JWE)"
+  },
+  "id": {
+    "input": "Input",
+    "inputPlaceholder": "Masukkan teks untuk dienkripsi atau letakkan file...",
+    "encrypt": "Enkripsi",
+    "embeddedInJwe": "(tertanam dalam JWE)"
+  },
+  "he": {
+    "input": "קלט",
+    "inputPlaceholder": "הזן טקסט להצפנה או גרור קובץ...",
+    "encrypt": "הצפן",
+    "embeddedInJwe": "(מוטמע ב-JWE)"
+  },
+  "ms": {
+    "input": "Input",
+    "inputPlaceholder": "Masukkan teks untuk disulitkan atau lepaskan fail...",
+    "encrypt": "Sulitkan",
+    "embeddedInJwe": "(tertanam dalam JWE)"
+  },
+  "no": {
+    "input": "Inndata",
+    "inputPlaceholder": "Skriv inn tekst som skal krypteres eller slipp en fil...",
+    "encrypt": "Krypter",
+    "embeddedInJwe": "(innebygd i JWE)"
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/components/EncryptOptions.vue
+++ b/tools/web/aes-encryptor/src/components/EncryptOptions.vue
@@ -1,0 +1,108 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('options') }}</ToolSectionHeader>
+    <n-grid :cols="4" :x-gap="12" :y-gap="12">
+      <n-form-item-gi :label="t('outputMode')">
+        <n-radio-group
+          :value="outputMode"
+          name="output-mode"
+          @update:value="$emit('update:outputMode', $event)"
+        >
+          <n-space vertical :size="4">
+            <n-radio value="jwe" :disabled="mode === 'CTR'">
+              JWE
+              <n-text depth="3" style="font-size: 12px">({{ t('recommended') }})</n-text>
+            </n-radio>
+            <n-radio value="raw">Raw</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+      <n-form-item-gi :label="t('mode')">
+        <n-radio-group :value="mode" name="mode" @update:value="$emit('update:mode', $event)">
+          <n-space vertical :size="4">
+            <n-radio value="GCM">GCM</n-radio>
+            <n-radio value="CBC" :disabled="outputMode === 'jwe' && keyType === 'raw'">
+              CBC
+            </n-radio>
+            <n-radio value="CTR">CTR</n-radio>
+          </n-space>
+        </n-radio-group>
+        <template v-if="mode === 'CTR'" #feedback>
+          <n-text type="warning" style="font-size: 12px">{{ t('ctrWarning') }}</n-text>
+        </template>
+      </n-form-item-gi>
+      <n-form-item-gi :label="t('keyLength')">
+        <n-radio-group
+          :value="keyLength"
+          name="key-length"
+          @update:value="$emit('update:keyLength', $event)"
+        >
+          <n-space vertical :size="4">
+            <n-radio :value="128">128-bit</n-radio>
+            <n-radio :value="192">192-bit</n-radio>
+            <n-radio :value="256">256-bit</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+      <n-form-item-gi v-if="outputMode === 'raw'" :label="t('outputFormat')">
+        <n-radio-group
+          :value="outputFormat"
+          name="output-format"
+          @update:value="$emit('update:outputFormat', $event)"
+        >
+          <n-space vertical :size="4">
+            <n-radio value="base64">Base64</n-radio>
+            <n-radio value="hex">Hex</n-radio>
+          </n-space>
+        </n-radio-group>
+      </n-form-item-gi>
+    </n-grid>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NGrid, NFormItemGi, NRadioGroup, NRadio, NSpace, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import type { AesMode, KeyLength, KeyType, OutputFormat, OutputMode } from '@utils/aes'
+
+defineProps<{
+  outputMode: OutputMode
+  mode: AesMode
+  keyLength: KeyLength
+  outputFormat: OutputFormat
+  keyType: KeyType
+}>()
+
+defineEmits<{
+  'update:outputMode': [value: OutputMode]
+  'update:mode': [value: AesMode]
+  'update:keyLength': [value: KeyLength]
+  'update:outputFormat': [value: OutputFormat]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "options": "Options",
+    "outputMode": "Output Format",
+    "recommended": "recommended",
+    "mode": "Mode",
+    "keyLength": "Key Length",
+    "outputFormat": "Encoding",
+    "ctrWarning": "CTR mode has no authentication - data can be tampered"
+  },
+  "zh": {
+    "options": "选项",
+    "outputMode": "输出格式",
+    "recommended": "推荐",
+    "mode": "模式",
+    "keyLength": "密钥长度",
+    "outputFormat": "编码",
+    "ctrWarning": "CTR 模式无认证 - 数据可能被篡改"
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/components/EncryptResult.vue
+++ b/tools/web/aes-encryptor/src/components/EncryptResult.vue
@@ -1,0 +1,176 @@
+<template>
+  <ToolSection v-if="result || error">
+    <ToolSectionHeader>{{ t('result') }}</ToolSectionHeader>
+    <n-alert v-if="error" type="error" :title="t('error')">{{ error }}</n-alert>
+    <template v-else>
+      <n-input
+        :value="result"
+        type="textarea"
+        readonly
+        :autosize="{ minRows: 3, maxRows: 10 }"
+        style="font-family: monospace"
+      />
+      <n-space style="margin-top: 8px">
+        <CopyToClipboardButton :content="result" />
+        <n-popselect
+          v-model:value="downloadType"
+          :options="downloadOptions"
+          trigger="click"
+          @update:value="handleDownload"
+        >
+          <n-button text>
+            <template #icon>
+              <n-icon :component="ArrowDownload16Regular" />
+            </template>
+            {{ t('download') }}
+          </n-button>
+        </n-popselect>
+      </n-space>
+
+      <n-collapse v-if="outputMode === 'raw'" style="margin-top: 12px">
+        <n-collapse-item :title="t('parameterDetails')" name="params">
+          <n-descriptions :column="1" label-placement="left">
+            <n-descriptions-item label="Salt">
+              <n-space align="center">
+                <code>{{ salt }}</code>
+                <CopyToClipboardButton :content="salt" size="tiny" />
+              </n-space>
+            </n-descriptions-item>
+            <n-descriptions-item label="IV">
+              <n-space align="center">
+                <code>{{ iv }}</code>
+                <CopyToClipboardButton :content="iv" size="tiny" />
+              </n-space>
+            </n-descriptions-item>
+          </n-descriptions>
+        </n-collapse-item>
+      </n-collapse>
+    </template>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import {
+  NSpace,
+  NAlert,
+  NInput,
+  NButton,
+  NIcon,
+  NPopselect,
+  NCollapse,
+  NCollapseItem,
+  NDescriptions,
+  NDescriptionsItem,
+} from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+import { ArrowDownload16Regular } from '@shared/icons/fluent'
+import type { OutputMode, OutputFormat } from '@utils/aes'
+
+const props = defineProps<{
+  result: string
+  error: string
+  salt: string
+  iv: string
+  binary: ArrayBuffer | null
+  outputMode: OutputMode
+  outputFormat: OutputFormat
+}>()
+
+const { t } = useI18n()
+
+const downloadType = ref<string | null>(null)
+
+const downloadOptions = computed(() => {
+  if (props.outputMode === 'jwe') {
+    return [{ label: 'JWE (.jwe)', value: 'jwe' }]
+  }
+  return [
+    { label: 'Binary (.bin)', value: 'binary' },
+    { label: 'Base64 (.txt)', value: 'base64' },
+    { label: 'Hex (.txt)', value: 'hex' },
+  ]
+})
+
+function handleDownload(value: string) {
+  if (value === 'jwe') {
+    downloadText(props.result, 'encrypted.jwe')
+  } else if (value === 'binary' && props.binary) {
+    downloadBinary(props.binary, 'encrypted.bin')
+  } else if (value === 'base64') {
+    const content = props.outputFormat === 'base64' ? props.result : hexToBase64(props.result)
+    downloadText(content, 'encrypted.txt')
+  } else if (value === 'hex') {
+    const content = props.outputFormat === 'hex' ? props.result : base64ToHex(props.result)
+    downloadText(content, 'encrypted.txt')
+  }
+  // Reset selection
+  downloadType.value = null
+}
+
+function downloadText(content: string, filename: string) {
+  const blob = new Blob([content], { type: 'text/plain' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function downloadBinary(data: ArrayBuffer, filename: string) {
+  const blob = new Blob([data], { type: 'application/octet-stream' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function hexToUint8Array(hex: string): Uint8Array {
+  const cleanHex = hex.replace(/\s/g, '')
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = parseInt(cleanHex.substring(i, i + 2), 16)
+  }
+  return bytes
+}
+
+function hexToBase64(hex: string): string {
+  const bytes = hexToUint8Array(hex)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+function base64ToHex(base64: string): string {
+  const binary = atob(base64)
+  let hex = ''
+  for (let i = 0; i < binary.length; i++) {
+    hex += binary.charCodeAt(i).toString(16).padStart(2, '0')
+  }
+  return hex
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "result": "Result",
+    "error": "Error",
+    "download": "Download",
+    "parameterDetails": "Parameter Details"
+  },
+  "zh": {
+    "result": "结果",
+    "error": "错误",
+    "download": "下载",
+    "parameterDetails": "参数详情"
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/components/KeyInput.vue
+++ b/tools/web/aes-encryptor/src/components/KeyInput.vue
@@ -1,0 +1,123 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('keySettings') }}</ToolSectionHeader>
+    <n-space vertical :size="12">
+      <n-radio-group
+        :value="keyType"
+        name="key-type"
+        @update:value="$emit('update:keyType', $event)"
+      >
+        <n-radio-button value="password">{{ t('password') }}</n-radio-button>
+        <n-radio-button value="raw">{{ t('rawKey') }}</n-radio-button>
+      </n-radio-group>
+
+      <template v-if="keyType === 'password'">
+        <n-input
+          :value="password"
+          type="password"
+          show-password-on="click"
+          :placeholder="t('passwordPlaceholder')"
+          @update:value="$emit('update:password', $event)"
+        />
+      </template>
+
+      <template v-else>
+        <n-input-group>
+          <n-input
+            :value="rawKey"
+            :placeholder="t('rawKeyPlaceholder')"
+            :status="rawKeyStatus"
+            style="font-family: monospace"
+            @update:value="$emit('update:rawKey', $event)"
+          />
+          <n-button v-if="showGenerate" @click="handleGenerateKey">{{ t('generate') }}</n-button>
+        </n-input-group>
+        <n-text v-if="rawKeyError" type="error" depth="3">{{ rawKeyError }}</n-text>
+        <n-text depth="3">{{ t('keyLengthHint', { length: expectedKeyLength }) }}</n-text>
+      </template>
+    </n-space>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NSpace, NRadioGroup, NRadioButton, NInput, NInputGroup, NButton, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { type KeyType, type KeyLength, generateRandomKey, isValidHex } from '@utils/aes'
+
+const props = withDefaults(
+  defineProps<{
+    keyType: KeyType
+    password: string
+    rawKey: string
+    keyLength: KeyLength
+    showGenerate?: boolean
+  }>(),
+  {
+    showGenerate: true,
+  },
+)
+
+const emit = defineEmits<{
+  'update:keyType': [value: KeyType]
+  'update:password': [value: string]
+  'update:rawKey': [value: string]
+}>()
+
+const { t } = useI18n()
+
+const expectedKeyLength = computed(() => props.keyLength / 4)
+
+const rawKeyStatus = computed(() => {
+  if (!props.rawKey) return undefined
+  if (!isValidHex(props.rawKey)) return 'error'
+  const cleanHex = props.rawKey.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) return 'error'
+  return 'success'
+})
+
+const rawKeyError = computed(() => {
+  if (!props.rawKey) return ''
+  if (!isValidHex(props.rawKey)) return t('invalidHex')
+  const cleanHex = props.rawKey.replace(/\s/g, '')
+  if (cleanHex.length !== expectedKeyLength.value) {
+    return t('wrongKeyLength', {
+      expected: expectedKeyLength.value,
+      actual: cleanHex.length,
+    })
+  }
+  return ''
+})
+
+function handleGenerateKey() {
+  emit('update:rawKey', generateRandomKey(props.keyLength))
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "keySettings": "Key Settings",
+    "password": "Password",
+    "rawKey": "Raw Key",
+    "passwordPlaceholder": "Enter password...",
+    "rawKeyPlaceholder": "Enter hex key...",
+    "generate": "Generate",
+    "keyLengthHint": "Expected {length} hex characters",
+    "invalidHex": "Invalid hex format",
+    "wrongKeyLength": "Expected {expected} hex chars, got {actual}"
+  },
+  "zh": {
+    "keySettings": "密钥设置",
+    "password": "密码",
+    "rawKey": "原始密钥",
+    "passwordPlaceholder": "输入密码...",
+    "rawKeyPlaceholder": "输入十六进制密钥...",
+    "generate": "生成",
+    "keyLengthHint": "需要 {length} 个十六进制字符",
+    "invalidHex": "无效的十六进制格式",
+    "wrongKeyLength": "需要 {expected} 个字符，当前 {actual} 个"
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/components/WhatIsAes.vue
+++ b/tools/web/aes-encryptor/src/components/WhatIsAes.vue
@@ -1,0 +1,199 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+    <n-text depth="2">{{ t('description') }}</n-text>
+    <n-ul style="margin-top: 8px">
+      <n-li><n-text strong>GCM</n-text>: {{ t('gcm') }}</n-li>
+      <n-li><n-text strong>CBC</n-text>: {{ t('cbc') }}</n-li>
+      <n-li><n-text strong>CTR</n-text>: {{ t('ctr') }}</n-li>
+    </n-ul>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NText, NUl, NLi } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is AES?",
+    "description": "AES (Advanced Encryption Standard) is a symmetric encryption algorithm widely used for secure data encryption. It supports key lengths of 128, 192, or 256 bits.",
+    "gcm": "Galois/Counter Mode - Provides both encryption and authentication. Recommended for most use cases.",
+    "cbc": "Cipher Block Chaining - Classic mode, widely compatible. Requires padding.",
+    "ctr": "Counter Mode - Stream cipher mode, no padding needed."
+  },
+  "zh": {
+    "title": "什么是 AES？",
+    "description": "AES（高级加密标准）是一种广泛用于安全数据加密的对称加密算法。支持 128、192 或 256 位密钥长度。",
+    "gcm": "伽罗瓦/计数器模式 - 同时提供加密和认证。推荐用于大多数场景。",
+    "cbc": "密码块链接模式 - 经典模式，兼容性好。需要填充。",
+    "ctr": "计数器模式 - 流密码模式，无需填充。"
+  },
+  "zh-CN": {
+    "title": "什么是 AES？",
+    "description": "AES（高级加密标准）是一种广泛用于安全数据加密的对称加密算法。支持 128、192 或 256 位密钥长度。",
+    "gcm": "伽罗瓦/计数器模式 - 同时提供加密和认证。推荐用于大多数场景。",
+    "cbc": "密码块链接模式 - 经典模式，兼容性好。需要填充。",
+    "ctr": "计数器模式 - 流密码模式，无需填充。"
+  },
+  "zh-TW": {
+    "title": "什麼是 AES？",
+    "description": "AES（進階加密標準）是一種廣泛用於安全資料加密的對稱加密演算法。支援 128、192 或 256 位元金鑰長度。",
+    "gcm": "伽羅瓦/計數器模式 - 同時提供加密和認證。推薦用於大多數場景。",
+    "cbc": "密碼區塊鏈結模式 - 經典模式，相容性好。需要填充。",
+    "ctr": "計數器模式 - 串流密碼模式，無需填充。"
+  },
+  "zh-HK": {
+    "title": "什麼是 AES？",
+    "description": "AES（進階加密標準）是一種廣泛用於安全資料加密的對稱加密演算法。支援 128、192 或 256 位元金鑰長度。",
+    "gcm": "伽羅瓦/計數器模式 - 同時提供加密和認證。推薦用於大多數場景。",
+    "cbc": "密碼區塊鏈結模式 - 經典模式，相容性好。需要填充。",
+    "ctr": "計數器模式 - 串流密碼模式，無需填充。"
+  },
+  "es": {
+    "title": "¿Qué es AES?",
+    "description": "AES (Estándar de Cifrado Avanzado) es un algoritmo de cifrado simétrico ampliamente utilizado para la encriptación segura de datos. Soporta longitudes de clave de 128, 192 o 256 bits.",
+    "gcm": "Modo Galois/Contador - Proporciona cifrado y autenticación. Recomendado para la mayoría de casos.",
+    "cbc": "Modo de Encadenamiento de Bloques - Modo clásico, ampliamente compatible. Requiere relleno.",
+    "ctr": "Modo Contador - Modo de cifrado de flujo, sin necesidad de relleno."
+  },
+  "fr": {
+    "title": "Qu'est-ce que AES ?",
+    "description": "AES (Advanced Encryption Standard) est un algorithme de chiffrement symétrique largement utilisé pour le chiffrement sécurisé des données. Il prend en charge des longueurs de clé de 128, 192 ou 256 bits.",
+    "gcm": "Mode Galois/Compteur - Fournit chiffrement et authentification. Recommandé pour la plupart des cas.",
+    "cbc": "Mode de chaînage de blocs - Mode classique, largement compatible. Nécessite un remplissage.",
+    "ctr": "Mode Compteur - Mode de chiffrement de flux, pas de remplissage nécessaire."
+  },
+  "de": {
+    "title": "Was ist AES?",
+    "description": "AES (Advanced Encryption Standard) ist ein symmetrischer Verschlüsselungsalgorithmus, der weit verbreitet für sichere Datenverschlüsselung verwendet wird. Er unterstützt Schlüssellängen von 128, 192 oder 256 Bit.",
+    "gcm": "Galois/Counter-Modus - Bietet Verschlüsselung und Authentifizierung. Für die meisten Anwendungsfälle empfohlen.",
+    "cbc": "Cipher Block Chaining-Modus - Klassischer Modus, weit kompatibel. Erfordert Padding.",
+    "ctr": "Counter-Modus - Stromchiffre-Modus, kein Padding erforderlich."
+  },
+  "it": {
+    "title": "Cos'è AES?",
+    "description": "AES (Advanced Encryption Standard) è un algoritmo di crittografia simmetrica ampiamente utilizzato per la crittografia sicura dei dati. Supporta lunghezze di chiave di 128, 192 o 256 bit.",
+    "gcm": "Modalità Galois/Counter - Fornisce crittografia e autenticazione. Consigliato per la maggior parte dei casi.",
+    "cbc": "Modalità Cipher Block Chaining - Modalità classica, ampiamente compatibile. Richiede padding.",
+    "ctr": "Modalità Counter - Modalità cifratura a flusso, nessun padding necessario."
+  },
+  "ja": {
+    "title": "AES とは？",
+    "description": "AES（Advanced Encryption Standard）は、安全なデータ暗号化に広く使用されている対称暗号化アルゴリズムです。128、192、256ビットの鍵長をサポートしています。",
+    "gcm": "Galois/Counter モード - 暗号化と認証の両方を提供。ほとんどのケースで推奨。",
+    "cbc": "Cipher Block Chaining モード - クラシックモード、広く互換性あり。パディングが必要。",
+    "ctr": "Counter モード - ストリーム暗号モード、パディング不要。"
+  },
+  "ko": {
+    "title": "AES란?",
+    "description": "AES(Advanced Encryption Standard)는 안전한 데이터 암호화에 널리 사용되는 대칭 암호화 알고리즘입니다. 128, 192 또는 256비트 키 길이를 지원합니다.",
+    "gcm": "Galois/Counter 모드 - 암호화와 인증을 모두 제공. 대부분의 경우 권장.",
+    "cbc": "Cipher Block Chaining 모드 - 클래식 모드, 광범위하게 호환. 패딩 필요.",
+    "ctr": "Counter 모드 - 스트림 암호 모드, 패딩 불필요."
+  },
+  "ru": {
+    "title": "Что такое AES?",
+    "description": "AES (Advanced Encryption Standard) — это симметричный алгоритм шифрования, широко используемый для безопасного шифрования данных. Поддерживает ключи длиной 128, 192 или 256 бит.",
+    "gcm": "Режим Galois/Counter — обеспечивает шифрование и аутентификацию. Рекомендуется для большинства случаев.",
+    "cbc": "Режим Cipher Block Chaining — классический режим, широко совместим. Требует дополнения.",
+    "ctr": "Режим Counter — потоковый режим шифрования, дополнение не требуется."
+  },
+  "pt": {
+    "title": "O que é AES?",
+    "description": "AES (Advanced Encryption Standard) é um algoritmo de criptografia simétrica amplamente utilizado para criptografia segura de dados. Suporta comprimentos de chave de 128, 192 ou 256 bits.",
+    "gcm": "Modo Galois/Counter - Fornece criptografia e autenticação. Recomendado para a maioria dos casos.",
+    "cbc": "Modo Cipher Block Chaining - Modo clássico, amplamente compatível. Requer preenchimento.",
+    "ctr": "Modo Counter - Modo de cifra de fluxo, sem necessidade de preenchimento."
+  },
+  "ar": {
+    "title": "ما هو AES؟",
+    "description": "AES (معيار التشفير المتقدم) هو خوارزمية تشفير متماثلة تُستخدم على نطاق واسع لتشفير البيانات الآمن. يدعم أطوال مفاتيح 128 أو 192 أو 256 بت.",
+    "gcm": "وضع Galois/Counter - يوفر التشفير والمصادقة. موصى به لمعظم الحالات.",
+    "cbc": "وضع تسلسل كتل التشفير - وضع كلاسيكي، متوافق على نطاق واسع. يتطلب الحشو.",
+    "ctr": "وضع العداد - وضع تشفير التدفق، لا حاجة للحشو."
+  },
+  "hi": {
+    "title": "AES क्या है?",
+    "description": "AES (एडवांस्ड एन्क्रिप्शन स्टैंडर्ड) एक सममित एन्क्रिप्शन एल्गोरिथम है जो सुरक्षित डेटा एन्क्रिप्शन के लिए व्यापक रूप से उपयोग किया जाता है। यह 128, 192 या 256 बिट की कुंजी लंबाई का समर्थन करता है।",
+    "gcm": "Galois/Counter मोड - एन्क्रिप्शन और प्रमाणीकरण दोनों प्रदान करता है। अधिकांश उपयोग के लिए अनुशंसित।",
+    "cbc": "Cipher Block Chaining मोड - क्लासिक मोड, व्यापक रूप से संगत। पैडिंग आवश्यक।",
+    "ctr": "Counter मोड - स्ट्रीम सिफर मोड, पैडिंग की आवश्यकता नहीं।"
+  },
+  "tr": {
+    "title": "AES Nedir?",
+    "description": "AES (Gelişmiş Şifreleme Standardı), güvenli veri şifreleme için yaygın olarak kullanılan bir simetrik şifreleme algoritmasıdır. 128, 192 veya 256 bit anahtar uzunluklarını destekler.",
+    "gcm": "Galois/Counter Modu - Şifreleme ve kimlik doğrulama sağlar. Çoğu kullanım için önerilir.",
+    "cbc": "Cipher Block Chaining Modu - Klasik mod, geniş uyumluluk. Dolgu gerektirir.",
+    "ctr": "Counter Modu - Akış şifre modu, dolgu gerekmez."
+  },
+  "nl": {
+    "title": "Wat is AES?",
+    "description": "AES (Advanced Encryption Standard) is een symmetrisch versleutelingsalgoritme dat veel wordt gebruikt voor veilige gegevensversleuteling. Het ondersteunt sleutellengtes van 128, 192 of 256 bits.",
+    "gcm": "Galois/Counter Mode - Biedt versleuteling en authenticatie. Aanbevolen voor de meeste gevallen.",
+    "cbc": "Cipher Block Chaining Mode - Klassieke modus, breed compatibel. Vereist opvulling.",
+    "ctr": "Counter Mode - Stream cipher modus, geen opvulling nodig."
+  },
+  "sv": {
+    "title": "Vad är AES?",
+    "description": "AES (Advanced Encryption Standard) är en symmetrisk krypteringsalgoritm som används i stor utsträckning för säker datakryptering. Den stöder nyckellängder på 128, 192 eller 256 bitar.",
+    "gcm": "Galois/Counter-läge - Ger kryptering och autentisering. Rekommenderas för de flesta fall.",
+    "cbc": "Cipher Block Chaining-läge - Klassiskt läge, bred kompatibilitet. Kräver utfyllnad.",
+    "ctr": "Counter-läge - Strömchifferläge, ingen utfyllnad behövs."
+  },
+  "pl": {
+    "title": "Czym jest AES?",
+    "description": "AES (Advanced Encryption Standard) to symetryczny algorytm szyfrowania szeroko stosowany do bezpiecznego szyfrowania danych. Obsługuje klucze o długości 128, 192 lub 256 bitów.",
+    "gcm": "Tryb Galois/Counter - Zapewnia szyfrowanie i uwierzytelnianie. Zalecany dla większości przypadków.",
+    "cbc": "Tryb Cipher Block Chaining - Tryb klasyczny, szeroko kompatybilny. Wymaga dopełnienia.",
+    "ctr": "Tryb Counter - Tryb szyfru strumieniowego, bez potrzeby dopełnienia."
+  },
+  "vi": {
+    "title": "AES là gì?",
+    "description": "AES (Advanced Encryption Standard) là thuật toán mã hóa đối xứng được sử dụng rộng rãi để mã hóa dữ liệu an toàn. Hỗ trợ độ dài khóa 128, 192 hoặc 256 bit.",
+    "gcm": "Chế độ Galois/Counter - Cung cấp mã hóa và xác thực. Khuyến nghị cho hầu hết các trường hợp.",
+    "cbc": "Chế độ Cipher Block Chaining - Chế độ cổ điển, tương thích rộng. Yêu cầu đệm.",
+    "ctr": "Chế độ Counter - Chế độ mã hóa dòng, không cần đệm."
+  },
+  "th": {
+    "title": "AES คืออะไร?",
+    "description": "AES (Advanced Encryption Standard) เป็นอัลกอริทึมการเข้ารหัสแบบสมมาตรที่ใช้กันอย่างแพร่หลายสำหรับการเข้ารหัสข้อมูลที่ปลอดภัย รองรับความยาวคีย์ 128, 192 หรือ 256 บิต",
+    "gcm": "โหมด Galois/Counter - ให้การเข้ารหัสและการยืนยันตัวตน แนะนำสำหรับกรณีส่วนใหญ่",
+    "cbc": "โหมด Cipher Block Chaining - โหมดคลาสสิก เข้ากันได้กว้าง ต้องใช้การเติม",
+    "ctr": "โหมด Counter - โหมดรหัสกระแส ไม่ต้องเติม"
+  },
+  "id": {
+    "title": "Apa itu AES?",
+    "description": "AES (Advanced Encryption Standard) adalah algoritma enkripsi simetris yang banyak digunakan untuk enkripsi data yang aman. Mendukung panjang kunci 128, 192, atau 256 bit.",
+    "gcm": "Mode Galois/Counter - Menyediakan enkripsi dan autentikasi. Direkomendasikan untuk sebagian besar kasus.",
+    "cbc": "Mode Cipher Block Chaining - Mode klasik, kompatibel luas. Memerlukan padding.",
+    "ctr": "Mode Counter - Mode stream cipher, tidak perlu padding."
+  },
+  "he": {
+    "title": "מה זה AES?",
+    "description": "AES (Advanced Encryption Standard) הוא אלגוריתם הצפנה סימטרי הנמצא בשימוש נרחב להצפנת נתונים מאובטחת. תומך באורכי מפתח של 128, 192 או 256 סיביות.",
+    "gcm": "מצב Galois/Counter - מספק הצפנה ואימות. מומלץ לרוב המקרים.",
+    "cbc": "מצב Cipher Block Chaining - מצב קלאסי, תואם באופן נרחב. דורש מילוי.",
+    "ctr": "מצב Counter - מצב צופן זרם, לא נדרש מילוי."
+  },
+  "ms": {
+    "title": "Apa itu AES?",
+    "description": "AES (Advanced Encryption Standard) ialah algoritma penyulitan simetri yang digunakan secara meluas untuk penyulitan data selamat. Menyokong panjang kunci 128, 192 atau 256 bit.",
+    "gcm": "Mod Galois/Counter - Menyediakan penyulitan dan pengesahan. Disyorkan untuk kebanyakan kes.",
+    "cbc": "Mod Cipher Block Chaining - Mod klasik, serasi secara meluas. Memerlukan pengisian.",
+    "ctr": "Mod Counter - Mod sifir aliran, tiada pengisian diperlukan."
+  },
+  "no": {
+    "title": "Hva er AES?",
+    "description": "AES (Advanced Encryption Standard) er en symmetrisk krypteringsalgoritme som brukes mye for sikker datakryptering. Den støtter nøkkellengder på 128, 192 eller 256 biter.",
+    "gcm": "Galois/Counter-modus - Gir kryptering og autentisering. Anbefalt for de fleste tilfeller.",
+    "cbc": "Cipher Block Chaining-modus - Klassisk modus, bred kompatibilitet. Krever utfylling.",
+    "ctr": "Counter-modus - Strømchiffermodus, ingen utfylling nødvendig."
+  }
+}
+</i18n>

--- a/tools/web/aes-encryptor/src/index.ts
+++ b/tools/web/aes-encryptor/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/web/aes-encryptor/src/info.ts
+++ b/tools/web/aes-encryptor/src/info.ts
@@ -1,0 +1,134 @@
+export { LockClosed20Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'aes-encryptor'
+export const path = '/tools/aes-encryptor'
+export const tags = ['encryption', 'aes', 'security', 'cipher', 'crypto']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'AES Encryptor',
+    description:
+      'Encrypt text or files using AES algorithm with GCM, CBC, and CTR modes. Supports password-based key derivation (PBKDF2) and raw key input with 128/192/256-bit key lengths',
+  },
+  zh: {
+    name: 'AES 加密器',
+    description:
+      '使用 AES 算法加密文本或文件，支持 GCM、CBC 和 CTR 模式。支持基于密码的密钥派生 (PBKDF2) 和原始密钥输入，密钥长度支持 128/192/256 位',
+  },
+  'zh-CN': {
+    name: 'AES 加密器',
+    description:
+      '使用 AES 算法加密文本或文件，支持 GCM、CBC 和 CTR 模式。支持基于密码的密钥派生 (PBKDF2) 和原始密钥输入，密钥长度支持 128/192/256 位',
+  },
+  'zh-TW': {
+    name: 'AES 加密器',
+    description:
+      '使用 AES 演算法加密文字或檔案，支援 GCM、CBC 和 CTR 模式。支援基於密碼的金鑰衍生 (PBKDF2) 和原始金鑰輸入，金鑰長度支援 128/192/256 位元',
+  },
+  'zh-HK': {
+    name: 'AES 加密器',
+    description:
+      '使用 AES 演算法加密文字或檔案，支援 GCM、CBC 和 CTR 模式。支援基於密碼的金鑰衍生 (PBKDF2) 和原始金鑰輸入，金鑰長度支援 128/192/256 位元',
+  },
+  es: {
+    name: 'Encriptador AES',
+    description:
+      'Encripta texto o archivos usando el algoritmo AES con modos GCM, CBC y CTR. Soporta derivación de clave basada en contraseña (PBKDF2) y entrada de clave directa con longitudes de 128/192/256 bits',
+  },
+  fr: {
+    name: 'Chiffreur AES',
+    description:
+      "Chiffrez du texte ou des fichiers avec l'algorithme AES en modes GCM, CBC et CTR. Prend en charge la dérivation de clé basée sur mot de passe (PBKDF2) et l'entrée de clé brute avec des longueurs de 128/192/256 bits",
+  },
+  de: {
+    name: 'AES-Verschlüsseler',
+    description:
+      'Verschlüsseln Sie Text oder Dateien mit dem AES-Algorithmus in GCM-, CBC- und CTR-Modi. Unterstützt passwortbasierte Schlüsselableitung (PBKDF2) und direkte Schlüsseleingabe mit 128/192/256-Bit-Schlüssellängen',
+  },
+  it: {
+    name: 'Crittografatore AES',
+    description:
+      "Cripta testo o file usando l'algoritmo AES con modalità GCM, CBC e CTR. Supporta la derivazione della chiave basata su password (PBKDF2) e l'input della chiave grezza con lunghezze di 128/192/256 bit",
+  },
+  ja: {
+    name: 'AES 暗号化ツール',
+    description:
+      'AES アルゴリズムを使用して GCM、CBC、CTR モードでテキストまたはファイルを暗号化。パスワードベースの鍵導出 (PBKDF2) と 128/192/256 ビット鍵長の直接鍵入力をサポート',
+  },
+  ko: {
+    name: 'AES 암호화 도구',
+    description:
+      'GCM, CBC, CTR 모드의 AES 알고리즘으로 텍스트 또는 파일 암호화. 비밀번호 기반 키 파생 (PBKDF2) 및 128/192/256비트 키 길이의 원시 키 입력 지원',
+  },
+  ru: {
+    name: 'AES Шифратор',
+    description:
+      'Шифруйте текст или файлы с помощью алгоритма AES в режимах GCM, CBC и CTR. Поддерживает вывод ключа на основе пароля (PBKDF2) и прямой ввод ключа с длиной 128/192/256 бит',
+  },
+  pt: {
+    name: 'Encriptador AES',
+    description:
+      'Encripte texto ou arquivos usando o algoritmo AES com modos GCM, CBC e CTR. Suporta derivação de chave baseada em senha (PBKDF2) e entrada de chave direta com comprimentos de 128/192/256 bits',
+  },
+  ar: {
+    name: 'مشفر AES',
+    description:
+      'تشفير النص أو الملفات باستخدام خوارزمية AES مع أوضاع GCM و CBC و CTR. يدعم اشتقاق المفتاح القائم على كلمة المرور (PBKDF2) وإدخال المفتاح المباشر بأطوال 128/192/256 بت',
+  },
+  hi: {
+    name: 'AES एन्क्रिप्टर',
+    description:
+      'GCM, CBC और CTR मोड के साथ AES एल्गोरिथम का उपयोग करके टेक्स्ट या फ़ाइलों को एन्क्रिप्ट करें। पासवर्ड-आधारित कुंजी व्युत्पत्ति (PBKDF2) और 128/192/256-बिट कुंजी लंबाई के साथ रॉ कुंजी इनपुट का समर्थन',
+  },
+  tr: {
+    name: 'AES Şifreleyici',
+    description:
+      'GCM, CBC ve CTR modlarıyla AES algoritması kullanarak metin veya dosyaları şifreleyin. Parola tabanlı anahtar türetme (PBKDF2) ve 128/192/256-bit anahtar uzunluklarıyla ham anahtar girişini destekler',
+  },
+  nl: {
+    name: 'AES-versleutelaar',
+    description:
+      'Versleutel tekst of bestanden met het AES-algoritme in GCM-, CBC- en CTR-modi. Ondersteunt wachtwoordgebaseerde sleutelafleiding (PBKDF2) en directe sleutelinvoer met 128/192/256-bit sleutellengtes',
+  },
+  sv: {
+    name: 'AES-krypterare',
+    description:
+      'Kryptera text eller filer med AES-algoritmen i GCM-, CBC- och CTR-lägen. Stöder lösenordsbaserad nyckelderivering (PBKDF2) och direkt nyckelinmatning med 128/192/256-bitars nyckellängder',
+  },
+  pl: {
+    name: 'Szyfrator AES',
+    description:
+      'Szyfruj tekst lub pliki za pomocą algorytmu AES w trybach GCM, CBC i CTR. Obsługuje wyprowadzanie klucza oparte na haśle (PBKDF2) i bezpośrednie wprowadzanie klucza o długości 128/192/256 bitów',
+  },
+  vi: {
+    name: 'Công cụ mã hóa AES',
+    description:
+      'Mã hóa văn bản hoặc tệp bằng thuật toán AES với các chế độ GCM, CBC và CTR. Hỗ trợ dẫn xuất khóa dựa trên mật khẩu (PBKDF2) và nhập khóa trực tiếp với độ dài 128/192/256 bit',
+  },
+  th: {
+    name: 'เครื่องมือเข้ารหัส AES',
+    description:
+      'เข้ารหัสข้อความหรือไฟล์ด้วยอัลกอริทึม AES ในโหมด GCM, CBC และ CTR รองรับการสร้างคีย์จากรหัสผ่าน (PBKDF2) และการป้อนคีย์โดยตรงที่ความยาว 128/192/256 บิต',
+  },
+  id: {
+    name: 'Enkriptor AES',
+    description:
+      'Enkripsi teks atau file menggunakan algoritma AES dengan mode GCM, CBC, dan CTR. Mendukung derivasi kunci berbasis kata sandi (PBKDF2) dan input kunci langsung dengan panjang 128/192/256 bit',
+  },
+  he: {
+    name: 'מצפין AES',
+    description:
+      'הצפן טקסט או קבצים באמצעות אלגוריתם AES במצבי GCM, CBC ו-CTR. תומך בגזירת מפתח מבוססת סיסמה (PBKDF2) וקלט מפתח ישיר באורכי 128/192/256 סיביות',
+  },
+  ms: {
+    name: 'Penyulit AES',
+    description:
+      'Sulitkan teks atau fail menggunakan algoritma AES dengan mod GCM, CBC dan CTR. Menyokong terbitan kunci berasaskan kata laluan (PBKDF2) dan input kunci mentah dengan panjang 128/192/256 bit',
+  },
+  no: {
+    name: 'AES-krypterer',
+    description:
+      'Krypter tekst eller filer med AES-algoritmen i GCM-, CBC- og CTR-moduser. Støtter passordbasert nøkkelutledning (PBKDF2) og direkte nøkkelinntasting med 128/192/256-biters nøkkellengder',
+  },
+}

--- a/tools/web/aes-encryptor/src/routes.ts
+++ b/tools/web/aes-encryptor/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'aes-encryptor',
+    path: '/tools/aes-encryptor',
+    component: () => import('./AesEncryptorView.vue'),
+  },
+] as const

--- a/utils/aes/package.json
+++ b/utils/aes/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@utils/aes",
+  "version": "1.0.0",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./types": "./src/types.ts"
+  },
+  "type": "module",
+  "dependencies": {
+    "jose": "catalog:"
+  }
+}

--- a/utils/aes/src/crypto.dom.test.ts
+++ b/utils/aes/src/crypto.dom.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest'
+import {
+  encryptWithPassword,
+  decryptWithPassword,
+  encryptWithRawKey,
+  decryptWithRawKey,
+  pack,
+  unpack,
+  generateRandomKey,
+  arrayBufferToBase64,
+  base64ToArrayBuffer,
+  arrayBufferToHex,
+  hexToArrayBuffer,
+  isValidHex,
+  isValidBase64,
+  arrayBufferToString,
+} from './crypto'
+import type { AesMode, KeyLength } from './types'
+
+describe('AES-GCM encryption with password', () => {
+  it('encrypts and decrypts text correctly', async () => {
+    const plaintext = 'Hello, World!'
+    const password = 'test-password-123'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    const decrypted = await decryptWithPassword(result.output, password, 'GCM', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('handles Unicode text', async () => {
+    const plaintext = '你好，世界！🌍 Привет мир!'
+    const password = 'unicode-test'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    const decrypted = await decryptWithPassword(result.output, password, 'GCM', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('handles empty string', async () => {
+    const plaintext = ''
+    const password = 'empty-test'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    const decrypted = await decryptWithPassword(result.output, password, 'GCM', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('fails with wrong password', async () => {
+    const plaintext = 'Secret message'
+    const result = await encryptWithPassword(plaintext, 'correct-password', 'GCM', 256, 'base64')
+    await expect(
+      decryptWithPassword(result.output, 'wrong-password', 'GCM', 256, 'base64'),
+    ).rejects.toThrow()
+  })
+
+  it('produces different ciphertext each time due to random IV', async () => {
+    const plaintext = 'Same message'
+    const password = 'same-password'
+    const result1 = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    const result2 = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    expect(result1.output).not.toBe(result2.output)
+  })
+})
+
+describe('AES-CBC encryption with password', () => {
+  it('encrypts and decrypts text correctly', async () => {
+    const plaintext = 'Hello, CBC World!'
+    const password = 'cbc-test-password'
+    const result = await encryptWithPassword(plaintext, password, 'CBC', 256, 'base64')
+    const decrypted = await decryptWithPassword(result.output, password, 'CBC', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('handles various text lengths', async () => {
+    const testCases = ['a', 'ab', '1234567890123456', 'Long text that spans multiple blocks...']
+    const password = 'cbc-length-test'
+
+    for (const plaintext of testCases) {
+      const result = await encryptWithPassword(plaintext, password, 'CBC', 256, 'base64')
+      const decrypted = await decryptWithPassword(result.output, password, 'CBC', 256, 'base64')
+      expect(arrayBufferToString(decrypted)).toBe(plaintext)
+    }
+  })
+})
+
+describe('AES-CTR encryption with password', () => {
+  it('encrypts and decrypts text correctly', async () => {
+    const plaintext = 'Hello, CTR World!'
+    const password = 'ctr-test-password'
+    const result = await encryptWithPassword(plaintext, password, 'CTR', 256, 'base64')
+    const decrypted = await decryptWithPassword(result.output, password, 'CTR', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+})
+
+describe('Key lengths', () => {
+  const keyLengths: KeyLength[] = [128, 192, 256]
+  const modes: AesMode[] = ['GCM', 'CBC', 'CTR']
+
+  for (const keyLength of keyLengths) {
+    for (const mode of modes) {
+      it(`works with ${keyLength}-bit key in ${mode} mode`, async () => {
+        const plaintext = `Testing ${keyLength}-bit ${mode}`
+        const password = 'key-length-test'
+        const result = await encryptWithPassword(plaintext, password, mode, keyLength, 'base64')
+        const decrypted = await decryptWithPassword(
+          result.output,
+          password,
+          mode,
+          keyLength,
+          'base64',
+        )
+        expect(arrayBufferToString(decrypted)).toBe(plaintext)
+      })
+    }
+  }
+})
+
+describe('Raw key encryption', () => {
+  it('encrypts and decrypts with 256-bit raw key', async () => {
+    const plaintext = 'Raw key test'
+    const keyHex = generateRandomKey(256)
+    const result = await encryptWithRawKey(plaintext, keyHex, 'GCM', 256, 'base64')
+    const decrypted = await decryptWithRawKey(result.output, keyHex, 'GCM', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('encrypts and decrypts with 128-bit raw key', async () => {
+    const plaintext = 'Raw key 128-bit test'
+    const keyHex = generateRandomKey(128)
+    const result = await encryptWithRawKey(plaintext, keyHex, 'GCM', 128, 'base64')
+    const decrypted = await decryptWithRawKey(result.output, keyHex, 'GCM', 128, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('fails with wrong key', async () => {
+    const plaintext = 'Secret with raw key'
+    const correctKey = generateRandomKey(256)
+    const wrongKey = generateRandomKey(256)
+    const result = await encryptWithRawKey(plaintext, correctKey, 'GCM', 256, 'base64')
+    await expect(decryptWithRawKey(result.output, wrongKey, 'GCM', 256, 'base64')).rejects.toThrow()
+  })
+})
+
+describe('Output formats', () => {
+  it('works with Base64 output', async () => {
+    const plaintext = 'Base64 format test'
+    const password = 'format-test'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+    expect(isValidBase64(result.output)).toBe(true)
+    const decrypted = await decryptWithPassword(result.output, password, 'GCM', 256, 'base64')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+
+  it('works with Hex output', async () => {
+    const plaintext = 'Hex format test'
+    const password = 'format-test'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'hex')
+    expect(isValidHex(result.output)).toBe(true)
+    const decrypted = await decryptWithPassword(result.output, password, 'GCM', 256, 'hex')
+    expect(arrayBufferToString(decrypted)).toBe(plaintext)
+  })
+})
+
+describe('Data packing', () => {
+  it('packs and unpacks correctly for GCM (12-byte IV)', () => {
+    const salt = new Uint8Array(16).fill(1)
+    const iv = new Uint8Array(12).fill(2)
+    const ciphertext = new Uint8Array([3, 4, 5, 6, 7])
+
+    const packed = pack(salt, iv, ciphertext.buffer)
+    const unpacked = unpack(packed, 'GCM')
+
+    expect(new Uint8Array(unpacked.salt)).toEqual(salt)
+    expect(new Uint8Array(unpacked.iv)).toEqual(iv)
+    expect(new Uint8Array(unpacked.ciphertext)).toEqual(ciphertext)
+  })
+
+  it('packs and unpacks correctly for CBC (16-byte IV)', () => {
+    const salt = new Uint8Array(16).fill(10)
+    const iv = new Uint8Array(16).fill(20)
+    const ciphertext = new Uint8Array([30, 40, 50])
+
+    const packed = pack(salt, iv, ciphertext.buffer)
+    const unpacked = unpack(packed, 'CBC')
+
+    expect(new Uint8Array(unpacked.salt)).toEqual(salt)
+    expect(new Uint8Array(unpacked.iv)).toEqual(iv)
+    expect(new Uint8Array(unpacked.ciphertext)).toEqual(ciphertext)
+  })
+
+  it('throws on too short data', () => {
+    const shortData = new Uint8Array(10).buffer
+    expect(() => unpack(shortData, 'GCM')).toThrow('Invalid encrypted data: too short')
+  })
+})
+
+describe('Encoding utilities', () => {
+  describe('Base64', () => {
+    it('round-trips correctly', () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255])
+      const base64 = arrayBufferToBase64(original.buffer)
+      const decoded = base64ToArrayBuffer(base64)
+      expect(new Uint8Array(decoded)).toEqual(original)
+    })
+
+    it('validates Base64 strings', () => {
+      expect(isValidBase64('SGVsbG8=')).toBe(true)
+      expect(isValidBase64('not valid base64!@#')).toBe(false)
+    })
+  })
+
+  describe('Hex', () => {
+    it('round-trips correctly', () => {
+      const original = new Uint8Array([0, 1, 127, 128, 255])
+      const hex = arrayBufferToHex(original)
+      const decoded = hexToArrayBuffer(hex)
+      expect(new Uint8Array(decoded)).toEqual(original)
+    })
+
+    it('validates hex strings', () => {
+      expect(isValidHex('0123456789abcdef')).toBe(true)
+      expect(isValidHex('ABCDEF')).toBe(true)
+      expect(isValidHex('0123456789abcdefg')).toBe(false)
+      expect(isValidHex('123')).toBe(false) // odd length
+    })
+
+    it('handles hex with spaces', () => {
+      expect(isValidHex('01 23 45')).toBe(true)
+    })
+  })
+})
+
+describe('generateRandomKey', () => {
+  it('generates correct length keys', () => {
+    expect(generateRandomKey(128).length).toBe(32) // 128 bits = 16 bytes = 32 hex chars
+    expect(generateRandomKey(192).length).toBe(48) // 192 bits = 24 bytes = 48 hex chars
+    expect(generateRandomKey(256).length).toBe(64) // 256 bits = 32 bytes = 64 hex chars
+  })
+
+  it('generates different keys each time', () => {
+    const key1 = generateRandomKey(256)
+    const key2 = generateRandomKey(256)
+    expect(key1).not.toBe(key2)
+  })
+
+  it('generates valid hex', () => {
+    const key = generateRandomKey(256)
+    expect(isValidHex(key)).toBe(true)
+  })
+})
+
+describe('Error handling', () => {
+  it('throws on corrupted ciphertext', async () => {
+    const plaintext = 'Test message'
+    const password = 'test-password'
+    const result = await encryptWithPassword(plaintext, password, 'GCM', 256, 'base64')
+
+    // Corrupt the ciphertext by modifying the last character
+    const corrupted = result.output.slice(0, -4) + 'AAAA'
+
+    await expect(decryptWithPassword(corrupted, password, 'GCM', 256, 'base64')).rejects.toThrow()
+  })
+
+  it('throws on invalid Base64 input', async () => {
+    const password = 'test-password'
+    await expect(
+      decryptWithPassword('not-valid-base64!!!', password, 'GCM', 256, 'base64'),
+    ).rejects.toThrow()
+  })
+
+  it('throws on invalid hex input', async () => {
+    const password = 'test-password'
+    await expect(
+      decryptWithPassword('not-valid-hex!!!', password, 'GCM', 256, 'hex'),
+    ).rejects.toThrow()
+  })
+})

--- a/utils/aes/src/crypto.ts
+++ b/utils/aes/src/crypto.ts
@@ -1,0 +1,345 @@
+import {
+  type AesMode,
+  type KeyLength,
+  type OutputFormat,
+  type EncryptOptions,
+  type Pbkdf2Options,
+  IV_LENGTH,
+  SALT_LENGTH,
+  PBKDF2_ITERATIONS,
+  PBKDF2_HASH,
+} from './types'
+
+export interface RawEncryptResult {
+  output: string // Encoded string (base64 or hex)
+  salt: string // Hex
+  iv: string // Hex
+  binary: ArrayBuffer // Raw packed binary
+}
+
+/**
+ * Generate random bytes
+ */
+export function generateRandomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length))
+}
+
+/**
+ * Generate a random key in hex format
+ */
+export function generateRandomKey(keyLength: KeyLength): string {
+  const bytes = generateRandomBytes(keyLength / 8)
+  return arrayBufferToHex(bytes)
+}
+
+/**
+ * Derive a CryptoKey from a password using PBKDF2
+ */
+export async function deriveKey(
+  password: string,
+  salt: Uint8Array,
+  keyLength: KeyLength,
+  mode: AesMode,
+  options: Pbkdf2Options = {},
+): Promise<CryptoKey> {
+  const iterations = options.iterations ?? PBKDF2_ITERATIONS
+  const hash = options.hash ?? PBKDF2_HASH
+
+  if (!Number.isFinite(iterations) || iterations < 1) {
+    throw new Error('Invalid PBKDF2 iterations')
+  }
+
+  const encoder = new TextEncoder()
+  const passwordKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  )
+
+  const algorithm = mode === 'CBC' ? 'AES-CBC' : mode === 'CTR' ? 'AES-CTR' : 'AES-GCM'
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt.buffer as ArrayBuffer,
+      iterations: Math.floor(iterations),
+      hash,
+    },
+    passwordKey,
+    { name: algorithm, length: keyLength },
+    false,
+    ['encrypt', 'decrypt'],
+  )
+}
+
+/**
+ * Import a raw key from hex string
+ */
+export async function importRawKey(
+  keyHex: string,
+  keyLength: KeyLength,
+  mode: AesMode,
+): Promise<CryptoKey> {
+  const keyBytes = hexToArrayBuffer(keyHex)
+  const expectedLength = keyLength / 8
+
+  if (keyBytes.byteLength !== expectedLength) {
+    throw new Error(
+      `Invalid key length: expected ${expectedLength} bytes, got ${keyBytes.byteLength}`,
+    )
+  }
+
+  const algorithm = mode === 'CBC' ? 'AES-CBC' : mode === 'CTR' ? 'AES-CTR' : 'AES-GCM'
+
+  return crypto.subtle.importKey('raw', keyBytes, { name: algorithm }, false, [
+    'encrypt',
+    'decrypt',
+  ])
+}
+
+/**
+ * Encrypt data using AES
+ */
+export async function encrypt(
+  data: ArrayBuffer | Uint8Array,
+  key: CryptoKey,
+  mode: AesMode,
+  iv: Uint8Array,
+): Promise<ArrayBuffer> {
+  const payload =
+    data instanceof ArrayBuffer
+      ? data
+      : data.buffer instanceof ArrayBuffer
+        ? data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
+        : new Uint8Array(data).buffer
+
+  let algorithm: AesGcmParams | AesCbcParams | AesCtrParams
+
+  switch (mode) {
+    case 'GCM':
+      algorithm = { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer }
+      break
+    case 'CBC':
+      algorithm = { name: 'AES-CBC', iv: iv.buffer as ArrayBuffer }
+      break
+    case 'CTR':
+      algorithm = { name: 'AES-CTR', counter: iv.buffer as ArrayBuffer, length: 64 }
+      break
+  }
+
+  return crypto.subtle.encrypt(algorithm, key, payload)
+}
+
+/**
+ * Decrypt data using AES
+ */
+export async function decrypt(
+  data: ArrayBuffer,
+  key: CryptoKey,
+  mode: AesMode,
+  iv: Uint8Array,
+): Promise<ArrayBuffer> {
+  let algorithm: AesGcmParams | AesCbcParams | AesCtrParams
+
+  switch (mode) {
+    case 'GCM':
+      algorithm = { name: 'AES-GCM', iv: iv.buffer as ArrayBuffer }
+      break
+    case 'CBC':
+      algorithm = { name: 'AES-CBC', iv: iv.buffer as ArrayBuffer }
+      break
+    case 'CTR':
+      algorithm = { name: 'AES-CTR', counter: iv.buffer as ArrayBuffer, length: 64 }
+      break
+  }
+
+  return crypto.subtle.decrypt(algorithm, key, data)
+}
+
+/**
+ * Pack salt, IV, and ciphertext into a single buffer
+ * Format: [salt (16 bytes)][iv (12 or 16 bytes)][ciphertext]
+ */
+export function pack(salt: Uint8Array, iv: Uint8Array, ciphertext: ArrayBuffer): ArrayBuffer {
+  const result = new Uint8Array(salt.length + iv.length + ciphertext.byteLength)
+  result.set(salt, 0)
+  result.set(iv, salt.length)
+  result.set(new Uint8Array(ciphertext), salt.length + iv.length)
+  return result.buffer
+}
+
+/**
+ * Unpack salt, IV, and ciphertext from a packed buffer
+ */
+export function unpack(
+  data: ArrayBuffer,
+  mode: AesMode,
+): { salt: Uint8Array; iv: Uint8Array; ciphertext: ArrayBuffer } {
+  const bytes = new Uint8Array(data)
+  const ivLength = IV_LENGTH[mode]
+
+  if (bytes.length < SALT_LENGTH + ivLength + 1) {
+    throw new Error('Invalid encrypted data: too short')
+  }
+
+  const salt = bytes.slice(0, SALT_LENGTH)
+  const iv = bytes.slice(SALT_LENGTH, SALT_LENGTH + ivLength)
+  const ciphertext = bytes.slice(SALT_LENGTH + ivLength).buffer
+
+  return { salt, iv, ciphertext }
+}
+
+/**
+ * High-level encrypt function with password
+ */
+export async function encryptWithPassword(
+  plaintext: string | ArrayBuffer,
+  password: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+  outputFormat: OutputFormat,
+  options?: EncryptOptions,
+): Promise<RawEncryptResult> {
+  const salt = options?.salt ?? generateRandomBytes(SALT_LENGTH)
+  const iv = options?.iv ?? generateRandomBytes(IV_LENGTH[mode])
+  const key = await deriveKey(password, salt, keyLength, mode, options)
+
+  const data = typeof plaintext === 'string' ? new TextEncoder().encode(plaintext) : plaintext
+
+  const ciphertext = await encrypt(data, key, mode, iv)
+  const packed = pack(salt, iv, ciphertext)
+
+  return {
+    output: outputFormat === 'base64' ? arrayBufferToBase64(packed) : arrayBufferToHex(packed),
+    salt: arrayBufferToHex(salt),
+    iv: arrayBufferToHex(iv),
+    binary: packed,
+  }
+}
+
+/**
+ * High-level decrypt function with password
+ */
+export async function decryptWithPassword(
+  encrypted: string,
+  password: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+  inputFormat: OutputFormat,
+  options?: Pbkdf2Options,
+): Promise<ArrayBuffer> {
+  const data =
+    inputFormat === 'base64' ? base64ToArrayBuffer(encrypted) : hexToArrayBuffer(encrypted)
+
+  const { salt, iv, ciphertext } = unpack(data, mode)
+  const key = await deriveKey(password, salt, keyLength, mode, options)
+
+  return decrypt(ciphertext, key, mode, iv)
+}
+
+/**
+ * High-level encrypt function with raw key
+ */
+export async function encryptWithRawKey(
+  plaintext: string | ArrayBuffer,
+  keyHex: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+  outputFormat: OutputFormat,
+  options?: { iv?: Uint8Array },
+): Promise<RawEncryptResult> {
+  const key = await importRawKey(keyHex, keyLength, mode)
+  const iv = options?.iv ?? generateRandomBytes(IV_LENGTH[mode])
+  // Use empty salt for raw key mode (still pack it for consistent format)
+  const salt = new Uint8Array(SALT_LENGTH)
+
+  const data = typeof plaintext === 'string' ? new TextEncoder().encode(plaintext) : plaintext
+
+  const ciphertext = await encrypt(data, key, mode, iv)
+  const packed = pack(salt, iv, ciphertext)
+
+  return {
+    output: outputFormat === 'base64' ? arrayBufferToBase64(packed) : arrayBufferToHex(packed),
+    salt: arrayBufferToHex(salt),
+    iv: arrayBufferToHex(iv),
+    binary: packed,
+  }
+}
+
+/**
+ * High-level decrypt function with raw key
+ */
+export async function decryptWithRawKey(
+  encrypted: string,
+  keyHex: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+  inputFormat: OutputFormat,
+): Promise<ArrayBuffer> {
+  const data =
+    inputFormat === 'base64' ? base64ToArrayBuffer(encrypted) : hexToArrayBuffer(encrypted)
+
+  const { iv, ciphertext } = unpack(data, mode)
+  const key = await importRawKey(keyHex, keyLength, mode)
+
+  return decrypt(ciphertext, key, mode, iv)
+}
+
+// Utility functions for encoding/decoding
+
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+}
+
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes.buffer
+}
+
+export function arrayBufferToHex(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export function hexToArrayBuffer(hex: string): ArrayBuffer {
+  const cleanHex = hex.replace(/\s/g, '')
+  if (cleanHex.length % 2 !== 0) {
+    throw new Error('Invalid hex string')
+  }
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = parseInt(cleanHex.substring(i, i + 2), 16)
+  }
+  return bytes.buffer
+}
+
+export function isValidHex(hex: string): boolean {
+  const cleanHex = hex.replace(/\s/g, '')
+  return /^[0-9a-fA-F]*$/.test(cleanHex) && cleanHex.length % 2 === 0
+}
+
+export function isValidBase64(base64: string): boolean {
+  try {
+    atob(base64)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function arrayBufferToString(buffer: ArrayBuffer): string {
+  return new TextDecoder().decode(buffer)
+}

--- a/utils/aes/src/index.ts
+++ b/utils/aes/src/index.ts
@@ -1,0 +1,3 @@
+export * from './types'
+export * from './crypto'
+export * from './jwe'

--- a/utils/aes/src/jwe.ts
+++ b/utils/aes/src/jwe.ts
@@ -1,0 +1,213 @@
+import { CompactEncrypt, compactDecrypt, base64url } from 'jose'
+import type { AesMode, KeyLength, Pbkdf2Options } from './types'
+import { PBES2_ALG, JWE_ENC_GCM, JWE_ENC_CBC, PBKDF2_ITERATIONS } from './types'
+
+// Allowed algorithms for decryption
+const ALLOWED_KEY_ALGORITHMS = [
+  'PBES2-HS256+A128KW',
+  'PBES2-HS384+A192KW',
+  'PBES2-HS512+A256KW',
+  'dir',
+]
+const ALLOWED_CONTENT_ALGORITHMS = [
+  'A128GCM',
+  'A192GCM',
+  'A256GCM',
+  'A128CBC-HS256',
+  'A192CBC-HS384',
+  'A256CBC-HS512',
+]
+
+/**
+ * Get JWE encryption algorithm based on AES mode and key length
+ * Note: JWE standard doesn't support CTR mode
+ */
+function getJweEnc(mode: AesMode, keyLength: KeyLength): string {
+  if (mode === 'CTR') {
+    throw new Error('JWE format does not support CTR mode. Please use Raw format instead.')
+  }
+  if (mode === 'GCM') {
+    return JWE_ENC_GCM[keyLength]
+  }
+  return JWE_ENC_CBC[keyLength]
+}
+
+/**
+ * Encrypt data using JWE format with password (PBES2)
+ */
+export async function encryptJweWithPassword(
+  plaintext: string | ArrayBuffer,
+  password: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+  options: Pbkdf2Options = {},
+): Promise<string> {
+  const { iterations = PBKDF2_ITERATIONS } = options
+
+  const data = typeof plaintext === 'string' ? new TextEncoder().encode(plaintext) : plaintext
+
+  const alg = PBES2_ALG[keyLength]
+  const enc = getJweEnc(mode, keyLength)
+
+  const jwe = await new CompactEncrypt(new Uint8Array(data))
+    .setProtectedHeader({
+      alg,
+      enc,
+      p2c: iterations, // PBKDF2 iteration count
+    })
+    .encrypt(new TextEncoder().encode(password))
+
+  return jwe
+}
+
+/**
+ * Encrypt data using JWE format with raw key (direct encryption)
+ */
+export async function encryptJweWithRawKey(
+  plaintext: string | ArrayBuffer,
+  keyHex: string,
+  mode: AesMode,
+  keyLength: KeyLength,
+): Promise<string> {
+  const data = typeof plaintext === 'string' ? new TextEncoder().encode(plaintext) : plaintext
+
+  const enc = getJweEnc(mode, keyLength)
+  const keyBytes = hexToUint8Array(keyHex)
+
+  // Validate key length
+  // For CBC mode with HMAC, we need a longer key (enc key + mac key)
+  // A128CBC-HS256 needs 32 bytes, A192CBC-HS384 needs 48 bytes, A256CBC-HS512 needs 64 bytes
+  // For GCM mode, we need the standard AES key length
+  const expectedLength =
+    mode === 'CBC'
+      ? (keyLength / 8) * 2 // CBC needs double (enc + mac)
+      : keyLength / 8 // GCM uses standard length
+
+  if (keyBytes.length !== expectedLength) {
+    if (mode === 'CBC') {
+      throw new Error(
+        `For CBC mode with raw key, expected ${expectedLength} bytes (enc + mac key), got ${keyBytes.length}`,
+      )
+    }
+    throw new Error(`Invalid key length: expected ${expectedLength} bytes, got ${keyBytes.length}`)
+  }
+
+  const jwe = await new CompactEncrypt(new Uint8Array(data))
+    .setProtectedHeader({
+      alg: 'dir', // Direct encryption
+      enc,
+    })
+    .encrypt(keyBytes)
+
+  return jwe
+}
+
+/**
+ * Decrypt JWE with password
+ */
+export async function decryptJweWithPassword(jwe: string, password: string): Promise<ArrayBuffer> {
+  const { plaintext } = await compactDecrypt(jwe, new TextEncoder().encode(password), {
+    keyManagementAlgorithms: ALLOWED_KEY_ALGORITHMS,
+    contentEncryptionAlgorithms: ALLOWED_CONTENT_ALGORITHMS,
+  })
+  // Copy to a new ArrayBuffer to avoid SharedArrayBuffer issues
+  return new Uint8Array(plaintext).buffer as ArrayBuffer
+}
+
+/**
+ * Decrypt JWE with raw key
+ */
+export async function decryptJweWithRawKey(jwe: string, keyHex: string): Promise<ArrayBuffer> {
+  const keyBytes = hexToUint8Array(keyHex)
+  const { plaintext } = await compactDecrypt(jwe, keyBytes, {
+    keyManagementAlgorithms: ALLOWED_KEY_ALGORITHMS,
+    contentEncryptionAlgorithms: ALLOWED_CONTENT_ALGORITHMS,
+  })
+  // Copy to a new ArrayBuffer to avoid SharedArrayBuffer issues
+  return new Uint8Array(plaintext).buffer as ArrayBuffer
+}
+
+/**
+ * Check if a string is a valid JWE compact serialization
+ */
+export function isJweFormat(input: string): boolean {
+  // JWE compact format has 5 parts separated by dots
+  const parts = input.trim().split('.')
+  if (parts.length !== 5) return false
+
+  // Try to decode and parse the header
+  try {
+    const headerPart = parts[0]
+    if (!headerPart) return false
+    const header = JSON.parse(new TextDecoder().decode(base64url.decode(headerPart)))
+    return typeof header.alg === 'string' && typeof header.enc === 'string'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse JWE header to get algorithm info
+ */
+export function parseJweHeader(jwe: string): {
+  alg: string
+  enc: string
+  p2c?: number // PBKDF2 iteration count
+  p2s?: string // PBKDF2 salt (base64url)
+} | null {
+  try {
+    const parts = jwe.trim().split('.')
+    if (parts.length !== 5) return null
+
+    const headerPart = parts[0]
+    if (!headerPart) return null
+    const header = JSON.parse(new TextDecoder().decode(base64url.decode(headerPart)))
+    return {
+      alg: header.alg,
+      enc: header.enc,
+      p2c: header.p2c,
+      p2s: header.p2s,
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Get mode and key length from JWE enc value
+ */
+export function getConfigFromJweEnc(enc: string): { mode: AesMode; keyLength: KeyLength } | null {
+  const gcmMap: Record<string, KeyLength> = {
+    A128GCM: 128,
+    A192GCM: 192,
+    A256GCM: 256,
+  }
+  const cbcMap: Record<string, KeyLength> = {
+    'A128CBC-HS256': 128,
+    'A192CBC-HS384': 192,
+    'A256CBC-HS512': 256,
+  }
+
+  const gcmKeyLength = gcmMap[enc]
+  if (gcmKeyLength !== undefined) {
+    return { mode: 'GCM', keyLength: gcmKeyLength }
+  }
+  const cbcKeyLength = cbcMap[enc]
+  if (cbcKeyLength !== undefined) {
+    return { mode: 'CBC', keyLength: cbcKeyLength }
+  }
+  return null
+}
+
+// Helper function
+function hexToUint8Array(hex: string): Uint8Array {
+  const cleanHex = hex.replace(/\s/g, '')
+  if (cleanHex.length % 2 !== 0) {
+    throw new Error('Invalid hex string')
+  }
+  const bytes = new Uint8Array(cleanHex.length / 2)
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = parseInt(cleanHex.substring(i, i + 2), 16)
+  }
+  return bytes
+}

--- a/utils/aes/src/types.ts
+++ b/utils/aes/src/types.ts
@@ -1,0 +1,73 @@
+export type AesMode = 'GCM' | 'CBC' | 'CTR'
+export type KeyLength = 128 | 192 | 256
+export type KeyType = 'password' | 'raw'
+export type OutputFormat = 'base64' | 'hex'
+export type OutputMode = 'jwe' | 'raw'
+export type InputFormat = 'base64' | 'hex' | 'binary'
+export type Pbkdf2Hash = 'SHA-1' | 'SHA-256' | 'SHA-384' | 'SHA-512'
+
+export interface Pbkdf2Options {
+  iterations?: number
+  hash?: Pbkdf2Hash
+}
+
+export interface AdvancedOptions {
+  salt?: Uint8Array // Manual salt (hex string will be converted before passing)
+  iv?: Uint8Array // Manual IV (hex string will be converted before passing)
+}
+
+export interface EncryptOptions extends Pbkdf2Options, AdvancedOptions {}
+
+export interface DecryptOptions extends Pbkdf2Options {
+  // For Raw mode: whether to extract salt/iv from data or use manual input
+  saltSource?: 'extract' | 'manual'
+  ivSource?: 'extract' | 'manual'
+  salt?: Uint8Array
+  iv?: Uint8Array
+}
+
+export interface EncryptResult {
+  // Main output (JWE string or encoded raw data)
+  output: string
+  // For display/logging purposes
+  salt: string // hex
+  iv: string // hex
+  // Raw ciphertext without salt/iv prefix (for interoperability)
+  ciphertext?: string // hex or base64
+}
+
+export interface AesConfig {
+  mode: AesMode
+  keyLength: KeyLength
+  keyType: KeyType
+  outputFormat: OutputFormat
+}
+
+export const IV_LENGTH: Record<AesMode, number> = {
+  GCM: 12,
+  CBC: 16,
+  CTR: 16,
+}
+
+export const SALT_LENGTH = 16
+export const PBKDF2_ITERATIONS = 100000
+export const PBKDF2_HASH: Pbkdf2Hash = 'SHA-256'
+
+// JWE algorithm mappings
+export const PBES2_ALG: Record<KeyLength, string> = {
+  128: 'PBES2-HS256+A128KW',
+  192: 'PBES2-HS384+A192KW',
+  256: 'PBES2-HS512+A256KW',
+}
+
+export const JWE_ENC_GCM: Record<KeyLength, string> = {
+  128: 'A128GCM',
+  192: 'A192GCM',
+  256: 'A256GCM',
+}
+
+export const JWE_ENC_CBC: Record<KeyLength, string> = {
+  128: 'A128CBC-HS256',
+  192: 'A192CBC-HS384',
+  256: 'A256CBC-HS512',
+}


### PR DESCRIPTION
## Summary
- Add AES Encryptor tool for encrypting text/files with password or raw key
- Add AES Decryptor tool for decrypting with auto-format detection
- Support GCM, CBC, CTR modes and JWE format with PBES2
- Include security warnings for CTR mode and low PBKDF2 iterations

## Features
- **Encryption modes:** GCM (recommended), CBC, CTR
- **Key derivation:** PBKDF2 with configurable iterations and hash
- **Output formats:** JWE (recommended), Raw (Base64/Hex)
- **Auto-detection:** Automatically detects JWE, Base64, Hex input formats
- **File support:** Encrypt/decrypt files, download as text or binary
- **Security warnings:** Alerts for CTR mode (no authentication) and low iterations

## Test plan
- [x] Type check passes
- [x] Lint check passes
- [x] Build passes
- [x] Unit tests pass (utils/aes/src/crypto.dom.test.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)