### PR TITLE
feat(tools): add Text Statistics tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -705,6 +705,9 @@ importers:
       '@tools/text-diff':
         specifier: workspace:*
         version: link:../../tools/document/text-diff
+      '@tools/text-statistics':
+        specifier: workspace:*
+        version: link:../../tools/text/text-statistics
       '@tools/toml-to-json-converter':
         specifier: workspace:*
         version: link:../../tools/code/toml-to-json-converter
@@ -2824,6 +2827,30 @@ importers:
       '@types/figlet':
         specifier: ^1.7.0
         version: 1.7.0
+
+  tools/text/text-statistics:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
 
   tools/time/cron-expression-parser:
     dependencies:

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -76,6 +76,7 @@
     "@tools/sha512-hash-text-or-file": "workspace:*",
     "@tools/sri-hash-generator": "workspace:*",
     "@tools/text-diff": "workspace:*",
+    "@tools/text-statistics": "workspace:*",
     "@tools/toml-to-json-converter": "workspace:*",
     "@tools/toml-to-yaml-converter": "workspace:*",
     "@tools/unicode-escape-unescape": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -78,6 +78,7 @@ import { toolInfo as asciiArtGeneratorToolInfo } from '@tools/ascii-art-generato
 import { toolInfo as aesEncryptorToolInfo } from '@tools/aes-encryptor'
 import { toolInfo as aesDecryptorToolInfo } from '@tools/aes-decryptor'
 import { toolInfo as portNumberLookupToolInfo } from '@tools/port-number-lookup'
+import { toolInfo as textStatisticsToolInfo } from '@tools/text-statistics'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -185,6 +186,7 @@ export const tools: ToolInfo[] = [
 
   // Text Tools
   asciiArtGeneratorToolInfo,
+  textStatisticsToolInfo,
 
   // Encryption Tools
   aesEncryptorToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -76,6 +76,7 @@ import { routes as asciiArtGeneratorRoutes } from '@tools/ascii-art-generator/ro
 import { routes as aesEncryptorRoutes } from '@tools/aes-encryptor/routes'
 import { routes as aesDecryptorRoutes } from '@tools/aes-decryptor/routes'
 import { routes as portNumberLookupRoutes } from '@tools/port-number-lookup/routes'
+import { routes as textStatisticsRoutes } from '@tools/text-statistics/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -155,4 +156,5 @@ export const routes: ToolRoute[] = [
   ...aesEncryptorRoutes,
   ...aesDecryptorRoutes,
   ...portNumberLookupRoutes,
+  ...textStatisticsRoutes,
 ]

--- a/tools/text/text-statistics/package.json
+++ b/tools/text/text-statistics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/text-statistics",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/text/text-statistics/src/TextStatisticsView.vue
+++ b/tools/text/text-statistics/src/TextStatisticsView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <TextStatisticsContent />
+    <WhatIsTextStatistics />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import TextStatisticsContent from './components/TextStatisticsContent.vue'
+import WhatIsTextStatistics from './components/WhatIsTextStatistics.vue'
+</script>

