### PR TITLE
fix(favicon): use svgo/browser to fix Vite build warnings

### DIFF
--- a/tools/favicon/favicon-assets-generator/src/utils/favicon-generator/desktop-browser/generate-favicon-svg.ts
+++ b/tools/favicon/favicon-assets-generator/src/utils/favicon-generator/desktop-browser/generate-favicon-svg.ts
@@ -6,7 +6,7 @@ export async function generateFaviconSVG(
 ): Promise<Blob> {
   // TODO: svgo will break css media queries
   // https://github.com/svg/svgo/issues/1834
-  const svgo = import('svgo')
+  const svgo = import('svgo/browser')
 
   const image = options?.image ?? blob
   if (image === undefined) {


### PR DESCRIPTION
Switches from svgo (Node.js build) to svgo/browser (browser build) to prevent Vite from externalizing Node.js modules (os, fs/promises, path, url) for browser compatibility.