--- a/tools/text/text-statistics/src/components/StatsDisplay.vue
+++ b/tools/text/text-statistics/src/components/StatsDisplay.vue
@@ -1,0 +1,285 @@
+<template>
+  <n-grid :cols="4" :x-gap="12" :y-gap="12" responsive="screen" :item-responsive="true">
+    <n-gi v-for="stat in displayStats" :key="stat.key" span="0:4 400:2 800:1">
+      <n-card>
+        <n-statistic :label="t(stat.key)" :value="stat.value" />
+      </n-card>
+    </n-gi>
+  </n-grid>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NGrid, NGi, NStatistic, NCard } from 'naive-ui'
+import { formatTime, type TextStats } from '../utils/textStats'
+
+const props = defineProps<{ stats: TextStats }>()
+const { t } = useI18n()
+
+const displayStats = computed(() => [
+  { key: 'characters', value: props.stats.characters },
+  { key: 'charactersNoSpaces', value: props.stats.charactersNoSpaces },
+  { key: 'words', value: props.stats.words },
+  { key: 'lines', value: props.stats.lines },
+  { key: 'paragraphs', value: props.stats.paragraphs },
+  { key: 'sentences', value: props.stats.sentences },
+  { key: 'readingTime', value: formatTime(props.stats.readingTimeMinutes) },
+  { key: 'speakingTime', value: formatTime(props.stats.speakingTimeMinutes) },
+])
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "characters": "Characters",
+    "charactersNoSpaces": "Characters (no spaces)",
+    "words": "Words",
+    "lines": "Lines",
+    "paragraphs": "Paragraphs",
+    "sentences": "Sentences",
+    "readingTime": "Reading Time",
+    "speakingTime": "Speaking Time"
+  },
+  "zh": {
+    "characters": "字符数",
+    "charactersNoSpaces": "字符数（不含空格）",
+    "words": "单词数",
+    "lines": "行数",
+    "paragraphs": "段落数",
+    "sentences": "句子数",
+    "readingTime": "阅读时间",
+    "speakingTime": "朗读时间"
+  },
+  "zh-CN": {
+    "characters": "字符数",
+    "charactersNoSpaces": "字符数（不含空格）",
+    "words": "单词数",
+    "lines": "行数",
+    "paragraphs": "段落数",
+    "sentences": "句子数",
+    "readingTime": "阅读时间",
+    "speakingTime": "朗读时间"
+  },
+  "zh-TW": {
+    "characters": "字元數",
+    "charactersNoSpaces": "字元數（不含空格）",
+    "words": "字數",
+    "lines": "行數",
+    "paragraphs": "段落數",
+    "sentences": "句子數",
+    "readingTime": "閱讀時間",
+    "speakingTime": "朗讀時間"
+  },
+  "zh-HK": {
+    "characters": "字元數",
+    "charactersNoSpaces": "字元數（不含空格）",
+    "words": "字數",
+    "lines": "行數",
+    "paragraphs": "段落數",
+    "sentences": "句子數",
+    "readingTime": "閱讀時間",
+    "speakingTime": "朗讀時間"
+  },
+  "es": {
+    "characters": "Caracteres",
+    "charactersNoSpaces": "Caracteres (sin espacios)",
+    "words": "Palabras",
+    "lines": "Líneas",
+    "paragraphs": "Párrafos",
+    "sentences": "Oraciones",
+    "readingTime": "Tiempo de lectura",
+    "speakingTime": "Tiempo de habla"
+  },
+  "fr": {
+    "characters": "Caractères",
+    "charactersNoSpaces": "Caractères (sans espaces)",
+    "words": "Mots",
+    "lines": "Lignes",
+    "paragraphs": "Paragraphes",
+    "sentences": "Phrases",
+    "readingTime": "Temps de lecture",
+    "speakingTime": "Temps de parole"
+  },
+  "de": {
+    "characters": "Zeichen",
+    "charactersNoSpaces": "Zeichen (ohne Leerzeichen)",
+    "words": "Wörter",
+    "lines": "Zeilen",
+    "paragraphs": "Absätze",
+    "sentences": "Sätze",
+    "readingTime": "Lesezeit",
+    "speakingTime": "Sprechzeit"
+  },
+  "it": {
+    "characters": "Caratteri",
+    "charactersNoSpaces": "Caratteri (senza spazi)",
+    "words": "Parole",
+    "lines": "Righe",
+    "paragraphs": "Paragrafi",
+    "sentences": "Frasi",
+    "readingTime": "Tempo di lettura",
+    "speakingTime": "Tempo di parlato"
+  },
+  "ja": {
+    "characters": "文字数",
+    "charactersNoSpaces": "文字数（空白除く）",
+    "words": "単語数",
+    "lines": "行数",
+    "paragraphs": "段落数",
+    "sentences": "文数",
+    "readingTime": "読書時間",
+    "speakingTime": "発話時間"
+  },
+  "ko": {
+    "characters": "문자 수",
+    "charactersNoSpaces": "문자 수 (공백 제외)",
+    "words": "단어 수",
+    "lines": "줄 수",
+    "paragraphs": "단락 수",
+    "sentences": "문장 수",
+    "readingTime": "읽기 시간",
+    "speakingTime": "말하기 시간"
+  },
+  "ru": {
+    "characters": "Символы",
+    "charactersNoSpaces": "Символы (без пробелов)",
+    "words": "Слова",
+    "lines": "Строки",
+    "paragraphs": "Абзацы",
+    "sentences": "Предложения",
+    "readingTime": "Время чтения",
+    "speakingTime": "Время произнесения"
+  },
+  "pt": {
+    "characters": "Caracteres",
+    "charactersNoSpaces": "Caracteres (sem espaços)",
+    "words": "Palavras",
+    "lines": "Linhas",
+    "paragraphs": "Parágrafos",
+    "sentences": "Frases",
+    "readingTime": "Tempo de leitura",
+    "speakingTime": "Tempo de fala"
+  },
+  "ar": {
+    "characters": "الأحرف",
+    "charactersNoSpaces": "الأحرف (بدون مسافات)",
+    "words": "الكلمات",
+    "lines": "الأسطر",
+    "paragraphs": "الفقرات",
+    "sentences": "الجمل",
+    "readingTime": "وقت القراءة",
+    "speakingTime": "وقت التحدث"
+  },
+  "hi": {
+    "characters": "वर्ण",
+    "charactersNoSpaces": "वर्ण (बिना रिक्त स्थान)",
+    "words": "शब्द",
+    "lines": "पंक्तियाँ",
+    "paragraphs": "पैराग्राफ",
+    "sentences": "वाक्य",
+    "readingTime": "पढ़ने का समय",
+    "speakingTime": "बोलने का समय"
+  },
+  "tr": {
+    "characters": "Karakterler",
+    "charactersNoSpaces": "Karakterler (boşluksuz)",
+    "words": "Kelimeler",
+    "lines": "Satırlar",
+    "paragraphs": "Paragraflar",
+    "sentences": "Cümleler",
+    "readingTime": "Okuma Süresi",
+    "speakingTime": "Konuşma Süresi"
+  },
+  "nl": {
+    "characters": "Tekens",
+    "charactersNoSpaces": "Tekens (zonder spaties)",
+    "words": "Woorden",
+    "lines": "Regels",
+    "paragraphs": "Alinea's",
+    "sentences": "Zinnen",
+    "readingTime": "Leestijd",
+    "speakingTime": "Spreektijd"
+  },
+  "sv": {
+    "characters": "Tecken",
+    "charactersNoSpaces": "Tecken (utan mellanslag)",
+    "words": "Ord",
+    "lines": "Rader",
+    "paragraphs": "Stycken",
+    "sentences": "Meningar",
+    "readingTime": "Lästid",
+    "speakingTime": "Taltid"
+  },
+  "pl": {
+    "characters": "Znaki",
+    "charactersNoSpaces": "Znaki (bez spacji)",
+    "words": "Słowa",
+    "lines": "Wiersze",
+    "paragraphs": "Akapity",
+    "sentences": "Zdania",
+    "readingTime": "Czas czytania",
+    "speakingTime": "Czas mówienia"
+  },
+  "vi": {
+    "characters": "Ký tự",
+    "charactersNoSpaces": "Ký tự (không có khoảng trắng)",
+    "words": "Từ",
+    "lines": "Dòng",
+    "paragraphs": "Đoạn văn",
+    "sentences": "Câu",
+    "readingTime": "Thời gian đọc",
+    "speakingTime": "Thời gian nói"
+  },
+  "th": {
+    "characters": "ตัวอักษร",
+    "charactersNoSpaces": "ตัวอักษร (ไม่รวมช่องว่าง)",
+    "words": "คำ",
+    "lines": "บรรทัด",
+    "paragraphs": "ย่อหน้า",
+    "sentences": "ประโยค",
+    "readingTime": "เวลาอ่าน",
+    "speakingTime": "เวลาพูด"
+  },
+  "id": {
+    "characters": "Karakter",
+    "charactersNoSpaces": "Karakter (tanpa spasi)",
+    "words": "Kata",
+    "lines": "Baris",
+    "paragraphs": "Paragraf",
+    "sentences": "Kalimat",
+    "readingTime": "Waktu Baca",
+    "speakingTime": "Waktu Bicara"
+  },
+  "he": {
+    "characters": "תווים",
+    "charactersNoSpaces": "תווים (ללא רווחים)",
+    "words": "מילים",
+    "lines": "שורות",
+    "paragraphs": "פסקאות",
+    "sentences": "משפטים",
+    "readingTime": "זמן קריאה",
+    "speakingTime": "זמן דיבור"
+  },
+  "ms": {
+    "characters": "Aksara",
+    "charactersNoSpaces": "Aksara (tanpa ruang)",
+    "words": "Perkataan",
+    "lines": "Baris",
+    "paragraphs": "Perenggan",
+    "sentences": "Ayat",
+    "readingTime": "Masa Membaca",
+    "speakingTime": "Masa Bercakap"
+  },
+  "no": {
+    "characters": "Tegn",
+    "charactersNoSpaces": "Tegn (uten mellomrom)",
+    "words": "Ord",
+    "lines": "Linjer",
+    "paragraphs": "Avsnitt",
+    "sentences": "Setninger",
+    "readingTime": "Lesetid",
+    "speakingTime": "Taletid"
+  }
+}
+</i18n>

--- a/tools/text/text-statistics/src/components/TextStatisticsContent.vue
+++ b/tools/text/text-statistics/src/components/TextStatisticsContent.vue
@@ -1,0 +1,58 @@
+<template>
+  <n-grid :cols="1" :x-gap="12" :y-gap="12">
+    <n-gi>
+      <n-input
+        v-model:value="inputText"
+        type="textarea"
+        :placeholder="t('placeholder')"
+        :rows="10"
+      />
+    </n-gi>
+    <n-gi>
+      <StatsDisplay :stats="stats" />
+    </n-gi>
+  </n-grid>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+import { NGrid, NGi, NInput } from 'naive-ui'
+import { calculateTextStats } from '../utils/textStats'
+import StatsDisplay from './StatsDisplay.vue'
+
+const { t } = useI18n()
+const inputText = useStorage('tools:text-statistics:text', '')
+const stats = computed(() => calculateTextStats(inputText.value))
+</script>
+
+<i18n lang="json">
+{
+  "en": { "placeholder": "Enter or paste your text here..." },
+  "zh": { "placeholder": "在此输入或粘贴文本..." },
+  "zh-CN": { "placeholder": "在此输入或粘贴文本..." },
+  "zh-TW": { "placeholder": "在此輸入或貼上文字..." },
+  "zh-HK": { "placeholder": "在此輸入或貼上文字..." },
+  "es": { "placeholder": "Introduce o pega tu texto aquí..." },
+  "fr": { "placeholder": "Entrez ou collez votre texte ici..." },
+  "de": { "placeholder": "Geben Sie hier Ihren Text ein oder fügen Sie ihn ein..." },
+  "it": { "placeholder": "Inserisci o incolla il tuo testo qui..." },
+  "ja": { "placeholder": "ここにテキストを入力または貼り付けてください..." },
+  "ko": { "placeholder": "여기에 텍스트를 입력하거나 붙여넣으세요..." },
+  "ru": { "placeholder": "Введите или вставьте текст здесь..." },
+  "pt": { "placeholder": "Digite ou cole seu texto aqui..." },
+  "ar": { "placeholder": "أدخل أو الصق النص هنا..." },
+  "hi": { "placeholder": "यहाँ टेक्स्ट दर्ज करें या पेस्ट करें..." },
+  "tr": { "placeholder": "Metninizi buraya girin veya yapıştırın..." },
+  "nl": { "placeholder": "Voer hier uw tekst in of plak deze..." },
+  "sv": { "placeholder": "Skriv eller klistra in din text här..." },
+  "pl": { "placeholder": "Wprowadź lub wklej tekst tutaj..." },
+  "vi": { "placeholder": "Nhập hoặc dán văn bản của bạn vào đây..." },
+  "th": { "placeholder": "ป้อนหรือวางข้อความของคุณที่นี่..." },
+  "id": { "placeholder": "Masukkan atau tempel teks Anda di sini..." },
+  "he": { "placeholder": "הזן או הדבק את הטקסט שלך כאן..." },
+  "ms": { "placeholder": "Masukkan atau tampal teks anda di sini..." },
+  "no": { "placeholder": "Skriv inn eller lim inn teksten din her..." }
+}
+</i18n>

--- a/tools/text/text-statistics/src/components/WhatIsTextStatistics.vue
+++ b/tools/text/text-statistics/src/components/WhatIsTextStatistics.vue
@@ -1,0 +1,118 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <p>{{ t('description') }}</p>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is Text Statistics?",
+    "description": "Text statistics tools help you analyze written content by counting characters, words, sentences, and more. These metrics are useful for writers, students, and content creators who need to meet specific length requirements or estimate reading time."
+  },
+  "zh": {
+    "title": "什么是文本统计？",
+    "description": "文本统计工具通过统计字符、单词、句子等来帮助您分析书面内容。这些指标对于需要满足特定长度要求或估计阅读时间的作家、学生和内容创作者非常有用。"
+  },
+  "zh-CN": {
+    "title": "什么是文本统计？",
+    "description": "文本统计工具通过统计字符、单词、句子等来帮助您分析书面内容。这些指标对于需要满足特定长度要求或估计阅读时间的作家、学生和内容创作者非常有用。"
+  },
+  "zh-TW": {
+    "title": "什麼是文字統計？",
+    "description": "文字統計工具通過統計字元、字數、句子等來幫助您分析書面內容。這些指標對於需要滿足特定長度要求或估計閱讀時間的作家、學生和內容創作者非常有用。"
+  },
+  "zh-HK": {
+    "title": "什麼是文字統計？",
+    "description": "文字統計工具通過統計字元、字數、句子等來幫助您分析書面內容。這些指標對於需要滿足特定長度要求或估計閱讀時間的作家、學生和內容創作者非常有用。"
+  },
+  "es": {
+    "title": "¿Qué son las estadísticas de texto?",
+    "description": "Las herramientas de estadísticas de texto le ayudan a analizar contenido escrito contando caracteres, palabras, oraciones y más. Estas métricas son útiles para escritores, estudiantes y creadores de contenido que necesitan cumplir con requisitos de longitud específicos o estimar el tiempo de lectura."
+  },
+  "fr": {
+    "title": "Qu'est-ce que les statistiques de texte ?",
+    "description": "Les outils de statistiques de texte vous aident à analyser le contenu écrit en comptant les caractères, les mots, les phrases et plus encore. Ces métriques sont utiles pour les écrivains, les étudiants et les créateurs de contenu qui doivent respecter des exigences de longueur spécifiques ou estimer le temps de lecture."
+  },
+  "de": {
+    "title": "Was ist Textstatistik?",
+    "description": "Textstatistik-Tools helfen Ihnen, geschriebene Inhalte zu analysieren, indem sie Zeichen, Wörter, Sätze und mehr zählen. Diese Metriken sind nützlich für Autoren, Studenten und Content-Ersteller, die bestimmte Längenanforderungen erfüllen oder die Lesezeit schätzen müssen."
+  },
+  "it": {
+    "title": "Cosa sono le statistiche del testo?",
+    "description": "Gli strumenti di statistiche del testo ti aiutano ad analizzare i contenuti scritti contando caratteri, parole, frasi e altro. Queste metriche sono utili per scrittori, studenti e creatori di contenuti che devono soddisfare requisiti di lunghezza specifici o stimare il tempo di lettura."
+  },
+  "ja": {
+    "title": "テキスト統計とは？",
+    "description": "テキスト統計ツールは、文字、単語、文などをカウントして書かれたコンテンツを分析するのに役立ちます。これらの指標は、特定の長さの要件を満たしたり、読書時間を見積もる必要がある作家、学生、コンテンツクリエイターに役立ちます。"
+  },
+  "ko": {
+    "title": "텍스트 통계란?",
+    "description": "텍스트 통계 도구는 문자, 단어, 문장 등을 세어 작성된 콘텐츠를 분석하는 데 도움이 됩니다. 이러한 지표는 특정 길이 요구 사항을 충족하거나 읽기 시간을 추정해야 하는 작가, 학생 및 콘텐츠 제작자에게 유용합니다."
+  },
+  "ru": {
+    "title": "Что такое статистика текста?",
+    "description": "Инструменты статистики текста помогают анализировать письменный контент, подсчитывая символы, слова, предложения и многое другое. Эти метрики полезны для писателей, студентов и создателей контента, которым необходимо соблюдать определённые требования к объёму или оценить время чтения."
+  },
+  "pt": {
+    "title": "O que é Estatísticas de Texto?",
+    "description": "As ferramentas de estatísticas de texto ajudam você a analisar conteúdo escrito contando caracteres, palavras, frases e muito mais. Essas métricas são úteis para escritores, estudantes e criadores de conteúdo que precisam atender a requisitos de comprimento específicos ou estimar o tempo de leitura."
+  },
+  "ar": {
+    "title": "ما هي إحصائيات النص؟",
+    "description": "تساعدك أدوات إحصائيات النص في تحليل المحتوى المكتوب من خلال حساب الأحرف والكلمات والجمل والمزيد. هذه المقاييس مفيدة للكتاب والطلاب ومنشئي المحتوى الذين يحتاجون إلى تلبية متطلبات طول محددة أو تقدير وقت القراءة."
+  },
+  "hi": {
+    "title": "टेक्स्ट आँकड़े क्या है?",
+    "description": "टेक्स्ट आँकड़े उपकरण वर्णों, शब्दों, वाक्यों और अधिक की गणना करके लिखित सामग्री का विश्लेषण करने में आपकी मदद करते हैं। ये मेट्रिक्स लेखकों, छात्रों और सामग्री निर्माताओं के लिए उपयोगी हैं जिन्हें विशिष्ट लंबाई आवश्यकताओं को पूरा करना है या पढ़ने के समय का अनुमान लगाना है।"
+  },
+  "tr": {
+    "title": "Metin İstatistikleri Nedir?",
+    "description": "Metin istatistikleri araçları, karakter, kelime, cümle ve daha fazlasını sayarak yazılı içeriği analiz etmenize yardımcı olur. Bu metrikler, belirli uzunluk gereksinimlerini karşılaması veya okuma süresini tahmin etmesi gereken yazarlar, öğrenciler ve içerik oluşturucular için faydalıdır."
+  },
+  "nl": {
+    "title": "Wat zijn tekststatistieken?",
+    "description": "Tekststatistiek-tools helpen u geschreven inhoud te analyseren door tekens, woorden, zinnen en meer te tellen. Deze statistieken zijn nuttig voor schrijvers, studenten en contentmakers die aan specifieke lengtevereisten moeten voldoen of de leestijd moeten inschatten."
+  },
+  "sv": {
+    "title": "Vad är textstatistik?",
+    "description": "Textstatistikverktyg hjälper dig att analysera skrivet innehåll genom att räkna tecken, ord, meningar och mer. Dessa mätvärden är användbara för författare, studenter och innehållsskapare som behöver uppfylla specifika längdkrav eller uppskatta lästid."
+  },
+  "pl": {
+    "title": "Czym są statystyki tekstu?",
+    "description": "Narzędzia do statystyk tekstu pomagają analizować treści pisemne poprzez liczenie znaków, słów, zdań i innych. Te metryki są przydatne dla pisarzy, studentów i twórców treści, którzy muszą spełnić określone wymagania dotyczące długości lub oszacować czas czytania."
+  },
+  "vi": {
+    "title": "Thống kê văn bản là gì?",
+    "description": "Công cụ thống kê văn bản giúp bạn phân tích nội dung viết bằng cách đếm ký tự, từ, câu và nhiều hơn nữa. Các chỉ số này hữu ích cho các nhà văn, sinh viên và người sáng tạo nội dung cần đáp ứng các yêu cầu về độ dài cụ thể hoặc ước tính thời gian đọc."
+  },
+  "th": {
+    "title": "สถิติข้อความคืออะไร?",
+    "description": "เครื่องมือสถิติข้อความช่วยให้คุณวิเคราะห์เนื้อหาที่เขียนโดยการนับตัวอักษร คำ ประโยค และอื่นๆ ตัวชี้วัดเหล่านี้มีประโยชน์สำหรับนักเขียน นักเรียน และผู้สร้างเนื้อหาที่ต้องการตอบสนองข้อกำหนดความยาวเฉพาะหรือประมาณเวลาอ่าน"
+  },
+  "id": {
+    "title": "Apa itu Statistik Teks?",
+    "description": "Alat statistik teks membantu Anda menganalisis konten tertulis dengan menghitung karakter, kata, kalimat, dan lainnya. Metrik ini berguna bagi penulis, pelajar, dan pembuat konten yang perlu memenuhi persyaratan panjang tertentu atau memperkirakan waktu baca."
+  },
+  "he": {
+    "title": "מהי סטטיסטיקת טקסט?",
+    "description": "כלי סטטיסטיקת טקסט עוזרים לך לנתח תוכן כתוב על ידי ספירת תווים, מילים, משפטים ועוד. מדדים אלה שימושיים לכותבים, סטודנטים ויוצרי תוכן שצריכים לעמוד בדרישות אורך ספציפיות או להעריך זמן קריאה."
+  },
+  "ms": {
+    "title": "Apakah Statistik Teks?",
+    "description": "Alat statistik teks membantu anda menganalisis kandungan bertulis dengan mengira aksara, perkataan, ayat dan banyak lagi. Metrik ini berguna untuk penulis, pelajar dan pencipta kandungan yang perlu memenuhi keperluan panjang tertentu atau menganggarkan masa membaca."
+  },
+  "no": {
+    "title": "Hva er tekststatistikk?",
+    "description": "Tekststatistikkverktøy hjelper deg med å analysere skrevet innhold ved å telle tegn, ord, setninger og mer. Disse beregningene er nyttige for forfattere, studenter og innholdsskapere som må oppfylle spesifikke lengdekrav eller estimere lesetid."
+  }
+}
+</i18n>

--- a/tools/text/text-statistics/src/index.ts
+++ b/tools/text/text-statistics/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/text/text-statistics/src/info.ts
+++ b/tools/text/text-statistics/src/info.ts
@@ -1,0 +1,127 @@
+export { TextAlignJustify as icon } from '@shared/icons/carbon'
+
+export const toolID = 'text-statistics'
+export const path = '/tools/text-statistics'
+export const tags = ['text', 'statistics', 'word', 'count', 'character', 'line', 'paragraph']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Text Statistics',
+    description:
+      'Analyze text to get character, word, line, paragraph, and sentence counts with reading time estimates',
+  },
+  zh: {
+    name: '文本统计',
+    description: '分析文本，获取字符、单词、行数、段落和句子统计，以及预计阅读时间',
+  },
+  'zh-CN': {
+    name: '文本统计',
+    description: '分析文本，获取字符、单词、行数、段落和句子统计，以及预计阅读时间',
+  },
+  'zh-TW': {
+    name: '文字統計',
+    description: '分析文字，取得字元、字數、行數、段落和句子統計，以及預估閱讀時間',
+  },
+  'zh-HK': {
+    name: '文字統計',
+    description: '分析文字，取得字元、字數、行數、段落和句子統計，以及預估閱讀時間',
+  },
+  es: {
+    name: 'Estadísticas de Texto',
+    description:
+      'Analiza texto para obtener recuentos de caracteres, palabras, líneas, párrafos y oraciones con estimaciones de tiempo de lectura',
+  },
+  fr: {
+    name: 'Statistiques de Texte',
+    description:
+      'Analysez le texte pour obtenir le nombre de caractères, mots, lignes, paragraphes et phrases avec des estimations de temps de lecture',
+  },
+  de: {
+    name: 'Textstatistik',
+    description:
+      'Analysieren Sie Text, um Zeichen-, Wort-, Zeilen-, Absatz- und Satzzählungen mit Lesezeitschätzungen zu erhalten',
+  },
+  it: {
+    name: 'Statistiche del Testo',
+    description:
+      'Analizza il testo per ottenere conteggi di caratteri, parole, righe, paragrafi e frasi con stime del tempo di lettura',
+  },
+  ja: {
+    name: 'テキスト統計',
+    description: 'テキストを分析して、文字数、単語数、行数、段落数、文数と読書時間の見積もりを取得',
+  },
+  ko: {
+    name: '텍스트 통계',
+    description: '텍스트를 분석하여 문자, 단어, 줄, 단락, 문장 수와 예상 읽기 시간을 확인',
+  },
+  ru: {
+    name: 'Статистика Текста',
+    description:
+      'Анализ текста для подсчёта символов, слов, строк, абзацев и предложений с оценкой времени чтения',
+  },
+  pt: {
+    name: 'Estatísticas de Texto',
+    description:
+      'Analise o texto para obter contagens de caracteres, palavras, linhas, parágrafos e frases com estimativas de tempo de leitura',
+  },
+  ar: {
+    name: 'إحصائيات النص',
+    description:
+      'تحليل النص للحصول على عدد الأحرف والكلمات والأسطر والفقرات والجمل مع تقدير وقت القراءة',
+  },
+  hi: {
+    name: 'टेक्स्ट आँकड़े',
+    description:
+      'पढ़ने के समय के अनुमान के साथ वर्ण, शब्द, पंक्ति, पैराग्राफ और वाक्य गणना प्राप्त करने के लिए टेक्स्ट का विश्लेषण करें',
+  },
+  tr: {
+    name: 'Metin İstatistikleri',
+    description:
+      'Okuma süresi tahminleriyle birlikte karakter, kelime, satır, paragraf ve cümle sayılarını almak için metni analiz edin',
+  },
+  nl: {
+    name: 'Tekststatistieken',
+    description:
+      'Analyseer tekst om aantallen tekens, woorden, regels, alineas en zinnen te krijgen met leestijdschattingen',
+  },
+  sv: {
+    name: 'Textstatistik',
+    description:
+      'Analysera text för att få antal tecken, ord, rader, stycken och meningar med uppskattad lästid',
+  },
+  pl: {
+    name: 'Statystyki Tekstu',
+    description:
+      'Analizuj tekst, aby uzyskać liczbę znaków, słów, wierszy, akapitów i zdań z szacowanym czasem czytania',
+  },
+  vi: {
+    name: 'Thống Kê Văn Bản',
+    description:
+      'Phân tích văn bản để đếm ký tự, từ, dòng, đoạn văn và câu cùng với ước tính thời gian đọc',
+  },
+  th: {
+    name: 'สถิติข้อความ',
+    description:
+      'วิเคราะห์ข้อความเพื่อรับจำนวนตัวอักษร คำ บรรทัด ย่อหน้า และประโยค พร้อมประมาณเวลาอ่าน',
+  },
+  id: {
+    name: 'Statistik Teks',
+    description:
+      'Analisis teks untuk mendapatkan jumlah karakter, kata, baris, paragraf, dan kalimat dengan perkiraan waktu baca',
+  },
+  he: {
+    name: 'סטטיסטיקת טקסט',
+    description: 'נתח טקסט כדי לקבל ספירת תווים, מילים, שורות, פסקאות ומשפטים עם הערכות זמן קריאה',
+  },
+  ms: {
+    name: 'Statistik Teks',
+    description:
+      'Analisis teks untuk mendapatkan kiraan aksara, perkataan, baris, perenggan dan ayat dengan anggaran masa membaca',
+  },
+  no: {
+    name: 'Tekststatistikk',
+    description:
+      'Analyser tekst for å få antall tegn, ord, linjer, avsnitt og setninger med estimert lesetid',
+  },
+}

--- a/tools/text/text-statistics/src/routes.ts
+++ b/tools/text/text-statistics/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'text-statistics',
+    path: '/tools/text-statistics',
+    component: () => import('./TextStatisticsView.vue'),
+  },
+] as const

--- a/tools/text/text-statistics/src/utils/textStats.dom.test.ts
+++ b/tools/text/text-statistics/src/utils/textStats.dom.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import { calculateTextStats, formatTime } from './textStats'
+
+describe('calculateTextStats', () => {
+  it('handles empty string', () => {
+    const stats = calculateTextStats('')
+    expect(stats.characters).toBe(0)
+    expect(stats.charactersNoSpaces).toBe(0)
+    expect(stats.words).toBe(0)
+    expect(stats.lines).toBe(0)
+    expect(stats.paragraphs).toBe(0)
+    expect(stats.sentences).toBe(0)
+  })
+
+  it('counts characters correctly', () => {
+    const stats = calculateTextStats('Hello World')
+    expect(stats.characters).toBe(11)
+    expect(stats.charactersNoSpaces).toBe(10)
+  })
+
+  it('counts words correctly', () => {
+    const stats = calculateTextStats('Hello World')
+    expect(stats.words).toBe(2)
+  })
+
+  it('counts words with multiple spaces correctly', () => {
+    const stats = calculateTextStats('Hello   World')
+    expect(stats.words).toBe(2)
+  })
+
+  it('counts lines correctly', () => {
+    const stats = calculateTextStats('Line 1\nLine 2\nLine 3')
+    expect(stats.lines).toBe(3)
+  })
+
+  it('counts single line correctly', () => {
+    const stats = calculateTextStats('Single line')
+    expect(stats.lines).toBe(1)
+  })
+
+  it('counts paragraphs correctly', () => {
+    const stats = calculateTextStats('Para 1\n\nPara 2\n\nPara 3')
+    expect(stats.paragraphs).toBe(3)
+  })
+
+  it('counts single paragraph correctly', () => {
+    const stats = calculateTextStats('Single paragraph with multiple lines\nstill same paragraph')
+    expect(stats.paragraphs).toBe(1)
+  })
+
+  it('counts sentences correctly', () => {
+    const stats = calculateTextStats('Hello. How are you? I am fine!')
+    expect(stats.sentences).toBe(3)
+  })
+
+  it('counts single sentence without punctuation', () => {
+    const stats = calculateTextStats('Hello World')
+    expect(stats.sentences).toBe(1)
+  })
+
+  it('calculates reading time correctly', () => {
+    // 200 words at 200 WPM = 1 minute
+    const words = Array(200).fill('word').join(' ')
+    const stats = calculateTextStats(words)
+    expect(stats.readingTimeMinutes).toBe(1)
+  })
+
+  it('calculates speaking time correctly', () => {
+    // 150 words at 150 WPM = 1 minute
+    const words = Array(150).fill('word').join(' ')
+    const stats = calculateTextStats(words)
+    expect(stats.speakingTimeMinutes).toBe(1)
+  })
+
+  it('handles Windows line endings', () => {
+    const stats = calculateTextStats('Line 1\r\nLine 2\r\nLine 3')
+    expect(stats.lines).toBe(3)
+  })
+
+  it('handles old Mac line endings', () => {
+    const stats = calculateTextStats('Line 1\rLine 2\rLine 3')
+    expect(stats.lines).toBe(3)
+  })
+})
+
+describe('formatTime', () => {
+  it('formats zero correctly', () => {
+    expect(formatTime(0)).toBe('0s')
+  })
+
+  it('formats seconds correctly', () => {
+    expect(formatTime(0.5)).toBe('30s')
+  })
+
+  it('formats one minute correctly', () => {
+    expect(formatTime(1)).toBe('1m')
+  })
+
+  it('formats minutes correctly', () => {
+    expect(formatTime(2)).toBe('2m')
+  })
+
+  it('formats minutes and seconds correctly', () => {
+    expect(formatTime(2.5)).toBe('2m 30s')
+  })
+
+  it('formats large time correctly', () => {
+    expect(formatTime(65)).toBe('65m')
+  })
+})

--- a/tools/text/text-statistics/src/utils/textStats.ts
+++ b/tools/text/text-statistics/src/utils/textStats.ts
@@ -1,0 +1,49 @@
+export interface TextStats {
+  characters: number
+  charactersNoSpaces: number
+  words: number
+  lines: number
+  paragraphs: number
+  sentences: number
+  readingTimeMinutes: number
+  speakingTimeMinutes: number
+}
+
+const READING_WPM = 200
+const SPEAKING_WPM = 150
+
+export function calculateTextStats(text: string): TextStats {
+  const characters = text.length
+  const charactersNoSpaces = text.replace(/\s/g, '').length
+
+  const trimmedText = text.trim()
+  const words = trimmedText ? trimmedText.split(/\s+/).length : 0
+
+  const lines = text ? text.split(/\r\n|\r|\n/).length : 0
+
+  const paragraphs = trimmedText ? trimmedText.split(/\n\s*\n/).filter((p) => p.trim()).length : 0
+
+  const sentenceMatches = text.match(/[.!?]+/g)
+  const sentences = sentenceMatches ? sentenceMatches.length : trimmedText ? 1 : 0
+
+  return {
+    characters,
+    charactersNoSpaces,
+    words,
+    lines,
+    paragraphs,
+    sentences,
+    readingTimeMinutes: words / READING_WPM,
+    speakingTimeMinutes: words / SPEAKING_WPM,
+  }
+}
+
+export function formatTime(minutes: number): string {
+  if (minutes < 1) {
+    const seconds = Math.round(minutes * 60)
+    return `${seconds}s`
+  }
+  const mins = Math.floor(minutes)
+  const secs = Math.round((minutes - mins) * 60)
+  return secs > 0 ? `${mins}m ${secs}s` : `${mins}m`
+}


### PR DESCRIPTION
## Summary
- Add new Text Statistics tool for analyzing text content
- Count characters (with/without spaces), words, lines, paragraphs, and sentences
- Estimate reading time (200 WPM) and speaking time (150 WPM)
- Full i18n support for all 25 languages
- Input persistence with `useStorage`
- Offline capable

## Test plan
- [x] Unit tests pass (20 new tests in `textStats.dom.test.ts`)
- [x] Type check passes
- [x] Lint passes
- [x] Build succeeds
- [ ] Manual testing: verify statistics update in real-time as text is entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)