### PR TITLE
feat(tools): add Cron Expression Generator tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -567,6 +567,9 @@ importers:
       '@tools/crc-checksum-calculator':
         specifier: workspace:*
         version: link:../../tools/hash/crc-checksum-calculator
+      '@tools/cron-expression-generator':
+        specifier: workspace:*
+        version: link:../../tools/time/cron-expression-generator
       '@tools/cron-expression-parser':
         specifier: workspace:*
         version: link:../../tools/time/cron-expression-parser
@@ -2939,6 +2942,36 @@ importers:
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
+
+  tools/time/cron-expression-generator:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      cron-parser:
+        specifier: 'catalog:'
+        version: 5.4.0
+      cronstrue:
+        specifier: 'catalog:'
+        version: 3.9.0
       naive-ui:
         specifier: 'catalog:'
         version: 2.43.2(vue@3.5.26(typescript@5.9.3))

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -28,6 +28,7 @@
     "@tools/cidrs-merger-excluder": "workspace:*",
     "@tools/color-converter": "workspace:*",
     "@tools/crc-checksum-calculator": "workspace:*",
+    "@tools/cron-expression-generator": "workspace:*",
     "@tools/cron-expression-parser": "workspace:*",
     "@tools/csv-to-json-converter": "workspace:*",
     "@tools/current-network-time": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -65,6 +65,7 @@ import { toolInfo as deviceInformationToolInfo } from '@tools/device-information
 import { toolInfo as romanNumeralConverterToolInfo } from '@tools/roman-numeral-converter'
 import { toolInfo as unixTimestampConverterToolInfo } from '@tools/unix-timestamp-converter'
 import { toolInfo as cronExpressionParserToolInfo } from '@tools/cron-expression-parser'
+import { toolInfo as cronExpressionGeneratorToolInfo } from '@tools/cron-expression-generator'
 import { toolInfo as textDiffToolInfo } from '@tools/text-diff'
 import { toolInfo as colorConverterToolInfo } from '@tools/color-converter'
 import { toolInfo as caseConverterToolInfo } from '@tools/case-converter'
@@ -167,6 +168,7 @@ export const tools: ToolInfo[] = [
   // Time Tools
   unixTimestampConverterToolInfo,
   cronExpressionParserToolInfo,
+  cronExpressionGeneratorToolInfo,
 
   // Document Tools
   textDiffToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -63,6 +63,7 @@ import { routes as deviceInformationRoutes } from '@tools/device-information/rou
 import { routes as romanNumeralConverterRoutes } from '@tools/roman-numeral-converter/routes'
 import { routes as unixTimestampConverterRoutes } from '@tools/unix-timestamp-converter/routes'
 import { routes as cronExpressionParserRoutes } from '@tools/cron-expression-parser/routes'
+import { routes as cronExpressionGeneratorRoutes } from '@tools/cron-expression-generator/routes'
 import { routes as textDiffRoutes } from '@tools/text-diff/routes'
 import { routes as colorConverterRoutes } from '@tools/color-converter/routes'
 import { routes as caseConverterRoutes } from '@tools/case-converter/routes'
@@ -146,6 +147,7 @@ export const routes: ToolRoute[] = [
   ...romanNumeralConverterRoutes,
   ...unixTimestampConverterRoutes,
   ...cronExpressionParserRoutes,
+  ...cronExpressionGeneratorRoutes,
   ...textDiffRoutes,
   ...colorConverterRoutes,
   ...caseConverterRoutes,

--- a/tools/time/cron-expression-generator/package.json
+++ b/tools/time/cron-expression-generator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/cron-expression-generator",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "cron-parser": "catalog:",
+    "cronstrue": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/time/cron-expression-generator/src/CronExpressionGeneratorView.vue
+++ b/tools/time/cron-expression-generator/src/CronExpressionGeneratorView.vue
@@ -1,0 +1,213 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <!-- Output area -->
+    <CronOutput :expression="expression" :human-description="humanDescription" />
+
+    <!-- Quick presets -->
+    <CronPresets @select="applyPreset" />
+
+    <!-- Field configuration -->
+    <ToolSectionHeader>{{ t('configureFields') }}</ToolSectionHeader>
+    <ToolSection>
+      <n-flex vertical :size="16">
+        <CronFieldBuilder v-model="minute" field-name="minute" />
+        <CronFieldBuilder v-model="hour" field-name="hour" />
+        <CronFieldBuilder v-model="dayOfMonth" field-name="dayOfMonth" />
+        <CronFieldBuilder v-model="month" field-name="month" />
+        <CronFieldBuilder v-model="dayOfWeek" field-name="dayOfWeek" />
+      </n-flex>
+    </ToolSection>
+
+    <!-- Next run times -->
+    <NextRunTimes :run-times="nextRunTimes" />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { NFlex } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { CronExpressionParser } from 'cron-parser'
+import cronstrue from 'cronstrue'
+import { ToolDefaultPageLayout, ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import * as toolInfo from './info'
+import CronOutput from './components/CronOutput.vue'
+import CronPresets from './components/CronPresets.vue'
+import CronFieldBuilder from './components/CronFieldBuilder.vue'
+import NextRunTimes from './components/NextRunTimes.vue'
+
+const { t, locale } = useI18n()
+
+// Field values with persistence
+const minute = useStorage('tools:cron-expression-generator:minute', '*')
+const hour = useStorage('tools:cron-expression-generator:hour', '*')
+const dayOfMonth = useStorage('tools:cron-expression-generator:dayOfMonth', '*')
+const month = useStorage('tools:cron-expression-generator:month', '*')
+const dayOfWeek = useStorage('tools:cron-expression-generator:dayOfWeek', '*')
+
+// Generated expression
+const expression = computed(() => {
+  return `${minute.value} ${hour.value} ${dayOfMonth.value} ${month.value} ${dayOfWeek.value}`
+})
+
+// Validation
+const isValid = computed(() => {
+  try {
+    CronExpressionParser.parse(expression.value)
+    return true
+  } catch {
+    return false
+  }
+})
+
+// Human-readable description
+const humanDescription = computed(() => {
+  if (!isValid.value) return ''
+  try {
+    const cronstrueLocale = mapToCronstrueLocale(locale.value)
+    return cronstrue.toString(expression.value, { locale: cronstrueLocale })
+  } catch {
+    return ''
+  }
+})
+
+// Next run times
+const nextRunTimes = computed(() => {
+  if (!isValid.value) return []
+  try {
+    const interval = CronExpressionParser.parse(expression.value)
+    const dates: Date[] = []
+    for (let i = 0; i < 5; i++) {
+      dates.push(interval.next().toDate())
+    }
+    return dates
+  } catch {
+    return []
+  }
+})
+
+// Apply preset
+function applyPreset(presetValue: string) {
+  const parts = presetValue.split(' ')
+  if (parts.length === 5) {
+    minute.value = parts[0]!
+    hour.value = parts[1]!
+    dayOfMonth.value = parts[2]!
+    month.value = parts[3]!
+    dayOfWeek.value = parts[4]!
+  }
+}
+
+// Map locale to cronstrue locale
+function mapToCronstrueLocale(appLocale: string): string {
+  const localeMap: Record<string, string> = {
+    en: 'en',
+    zh: 'zh_CN',
+    'zh-CN': 'zh_CN',
+    'zh-TW': 'zh_TW',
+    'zh-HK': 'zh_TW',
+    es: 'es',
+    fr: 'fr',
+    de: 'de',
+    it: 'it',
+    ja: 'ja',
+    ko: 'ko',
+    ru: 'ru',
+    pt: 'pt_BR',
+    ar: 'ar',
+    hi: 'en',
+    tr: 'tr',
+    nl: 'nl',
+    sv: 'sv',
+    pl: 'pl',
+    vi: 'vi',
+    th: 'th',
+    id: 'id',
+    he: 'he',
+    ms: 'en',
+    no: 'nb',
+  }
+  return localeMap[appLocale] || 'en'
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "configureFields": "Configure Fields"
+  },
+  "zh": {
+    "configureFields": "配置字段"
+  },
+  "zh-CN": {
+    "configureFields": "配置字段"
+  },
+  "zh-TW": {
+    "configureFields": "設定欄位"
+  },
+  "zh-HK": {
+    "configureFields": "設定欄位"
+  },
+  "es": {
+    "configureFields": "Configurar Campos"
+  },
+  "fr": {
+    "configureFields": "Configurer les Champs"
+  },
+  "de": {
+    "configureFields": "Felder Konfigurieren"
+  },
+  "it": {
+    "configureFields": "Configura Campi"
+  },
+  "ja": {
+    "configureFields": "フィールドを設定"
+  },
+  "ko": {
+    "configureFields": "필드 구성"
+  },
+  "ru": {
+    "configureFields": "Настроить Поля"
+  },
+  "pt": {
+    "configureFields": "Configurar Campos"
+  },
+  "ar": {
+    "configureFields": "تكوين الحقول"
+  },
+  "hi": {
+    "configureFields": "फ़ील्ड कॉन्फ़िगर करें"
+  },
+  "tr": {
+    "configureFields": "Alanları Yapılandır"
+  },
+  "nl": {
+    "configureFields": "Velden Configureren"
+  },
+  "sv": {
+    "configureFields": "Konfigurera Fält"
+  },
+  "pl": {
+    "configureFields": "Konfiguruj Pola"
+  },
+  "vi": {
+    "configureFields": "Cấu Hình Trường"
+  },
+  "th": {
+    "configureFields": "กำหนดค่าฟิลด์"
+  },
+  "id": {
+    "configureFields": "Konfigurasi Bidang"
+  },
+  "he": {
+    "configureFields": "הגדר שדות"
+  },
+  "ms": {
+    "configureFields": "Konfigurasikan Medan"
+  },
+  "no": {
+    "configureFields": "Konfigurer Felt"
+  }
+}
+</i18n>

--- a/tools/time/cron-expression-generator/src/components/CronFieldBuilder.vue
+++ b/tools/time/cron-expression-generator/src/components/CronFieldBuilder.vue
@@ -1,0 +1,1163 @@
+<template>
+  <n-card size="small">
+    <template #header>
+      <n-text strong>{{ t(fieldName) }}</n-text>
+    </template>
+
+    <n-flex vertical :size="12">
+      <!-- Mode selection -->
+      <n-radio-group v-model:value="mode" size="small">
+        <n-flex :size="16" wrap>
+          <n-radio value="every">{{ t('every') }}</n-radio>
+          <n-radio value="interval">{{ t('interval') }}</n-radio>
+          <n-radio value="specific">{{ t('specific') }}</n-radio>
+          <n-radio value="range">{{ t('range') }}</n-radio>
+        </n-flex>
+      </n-radio-group>
+
+      <!-- Mode-specific controls -->
+      <template v-if="mode === 'every'">
+        <n-text depth="3">{{
+          t('everyDescription', { field: t(fieldName).toLowerCase() })
+        }}</n-text>
+      </template>
+
+      <template v-else-if="mode === 'interval'">
+        <n-flex align="center" :size="8">
+          <n-text>{{ t('every') }}</n-text>
+          <n-input-number
+            v-model:value="intervalValue"
+            :min="1"
+            :max="fieldConfig.max - fieldConfig.min + 1"
+            size="small"
+            style="width: 80px"
+          />
+          <n-text>{{ t(fieldConfig.unit) }}</n-text>
+        </n-flex>
+      </template>
+
+      <template v-else-if="mode === 'specific'">
+        <n-checkbox-group v-model:value="specificValues">
+          <n-grid :cols="fieldConfig.gridCols" :x-gap="4" :y-gap="4">
+            <n-gi v-for="opt in valueOptions" :key="opt.value">
+              <n-checkbox :value="opt.value" size="small">
+                {{ opt.label }}
+              </n-checkbox>
+            </n-gi>
+          </n-grid>
+        </n-checkbox-group>
+      </template>
+
+      <template v-else-if="mode === 'range'">
+        <n-flex align="center" :size="8">
+          <n-text>{{ t('from') }}</n-text>
+          <n-select
+            v-model:value="rangeStart"
+            :options="valueOptions"
+            size="small"
+            style="width: 100px"
+          />
+          <n-text>{{ t('to') }}</n-text>
+          <n-select
+            v-model:value="rangeEnd"
+            :options="valueOptions"
+            size="small"
+            style="width: 100px"
+          />
+        </n-flex>
+      </template>
+    </n-flex>
+  </n-card>
+</template>
+
+<script setup lang="ts">
+import { computed, watch, ref } from 'vue'
+import {
+  NCard,
+  NFlex,
+  NText,
+  NRadioGroup,
+  NRadio,
+  NInputNumber,
+  NCheckboxGroup,
+  NCheckbox,
+  NGrid,
+  NGi,
+  NSelect,
+} from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+
+type FieldName = 'minute' | 'hour' | 'dayOfMonth' | 'month' | 'dayOfWeek'
+type Mode = 'every' | 'interval' | 'specific' | 'range'
+
+interface FieldConfig {
+  min: number
+  max: number
+  unit: string
+  gridCols: number
+  labels?: string[]
+}
+
+const props = defineProps<{
+  fieldName: FieldName
+  modelValue: string
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const { t } = useI18n()
+
+const FIELD_CONFIGS: Record<FieldName, FieldConfig> = {
+  minute: { min: 0, max: 59, unit: 'minutes', gridCols: 10 },
+  hour: { min: 0, max: 23, unit: 'hours', gridCols: 8 },
+  dayOfMonth: { min: 1, max: 31, unit: 'days', gridCols: 8 },
+  month: {
+    min: 1,
+    max: 12,
+    unit: 'months',
+    gridCols: 6,
+    labels: ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep', 'oct', 'nov', 'dec'],
+  },
+  dayOfWeek: {
+    min: 0,
+    max: 6,
+    unit: 'daysOfWeek',
+    gridCols: 7,
+    labels: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+  },
+}
+
+const fieldConfig = computed(() => FIELD_CONFIGS[props.fieldName])
+
+const valueOptions = computed(() => {
+  const config = fieldConfig.value
+  const options = []
+  for (let i = config.min; i <= config.max; i++) {
+    const label = config.labels ? t(config.labels[i - config.min]!) : String(i)
+    options.push({ value: i, label })
+  }
+  return options
+})
+
+// Internal state
+const mode = ref<Mode>('every')
+const intervalValue = ref(5)
+const specificValues = ref<number[]>([])
+const rangeStart = ref(fieldConfig.value.min)
+const rangeEnd = ref(fieldConfig.value.max)
+
+// Parse initial value
+function parseValue(value: string) {
+  if (value === '*') {
+    mode.value = 'every'
+  } else if (value.startsWith('*/')) {
+    mode.value = 'interval'
+    intervalValue.value = parseInt(value.slice(2)) || 5
+  } else if (value.includes('-')) {
+    mode.value = 'range'
+    const [start, end] = value.split('-').map(Number)
+    rangeStart.value = start ?? fieldConfig.value.min
+    rangeEnd.value = end ?? fieldConfig.value.max
+  } else if (value.includes(',') || /^\d+$/.test(value)) {
+    mode.value = 'specific'
+    specificValues.value = value
+      .split(',')
+      .map(Number)
+      .filter((n) => !isNaN(n))
+  }
+}
+
+// Generate cron field value
+const generatedValue = computed(() => {
+  switch (mode.value) {
+    case 'every':
+      return '*'
+    case 'interval':
+      return `*/${intervalValue.value}`
+    case 'specific':
+      if (specificValues.value.length === 0) {
+        return '*'
+      }
+      return [...specificValues.value].sort((a, b) => a - b).join(',')
+    case 'range':
+      return `${rangeStart.value}-${rangeEnd.value}`
+    default:
+      return '*'
+  }
+})
+
+// Initialize from prop
+parseValue(props.modelValue)
+
+// Watch for external changes
+watch(
+  () => props.modelValue,
+  (newValue) => {
+    if (newValue !== generatedValue.value) {
+      parseValue(newValue)
+    }
+  },
+)
+
+// Emit changes
+watch(generatedValue, (newValue) => {
+  emit('update:modelValue', newValue)
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "minute": "Minute",
+    "hour": "Hour",
+    "dayOfMonth": "Day of Month",
+    "month": "Month",
+    "dayOfWeek": "Day of Week",
+    "every": "Every",
+    "interval": "Interval",
+    "specific": "Specific",
+    "range": "Range",
+    "everyDescription": "Runs on every {field}",
+    "from": "From",
+    "to": "to",
+    "minutes": "minute(s)",
+    "hours": "hour(s)",
+    "days": "day(s)",
+    "months": "month(s)",
+    "daysOfWeek": "day(s)",
+    "sun": "Sun",
+    "mon": "Mon",
+    "tue": "Tue",
+    "wed": "Wed",
+    "thu": "Thu",
+    "fri": "Fri",
+    "sat": "Sat",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "May",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Aug",
+    "sep": "Sep",
+    "oct": "Oct",
+    "nov": "Nov",
+    "dec": "Dec"
+  },
+  "zh": {
+    "minute": "分钟",
+    "hour": "小时",
+    "dayOfMonth": "日期",
+    "month": "月份",
+    "dayOfWeek": "星期",
+    "every": "每个",
+    "interval": "间隔",
+    "specific": "指定",
+    "range": "范围",
+    "everyDescription": "每个{field}都运行",
+    "from": "从",
+    "to": "到",
+    "minutes": "分钟",
+    "hours": "小时",
+    "days": "天",
+    "months": "个月",
+    "daysOfWeek": "天",
+    "sun": "周日",
+    "mon": "周一",
+    "tue": "周二",
+    "wed": "周三",
+    "thu": "周四",
+    "fri": "周五",
+    "sat": "周六",
+    "jan": "1月",
+    "feb": "2月",
+    "mar": "3月",
+    "apr": "4月",
+    "may": "5月",
+    "jun": "6月",
+    "jul": "7月",
+    "aug": "8月",
+    "sep": "9月",
+    "oct": "10月",
+    "nov": "11月",
+    "dec": "12月"
+  },
+  "zh-CN": {
+    "minute": "分钟",
+    "hour": "小时",
+    "dayOfMonth": "日期",
+    "month": "月份",
+    "dayOfWeek": "星期",
+    "every": "每个",
+    "interval": "间隔",
+    "specific": "指定",
+    "range": "范围",
+    "everyDescription": "每个{field}都运行",
+    "from": "从",
+    "to": "到",
+    "minutes": "分钟",
+    "hours": "小时",
+    "days": "天",
+    "months": "个月",
+    "daysOfWeek": "天",
+    "sun": "周日",
+    "mon": "周一",
+    "tue": "周二",
+    "wed": "周三",
+    "thu": "周四",
+    "fri": "周五",
+    "sat": "周六",
+    "jan": "1月",
+    "feb": "2月",
+    "mar": "3月",
+    "apr": "4月",
+    "may": "5月",
+    "jun": "6月",
+    "jul": "7月",
+    "aug": "8月",
+    "sep": "9月",
+    "oct": "10月",
+    "nov": "11月",
+    "dec": "12月"
+  },
+  "zh-TW": {
+    "minute": "分鐘",
+    "hour": "小時",
+    "dayOfMonth": "日期",
+    "month": "月份",
+    "dayOfWeek": "星期",
+    "every": "每個",
+    "interval": "間隔",
+    "specific": "指定",
+    "range": "範圍",
+    "everyDescription": "每個{field}都執行",
+    "from": "從",
+    "to": "到",
+    "minutes": "分鐘",
+    "hours": "小時",
+    "days": "天",
+    "months": "個月",
+    "daysOfWeek": "天",
+    "sun": "週日",
+    "mon": "週一",
+    "tue": "週二",
+    "wed": "週三",
+    "thu": "週四",
+    "fri": "週五",
+    "sat": "週六",
+    "jan": "1月",
+    "feb": "2月",
+    "mar": "3月",
+    "apr": "4月",
+    "may": "5月",
+    "jun": "6月",
+    "jul": "7月",
+    "aug": "8月",
+    "sep": "9月",
+    "oct": "10月",
+    "nov": "11月",
+    "dec": "12月"
+  },
+  "zh-HK": {
+    "minute": "分鐘",
+    "hour": "小時",
+    "dayOfMonth": "日期",
+    "month": "月份",
+    "dayOfWeek": "星期",
+    "every": "每個",
+    "interval": "間隔",
+    "specific": "指定",
+    "range": "範圍",
+    "everyDescription": "每個{field}都執行",
+    "from": "從",
+    "to": "到",
+    "minutes": "分鐘",
+    "hours": "小時",
+    "days": "天",
+    "months": "個月",
+    "daysOfWeek": "天",
+    "sun": "週日",
+    "mon": "週一",
+    "tue": "週二",
+    "wed": "週三",
+    "thu": "週四",
+    "fri": "週五",
+    "sat": "週六",
+    "jan": "1月",
+    "feb": "2月",
+    "mar": "3月",
+    "apr": "4月",
+    "may": "5月",
+    "jun": "6月",
+    "jul": "7月",
+    "aug": "8月",
+    "sep": "9月",
+    "oct": "10月",
+    "nov": "11月",
+    "dec": "12月"
+  },
+  "es": {
+    "minute": "Minuto",
+    "hour": "Hora",
+    "dayOfMonth": "Dia del mes",
+    "month": "Mes",
+    "dayOfWeek": "Dia de la semana",
+    "every": "Cada",
+    "interval": "Intervalo",
+    "specific": "Especifico",
+    "range": "Rango",
+    "everyDescription": "Se ejecuta cada {field}",
+    "from": "Desde",
+    "to": "hasta",
+    "minutes": "minuto(s)",
+    "hours": "hora(s)",
+    "days": "dia(s)",
+    "months": "mes(es)",
+    "daysOfWeek": "dia(s)",
+    "sun": "Dom",
+    "mon": "Lun",
+    "tue": "Mar",
+    "wed": "Mie",
+    "thu": "Jue",
+    "fri": "Vie",
+    "sat": "Sab",
+    "jan": "Ene",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Abr",
+    "may": "May",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Ago",
+    "sep": "Sep",
+    "oct": "Oct",
+    "nov": "Nov",
+    "dec": "Dic"
+  },
+  "fr": {
+    "minute": "Minute",
+    "hour": "Heure",
+    "dayOfMonth": "Jour du mois",
+    "month": "Mois",
+    "dayOfWeek": "Jour de la semaine",
+    "every": "Chaque",
+    "interval": "Intervalle",
+    "specific": "Specifique",
+    "range": "Plage",
+    "everyDescription": "S'execute chaque {field}",
+    "from": "De",
+    "to": "a",
+    "minutes": "minute(s)",
+    "hours": "heure(s)",
+    "days": "jour(s)",
+    "months": "mois",
+    "daysOfWeek": "jour(s)",
+    "sun": "Dim",
+    "mon": "Lun",
+    "tue": "Mar",
+    "wed": "Mer",
+    "thu": "Jeu",
+    "fri": "Ven",
+    "sat": "Sam",
+    "jan": "Jan",
+    "feb": "Fev",
+    "mar": "Mar",
+    "apr": "Avr",
+    "may": "Mai",
+    "jun": "Juin",
+    "jul": "Juil",
+    "aug": "Aout",
+    "sep": "Sep",
+    "oct": "Oct",
+    "nov": "Nov",
+    "dec": "Dec"
+  },
+  "de": {
+    "minute": "Minute",
+    "hour": "Stunde",
+    "dayOfMonth": "Tag des Monats",
+    "month": "Monat",
+    "dayOfWeek": "Wochentag",
+    "every": "Jede",
+    "interval": "Intervall",
+    "specific": "Spezifisch",
+    "range": "Bereich",
+    "everyDescription": "Wird jede {field} ausgefuhrt",
+    "from": "Von",
+    "to": "bis",
+    "minutes": "Minute(n)",
+    "hours": "Stunde(n)",
+    "days": "Tag(e)",
+    "months": "Monat(e)",
+    "daysOfWeek": "Tag(e)",
+    "sun": "So",
+    "mon": "Mo",
+    "tue": "Di",
+    "wed": "Mi",
+    "thu": "Do",
+    "fri": "Fr",
+    "sat": "Sa",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "Mai",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Aug",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Dez"
+  },
+  "it": {
+    "minute": "Minuto",
+    "hour": "Ora",
+    "dayOfMonth": "Giorno del mese",
+    "month": "Mese",
+    "dayOfWeek": "Giorno della settimana",
+    "every": "Ogni",
+    "interval": "Intervallo",
+    "specific": "Specifico",
+    "range": "Intervallo",
+    "everyDescription": "Viene eseguito ogni {field}",
+    "from": "Da",
+    "to": "a",
+    "minutes": "minuto/i",
+    "hours": "ora/e",
+    "days": "giorno/i",
+    "months": "mese/i",
+    "daysOfWeek": "giorno/i",
+    "sun": "Dom",
+    "mon": "Lun",
+    "tue": "Mar",
+    "wed": "Mer",
+    "thu": "Gio",
+    "fri": "Ven",
+    "sat": "Sab",
+    "jan": "Gen",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "Mag",
+    "jun": "Giu",
+    "jul": "Lug",
+    "aug": "Ago",
+    "sep": "Set",
+    "oct": "Ott",
+    "nov": "Nov",
+    "dec": "Dic"
+  },
+  "ja": {
+    "minute": "分",
+    "hour": "時",
+    "dayOfMonth": "日",
+    "month": "月",
+    "dayOfWeek": "曜日",
+    "every": "毎",
+    "interval": "間隔",
+    "specific": "指定",
+    "range": "範囲",
+    "everyDescription": "毎{field}実行",
+    "from": "開始",
+    "to": "終了",
+    "minutes": "分",
+    "hours": "時間",
+    "days": "日",
+    "months": "ヶ月",
+    "daysOfWeek": "日",
+    "sun": "日",
+    "mon": "月",
+    "tue": "火",
+    "wed": "水",
+    "thu": "木",
+    "fri": "金",
+    "sat": "土",
+    "jan": "1月",
+    "feb": "2月",
+    "mar": "3月",
+    "apr": "4月",
+    "may": "5月",
+    "jun": "6月",
+    "jul": "7月",
+    "aug": "8月",
+    "sep": "9月",
+    "oct": "10月",
+    "nov": "11月",
+    "dec": "12月"
+  },
+  "ko": {
+    "minute": "분",
+    "hour": "시",
+    "dayOfMonth": "일",
+    "month": "월",
+    "dayOfWeek": "요일",
+    "every": "매",
+    "interval": "간격",
+    "specific": "지정",
+    "range": "범위",
+    "everyDescription": "매 {field}마다 실행",
+    "from": "시작",
+    "to": "끝",
+    "minutes": "분",
+    "hours": "시간",
+    "days": "일",
+    "months": "개월",
+    "daysOfWeek": "일",
+    "sun": "일",
+    "mon": "월",
+    "tue": "화",
+    "wed": "수",
+    "thu": "목",
+    "fri": "금",
+    "sat": "토",
+    "jan": "1월",
+    "feb": "2월",
+    "mar": "3월",
+    "apr": "4월",
+    "may": "5월",
+    "jun": "6월",
+    "jul": "7월",
+    "aug": "8월",
+    "sep": "9월",
+    "oct": "10월",
+    "nov": "11월",
+    "dec": "12월"
+  },
+  "ru": {
+    "minute": "Минута",
+    "hour": "Час",
+    "dayOfMonth": "День месяца",
+    "month": "Месяц",
+    "dayOfWeek": "День недели",
+    "every": "Каждый",
+    "interval": "Интервал",
+    "specific": "Конкретный",
+    "range": "Диапазон",
+    "everyDescription": "Выполняется каждый {field}",
+    "from": "От",
+    "to": "до",
+    "minutes": "минут(а)",
+    "hours": "час(ов)",
+    "days": "день(дней)",
+    "months": "месяц(ев)",
+    "daysOfWeek": "день(дней)",
+    "sun": "Вс",
+    "mon": "Пн",
+    "tue": "Вт",
+    "wed": "Ср",
+    "thu": "Чт",
+    "fri": "Пт",
+    "sat": "Сб",
+    "jan": "Янв",
+    "feb": "Фев",
+    "mar": "Мар",
+    "apr": "Апр",
+    "may": "Май",
+    "jun": "Июн",
+    "jul": "Июл",
+    "aug": "Авг",
+    "sep": "Сен",
+    "oct": "Окт",
+    "nov": "Ноя",
+    "dec": "Дек"
+  },
+  "pt": {
+    "minute": "Minuto",
+    "hour": "Hora",
+    "dayOfMonth": "Dia do mes",
+    "month": "Mes",
+    "dayOfWeek": "Dia da semana",
+    "every": "Cada",
+    "interval": "Intervalo",
+    "specific": "Especifico",
+    "range": "Faixa",
+    "everyDescription": "Executa a cada {field}",
+    "from": "De",
+    "to": "ate",
+    "minutes": "minuto(s)",
+    "hours": "hora(s)",
+    "days": "dia(s)",
+    "months": "mes(es)",
+    "daysOfWeek": "dia(s)",
+    "sun": "Dom",
+    "mon": "Seg",
+    "tue": "Ter",
+    "wed": "Qua",
+    "thu": "Qui",
+    "fri": "Sex",
+    "sat": "Sab",
+    "jan": "Jan",
+    "feb": "Fev",
+    "mar": "Mar",
+    "apr": "Abr",
+    "may": "Mai",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Ago",
+    "sep": "Set",
+    "oct": "Out",
+    "nov": "Nov",
+    "dec": "Dez"
+  },
+  "ar": {
+    "minute": "دقيقة",
+    "hour": "ساعة",
+    "dayOfMonth": "يوم الشهر",
+    "month": "شهر",
+    "dayOfWeek": "يوم الاسبوع",
+    "every": "كل",
+    "interval": "فاصل",
+    "specific": "محدد",
+    "range": "نطاق",
+    "everyDescription": "يعمل كل {field}",
+    "from": "من",
+    "to": "الى",
+    "minutes": "دقيقة",
+    "hours": "ساعة",
+    "days": "يوم",
+    "months": "شهر",
+    "daysOfWeek": "يوم",
+    "sun": "احد",
+    "mon": "اثنين",
+    "tue": "ثلاثاء",
+    "wed": "اربعاء",
+    "thu": "خميس",
+    "fri": "جمعة",
+    "sat": "سبت",
+    "jan": "يناير",
+    "feb": "فبراير",
+    "mar": "مارس",
+    "apr": "ابريل",
+    "may": "مايو",
+    "jun": "يونيو",
+    "jul": "يوليو",
+    "aug": "اغسطس",
+    "sep": "سبتمبر",
+    "oct": "اكتوبر",
+    "nov": "نوفمبر",
+    "dec": "ديسمبر"
+  },
+  "hi": {
+    "minute": "मिनट",
+    "hour": "घंटा",
+    "dayOfMonth": "महीने का दिन",
+    "month": "महीना",
+    "dayOfWeek": "सप्ताह का दिन",
+    "every": "हर",
+    "interval": "अंतराल",
+    "specific": "विशिष्ट",
+    "range": "सीमा",
+    "everyDescription": "हर {field} पर चलता है",
+    "from": "से",
+    "to": "तक",
+    "minutes": "मिनट",
+    "hours": "घंटे",
+    "days": "दिन",
+    "months": "महीने",
+    "daysOfWeek": "दिन",
+    "sun": "रवि",
+    "mon": "सोम",
+    "tue": "मंगल",
+    "wed": "बुध",
+    "thu": "गुरु",
+    "fri": "शुक्र",
+    "sat": "शनि",
+    "jan": "जन",
+    "feb": "फर",
+    "mar": "मार्च",
+    "apr": "अप्रैल",
+    "may": "मई",
+    "jun": "जून",
+    "jul": "जुला",
+    "aug": "अग",
+    "sep": "सित",
+    "oct": "अक्टू",
+    "nov": "नव",
+    "dec": "दिस"
+  },
+  "tr": {
+    "minute": "Dakika",
+    "hour": "Saat",
+    "dayOfMonth": "Ayin gunu",
+    "month": "Ay",
+    "dayOfWeek": "Haftanin gunu",
+    "every": "Her",
+    "interval": "Aralik",
+    "specific": "Belirli",
+    "range": "Aralik",
+    "everyDescription": "Her {field} calisir",
+    "from": "Baslangic",
+    "to": "bitis",
+    "minutes": "dakika",
+    "hours": "saat",
+    "days": "gun",
+    "months": "ay",
+    "daysOfWeek": "gun",
+    "sun": "Paz",
+    "mon": "Pzt",
+    "tue": "Sal",
+    "wed": "Car",
+    "thu": "Per",
+    "fri": "Cum",
+    "sat": "Cmt",
+    "jan": "Oca",
+    "feb": "Sub",
+    "mar": "Mar",
+    "apr": "Nis",
+    "may": "May",
+    "jun": "Haz",
+    "jul": "Tem",
+    "aug": "Agu",
+    "sep": "Eyl",
+    "oct": "Eki",
+    "nov": "Kas",
+    "dec": "Ara"
+  },
+  "nl": {
+    "minute": "Minuut",
+    "hour": "Uur",
+    "dayOfMonth": "Dag van de maand",
+    "month": "Maand",
+    "dayOfWeek": "Dag van de week",
+    "every": "Elke",
+    "interval": "Interval",
+    "specific": "Specifiek",
+    "range": "Bereik",
+    "everyDescription": "Wordt elke {field} uitgevoerd",
+    "from": "Van",
+    "to": "tot",
+    "minutes": "minu(u)t(en)",
+    "hours": "uur/uren",
+    "days": "dag(en)",
+    "months": "maand(en)",
+    "daysOfWeek": "dag(en)",
+    "sun": "Zo",
+    "mon": "Ma",
+    "tue": "Di",
+    "wed": "Wo",
+    "thu": "Do",
+    "fri": "Vr",
+    "sat": "Za",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mrt",
+    "apr": "Apr",
+    "may": "Mei",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Aug",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Dec"
+  },
+  "sv": {
+    "minute": "Minut",
+    "hour": "Timme",
+    "dayOfMonth": "Dag i manaden",
+    "month": "Manad",
+    "dayOfWeek": "Veckodag",
+    "every": "Varje",
+    "interval": "Intervall",
+    "specific": "Specifik",
+    "range": "Omrade",
+    "everyDescription": "Kors varje {field}",
+    "from": "Fran",
+    "to": "till",
+    "minutes": "minut(er)",
+    "hours": "timme/timmar",
+    "days": "dag(ar)",
+    "months": "manad(er)",
+    "daysOfWeek": "dag(ar)",
+    "sun": "Son",
+    "mon": "Man",
+    "tue": "Tis",
+    "wed": "Ons",
+    "thu": "Tor",
+    "fri": "Fre",
+    "sat": "Lor",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "Maj",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Aug",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Dec"
+  },
+  "pl": {
+    "minute": "Minuta",
+    "hour": "Godzina",
+    "dayOfMonth": "Dzien miesiaca",
+    "month": "Miesiac",
+    "dayOfWeek": "Dzien tygodnia",
+    "every": "Kazdy",
+    "interval": "Interwal",
+    "specific": "Okreslony",
+    "range": "Zakres",
+    "everyDescription": "Uruchamia sie co {field}",
+    "from": "Od",
+    "to": "do",
+    "minutes": "minut(a)",
+    "hours": "godzin(a)",
+    "days": "dzien/dni",
+    "months": "miesiac/e",
+    "daysOfWeek": "dzien/dni",
+    "sun": "Nd",
+    "mon": "Pn",
+    "tue": "Wt",
+    "wed": "Sr",
+    "thu": "Cz",
+    "fri": "Pt",
+    "sat": "Sb",
+    "jan": "Sty",
+    "feb": "Lut",
+    "mar": "Mar",
+    "apr": "Kwi",
+    "may": "Maj",
+    "jun": "Cze",
+    "jul": "Lip",
+    "aug": "Sie",
+    "sep": "Wrz",
+    "oct": "Paz",
+    "nov": "Lis",
+    "dec": "Gru"
+  },
+  "vi": {
+    "minute": "Phut",
+    "hour": "Gio",
+    "dayOfMonth": "Ngay trong thang",
+    "month": "Thang",
+    "dayOfWeek": "Ngay trong tuan",
+    "every": "Moi",
+    "interval": "Khoang",
+    "specific": "Cu the",
+    "range": "Pham vi",
+    "everyDescription": "Chay moi {field}",
+    "from": "Tu",
+    "to": "den",
+    "minutes": "phut",
+    "hours": "gio",
+    "days": "ngay",
+    "months": "thang",
+    "daysOfWeek": "ngay",
+    "sun": "CN",
+    "mon": "T2",
+    "tue": "T3",
+    "wed": "T4",
+    "thu": "T5",
+    "fri": "T6",
+    "sat": "T7",
+    "jan": "Th1",
+    "feb": "Th2",
+    "mar": "Th3",
+    "apr": "Th4",
+    "may": "Th5",
+    "jun": "Th6",
+    "jul": "Th7",
+    "aug": "Th8",
+    "sep": "Th9",
+    "oct": "Th10",
+    "nov": "Th11",
+    "dec": "Th12"
+  },
+  "th": {
+    "minute": "นาที",
+    "hour": "ชั่วโมง",
+    "dayOfMonth": "วันของเดือน",
+    "month": "เดือน",
+    "dayOfWeek": "วันในสัปดาห์",
+    "every": "ทุก",
+    "interval": "ช่วง",
+    "specific": "เฉพาะ",
+    "range": "ช่วง",
+    "everyDescription": "ทำงานทุก {field}",
+    "from": "จาก",
+    "to": "ถึง",
+    "minutes": "นาที",
+    "hours": "ชั่วโมง",
+    "days": "วัน",
+    "months": "เดือน",
+    "daysOfWeek": "วัน",
+    "sun": "อา",
+    "mon": "จ",
+    "tue": "อ",
+    "wed": "พ",
+    "thu": "พฤ",
+    "fri": "ศ",
+    "sat": "ส",
+    "jan": "ม.ค.",
+    "feb": "ก.พ.",
+    "mar": "มี.ค.",
+    "apr": "เม.ย.",
+    "may": "พ.ค.",
+    "jun": "มิ.ย.",
+    "jul": "ก.ค.",
+    "aug": "ส.ค.",
+    "sep": "ก.ย.",
+    "oct": "ต.ค.",
+    "nov": "พ.ย.",
+    "dec": "ธ.ค."
+  },
+  "id": {
+    "minute": "Menit",
+    "hour": "Jam",
+    "dayOfMonth": "Hari dalam bulan",
+    "month": "Bulan",
+    "dayOfWeek": "Hari dalam minggu",
+    "every": "Setiap",
+    "interval": "Interval",
+    "specific": "Spesifik",
+    "range": "Rentang",
+    "everyDescription": "Berjalan setiap {field}",
+    "from": "Dari",
+    "to": "sampai",
+    "minutes": "menit",
+    "hours": "jam",
+    "days": "hari",
+    "months": "bulan",
+    "daysOfWeek": "hari",
+    "sun": "Min",
+    "mon": "Sen",
+    "tue": "Sel",
+    "wed": "Rab",
+    "thu": "Kam",
+    "fri": "Jum",
+    "sat": "Sab",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "Mei",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Agu",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Des"
+  },
+  "he": {
+    "minute": "דקה",
+    "hour": "שעה",
+    "dayOfMonth": "יום בחודש",
+    "month": "חודש",
+    "dayOfWeek": "יום בשבוע",
+    "every": "כל",
+    "interval": "מרווח",
+    "specific": "ספציפי",
+    "range": "טווח",
+    "everyDescription": "רץ כל {field}",
+    "from": "מ",
+    "to": "עד",
+    "minutes": "דקות",
+    "hours": "שעות",
+    "days": "ימים",
+    "months": "חודשים",
+    "daysOfWeek": "ימים",
+    "sun": "א",
+    "mon": "ב",
+    "tue": "ג",
+    "wed": "ד",
+    "thu": "ה",
+    "fri": "ו",
+    "sat": "ש",
+    "jan": "ינו",
+    "feb": "פבר",
+    "mar": "מרץ",
+    "apr": "אפר",
+    "may": "מאי",
+    "jun": "יונ",
+    "jul": "יול",
+    "aug": "אוג",
+    "sep": "ספט",
+    "oct": "אוק",
+    "nov": "נוב",
+    "dec": "דצמ"
+  },
+  "ms": {
+    "minute": "Minit",
+    "hour": "Jam",
+    "dayOfMonth": "Hari dalam bulan",
+    "month": "Bulan",
+    "dayOfWeek": "Hari dalam minggu",
+    "every": "Setiap",
+    "interval": "Selang",
+    "specific": "Khusus",
+    "range": "Julat",
+    "everyDescription": "Berjalan setiap {field}",
+    "from": "Dari",
+    "to": "hingga",
+    "minutes": "minit",
+    "hours": "jam",
+    "days": "hari",
+    "months": "bulan",
+    "daysOfWeek": "hari",
+    "sun": "Ahd",
+    "mon": "Isn",
+    "tue": "Sel",
+    "wed": "Rab",
+    "thu": "Kha",
+    "fri": "Jum",
+    "sat": "Sab",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mac",
+    "apr": "Apr",
+    "may": "Mei",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Ogo",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Dis"
+  },
+  "no": {
+    "minute": "Minutt",
+    "hour": "Time",
+    "dayOfMonth": "Dag i maneden",
+    "month": "Maned",
+    "dayOfWeek": "Ukedag",
+    "every": "Hver",
+    "interval": "Intervall",
+    "specific": "Spesifikk",
+    "range": "Omrade",
+    "everyDescription": "Kjorer hver {field}",
+    "from": "Fra",
+    "to": "til",
+    "minutes": "minutt(er)",
+    "hours": "time(r)",
+    "days": "dag(er)",
+    "months": "maned(er)",
+    "daysOfWeek": "dag(er)",
+    "sun": "Son",
+    "mon": "Man",
+    "tue": "Tir",
+    "wed": "Ons",
+    "thu": "Tor",
+    "fri": "Fre",
+    "sat": "Lor",
+    "jan": "Jan",
+    "feb": "Feb",
+    "mar": "Mar",
+    "apr": "Apr",
+    "may": "Mai",
+    "jun": "Jun",
+    "jul": "Jul",
+    "aug": "Aug",
+    "sep": "Sep",
+    "oct": "Okt",
+    "nov": "Nov",
+    "dec": "Des"
+  }
+}
+</i18n>

--- a/tools/time/cron-expression-generator/src/components/CronOutput.vue
+++ b/tools/time/cron-expression-generator/src/components/CronOutput.vue
@@ -1,0 +1,115 @@
+<template>
+  <ToolSection>
+    <n-flex vertical :size="12" align="center">
+      <!-- Expression display -->
+      <n-flex align="center" :size="12">
+        <n-text code style="font-size: 1.5em; padding: 8px 16px">
+          {{ expression }}
+        </n-text>
+        <CopyToClipboardButton :content="expression" />
+      </n-flex>
+
+      <!-- Human-readable description -->
+      <n-text v-if="humanDescription" depth="2" style="text-align: center">
+        {{ humanDescription }}
+      </n-text>
+      <n-text v-else depth="3" style="text-align: center">
+        {{ t('invalidExpression') }}
+      </n-text>
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NFlex, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+defineProps<{
+  expression: string
+  humanDescription: string
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "invalidExpression": "Invalid cron expression"
+  },
+  "zh": {
+    "invalidExpression": "无效的 cron 表达式"
+  },
+  "zh-CN": {
+    "invalidExpression": "无效的 cron 表达式"
+  },
+  "zh-TW": {
+    "invalidExpression": "無效的 cron 表達式"
+  },
+  "zh-HK": {
+    "invalidExpression": "無效的 cron 表達式"
+  },
+  "es": {
+    "invalidExpression": "Expresion cron invalida"
+  },
+  "fr": {
+    "invalidExpression": "Expression cron invalide"
+  },
+  "de": {
+    "invalidExpression": "Ungultiger Cron-Ausdruck"
+  },
+  "it": {
+    "invalidExpression": "Espressione cron non valida"
+  },
+  "ja": {
+    "invalidExpression": "無効な cron 式"
+  },
+  "ko": {
+    "invalidExpression": "잘못된 cron 표현식"
+  },
+  "ru": {
+    "invalidExpression": "Недопустимое выражение cron"
+  },
+  "pt": {
+    "invalidExpression": "Expressao cron invalida"
+  },
+  "ar": {
+    "invalidExpression": "تعبير cron غير صالح"
+  },
+  "hi": {
+    "invalidExpression": "अमान्य cron अभिव्यक्ति"
+  },
+  "tr": {
+    "invalidExpression": "Gecersiz cron ifadesi"
+  },
+  "nl": {
+    "invalidExpression": "Ongeldige cron-expressie"
+  },
+  "sv": {
+    "invalidExpression": "Ogiltigt cron-uttryck"
+  },
+  "pl": {
+    "invalidExpression": "Nieprawidlowe wyrazenie cron"
+  },
+  "vi": {
+    "invalidExpression": "Bieu thuc cron khong hop le"
+  },
+  "th": {
+    "invalidExpression": "นิพจน์ cron ไม่ถูกต้อง"
+  },
+  "id": {
+    "invalidExpression": "Ekspresi cron tidak valid"
+  },
+  "he": {
+    "invalidExpression": "ביטוי cron לא חוקי"
+  },
+  "ms": {
+    "invalidExpression": "Ungkapan cron tidak sah"
+  },
+  "no": {
+    "invalidExpression": "Ugyldig cron-uttrykk"
+  }
+}
+</i18n>

--- a/tools/time/cron-expression-generator/src/components/CronPresets.vue
+++ b/tools/time/cron-expression-generator/src/components/CronPresets.vue
@@ -1,0 +1,397 @@
+<template>
+  <ToolSectionHeader>{{ t('presets') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-flex :size="8" wrap>
+      <n-button
+        v-for="preset in CRON_PRESETS"
+        :key="preset.value"
+        size="small"
+        secondary
+        @click="$emit('select', preset.value)"
+      >
+        {{ t(preset.label) }}
+      </n-button>
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { NFlex, NButton } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const CRON_PRESETS = [
+  { label: 'Every minute', value: '* * * * *' },
+  { label: 'Every 5 minutes', value: '*/5 * * * *' },
+  { label: 'Every 15 minutes', value: '*/15 * * * *' },
+  { label: 'Every 30 minutes', value: '*/30 * * * *' },
+  { label: 'Every hour', value: '0 * * * *' },
+  { label: 'Every day at midnight', value: '0 0 * * *' },
+  { label: 'Every day at noon', value: '0 12 * * *' },
+  { label: 'Every Sunday at midnight', value: '0 0 * * 0' },
+  { label: 'Every Monday at 9 AM', value: '0 9 * * 1' },
+  { label: 'First day of month', value: '0 0 1 * *' },
+  { label: 'Every weekday at 9 AM', value: '0 9 * * 1-5' },
+] as const
+
+defineEmits<{
+  select: [value: string]
+}>()
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "presets": "Quick Presets",
+    "Every minute": "Every minute",
+    "Every 5 minutes": "Every 5 minutes",
+    "Every 15 minutes": "Every 15 minutes",
+    "Every 30 minutes": "Every 30 minutes",
+    "Every hour": "Every hour",
+    "Every day at midnight": "Daily at midnight",
+    "Every day at noon": "Daily at noon",
+    "Every Sunday at midnight": "Every Sunday",
+    "Every Monday at 9 AM": "Every Monday 9 AM",
+    "First day of month": "Monthly",
+    "Every weekday at 9 AM": "Weekdays 9 AM"
+  },
+  "zh": {
+    "presets": "快速预设",
+    "Every minute": "每分钟",
+    "Every 5 minutes": "每5分钟",
+    "Every 15 minutes": "每15分钟",
+    "Every 30 minutes": "每30分钟",
+    "Every hour": "每小时",
+    "Every day at midnight": "每天午夜",
+    "Every day at noon": "每天中午",
+    "Every Sunday at midnight": "每周日",
+    "Every Monday at 9 AM": "每周一9点",
+    "First day of month": "每月",
+    "Every weekday at 9 AM": "工作日9点"
+  },
+  "zh-CN": {
+    "presets": "快速预设",
+    "Every minute": "每分钟",
+    "Every 5 minutes": "每5分钟",
+    "Every 15 minutes": "每15分钟",
+    "Every 30 minutes": "每30分钟",
+    "Every hour": "每小时",
+    "Every day at midnight": "每天午夜",
+    "Every day at noon": "每天中午",
+    "Every Sunday at midnight": "每周日",
+    "Every Monday at 9 AM": "每周一9点",
+    "First day of month": "每月",
+    "Every weekday at 9 AM": "工作日9点"
+  },
+  "zh-TW": {
+    "presets": "快速預設",
+    "Every minute": "每分鐘",
+    "Every 5 minutes": "每5分鐘",
+    "Every 15 minutes": "每15分鐘",
+    "Every 30 minutes": "每30分鐘",
+    "Every hour": "每小時",
+    "Every day at midnight": "每天午夜",
+    "Every day at noon": "每天中午",
+    "Every Sunday at midnight": "每週日",
+    "Every Monday at 9 AM": "每週一9點",
+    "First day of month": "每月",
+    "Every weekday at 9 AM": "工作日9點"
+  },
+  "zh-HK": {
+    "presets": "快速預設",
+    "Every minute": "每分鐘",
+    "Every 5 minutes": "每5分鐘",
+    "Every 15 minutes": "每15分鐘",
+    "Every 30 minutes": "每30分鐘",
+    "Every hour": "每小時",
+    "Every day at midnight": "每天午夜",
+    "Every day at noon": "每天中午",
+    "Every Sunday at midnight": "每週日",
+    "Every Monday at 9 AM": "每週一9點",
+    "First day of month": "每月",
+    "Every weekday at 9 AM": "工作日9點"
+  },
+  "es": {
+    "presets": "Preajustes rapidos",
+    "Every minute": "Cada minuto",
+    "Every 5 minutes": "Cada 5 minutos",
+    "Every 15 minutes": "Cada 15 minutos",
+    "Every 30 minutes": "Cada 30 minutos",
+    "Every hour": "Cada hora",
+    "Every day at midnight": "Diario a medianoche",
+    "Every day at noon": "Diario al mediodia",
+    "Every Sunday at midnight": "Cada domingo",
+    "Every Monday at 9 AM": "Cada lunes 9 AM",
+    "First day of month": "Mensual",
+    "Every weekday at 9 AM": "Dias laborables 9 AM"
+  },
+  "fr": {
+    "presets": "Preselections rapides",
+    "Every minute": "Chaque minute",
+    "Every 5 minutes": "Toutes les 5 minutes",
+    "Every 15 minutes": "Toutes les 15 minutes",
+    "Every 30 minutes": "Toutes les 30 minutes",
+    "Every hour": "Chaque heure",
+    "Every day at midnight": "Quotidien a minuit",
+    "Every day at noon": "Quotidien a midi",
+    "Every Sunday at midnight": "Chaque dimanche",
+    "Every Monday at 9 AM": "Chaque lundi 9h",
+    "First day of month": "Mensuel",
+    "Every weekday at 9 AM": "Jours ouvrables 9h"
+  },
+  "de": {
+    "presets": "Schnellvorlagen",
+    "Every minute": "Jede Minute",
+    "Every 5 minutes": "Alle 5 Minuten",
+    "Every 15 minutes": "Alle 15 Minuten",
+    "Every 30 minutes": "Alle 30 Minuten",
+    "Every hour": "Jede Stunde",
+    "Every day at midnight": "Taglich um Mitternacht",
+    "Every day at noon": "Taglich um Mittag",
+    "Every Sunday at midnight": "Jeden Sonntag",
+    "Every Monday at 9 AM": "Jeden Montag 9 Uhr",
+    "First day of month": "Monatlich",
+    "Every weekday at 9 AM": "Wochentags 9 Uhr"
+  },
+  "it": {
+    "presets": "Preset rapidi",
+    "Every minute": "Ogni minuto",
+    "Every 5 minutes": "Ogni 5 minuti",
+    "Every 15 minutes": "Ogni 15 minuti",
+    "Every 30 minutes": "Ogni 30 minuti",
+    "Every hour": "Ogni ora",
+    "Every day at midnight": "Ogni giorno a mezzanotte",
+    "Every day at noon": "Ogni giorno a mezzogiorno",
+    "Every Sunday at midnight": "Ogni domenica",
+    "Every Monday at 9 AM": "Ogni lunedi alle 9",
+    "First day of month": "Mensile",
+    "Every weekday at 9 AM": "Giorni feriali alle 9"
+  },
+  "ja": {
+    "presets": "クイックプリセット",
+    "Every minute": "毎分",
+    "Every 5 minutes": "5分ごと",
+    "Every 15 minutes": "15分ごと",
+    "Every 30 minutes": "30分ごと",
+    "Every hour": "毎時",
+    "Every day at midnight": "毎日深夜0時",
+    "Every day at noon": "毎日正午",
+    "Every Sunday at midnight": "毎週日曜日",
+    "Every Monday at 9 AM": "毎週月曜9時",
+    "First day of month": "毎月",
+    "Every weekday at 9 AM": "平日9時"
+  },
+  "ko": {
+    "presets": "빠른 프리셋",
+    "Every minute": "매분",
+    "Every 5 minutes": "5분마다",
+    "Every 15 minutes": "15분마다",
+    "Every 30 minutes": "30분마다",
+    "Every hour": "매시간",
+    "Every day at midnight": "매일 자정",
+    "Every day at noon": "매일 정오",
+    "Every Sunday at midnight": "매주 일요일",
+    "Every Monday at 9 AM": "매주 월요일 9시",
+    "First day of month": "매월",
+    "Every weekday at 9 AM": "평일 9시"
+  },
+  "ru": {
+    "presets": "Быстрые пресеты",
+    "Every minute": "Каждую минуту",
+    "Every 5 minutes": "Каждые 5 минут",
+    "Every 15 minutes": "Каждые 15 минут",
+    "Every 30 minutes": "Каждые 30 минут",
+    "Every hour": "Каждый час",
+    "Every day at midnight": "Ежедневно в полночь",
+    "Every day at noon": "Ежедневно в полдень",
+    "Every Sunday at midnight": "Каждое воскресенье",
+    "Every Monday at 9 AM": "Каждый понедельник в 9",
+    "First day of month": "Ежемесячно",
+    "Every weekday at 9 AM": "Будни в 9"
+  },
+  "pt": {
+    "presets": "Predefinicoes rapidas",
+    "Every minute": "A cada minuto",
+    "Every 5 minutes": "A cada 5 minutos",
+    "Every 15 minutes": "A cada 15 minutos",
+    "Every 30 minutes": "A cada 30 minutos",
+    "Every hour": "A cada hora",
+    "Every day at midnight": "Diariamente a meia-noite",
+    "Every day at noon": "Diariamente ao meio-dia",
+    "Every Sunday at midnight": "Todo domingo",
+    "Every Monday at 9 AM": "Toda segunda 9h",
+    "First day of month": "Mensal",
+    "Every weekday at 9 AM": "Dias uteis 9h"
+  },
+  "ar": {
+    "presets": "اعدادات سريعة",
+    "Every minute": "كل دقيقة",
+    "Every 5 minutes": "كل 5 دقائق",
+    "Every 15 minutes": "كل 15 دقيقة",
+    "Every 30 minutes": "كل 30 دقيقة",
+    "Every hour": "كل ساعة",
+    "Every day at midnight": "يوميا عند منتصف الليل",
+    "Every day at noon": "يوميا عند الظهر",
+    "Every Sunday at midnight": "كل احد",
+    "Every Monday at 9 AM": "كل اثنين 9 صباحا",
+    "First day of month": "شهريا",
+    "Every weekday at 9 AM": "ايام العمل 9 صباحا"
+  },
+  "hi": {
+    "presets": "त्वरित प्रीसेट",
+    "Every minute": "हर मिनट",
+    "Every 5 minutes": "हर 5 मिनट",
+    "Every 15 minutes": "हर 15 मिनट",
+    "Every 30 minutes": "हर 30 मिनट",
+    "Every hour": "हर घंटे",
+    "Every day at midnight": "रोज आधी रात",
+    "Every day at noon": "रोज दोपहर",
+    "Every Sunday at midnight": "हर रविवार",
+    "Every Monday at 9 AM": "हर सोमवार 9 बजे",
+    "First day of month": "मासिक",
+    "Every weekday at 9 AM": "कार्यदिवस 9 बजे"
+  },
+  "tr": {
+    "presets": "Hizli Onayarlar",
+    "Every minute": "Her dakika",
+    "Every 5 minutes": "Her 5 dakika",
+    "Every 15 minutes": "Her 15 dakika",
+    "Every 30 minutes": "Her 30 dakika",
+    "Every hour": "Her saat",
+    "Every day at midnight": "Her gun gece yarisi",
+    "Every day at noon": "Her gun ogle",
+    "Every Sunday at midnight": "Her pazar",
+    "Every Monday at 9 AM": "Her pazartesi 9",
+    "First day of month": "Aylik",
+    "Every weekday at 9 AM": "Hafta ici 9"
+  },
+  "nl": {
+    "presets": "Snelle presets",
+    "Every minute": "Elke minuut",
+    "Every 5 minutes": "Elke 5 minuten",
+    "Every 15 minutes": "Elke 15 minuten",
+    "Every 30 minutes": "Elke 30 minuten",
+    "Every hour": "Elk uur",
+    "Every day at midnight": "Dagelijks om middernacht",
+    "Every day at noon": "Dagelijks om 12 uur",
+    "Every Sunday at midnight": "Elke zondag",
+    "Every Monday at 9 AM": "Elke maandag 9 uur",
+    "First day of month": "Maandelijks",
+    "Every weekday at 9 AM": "Werkdagen 9 uur"
+  },
+  "sv": {
+    "presets": "Snabbval",
+    "Every minute": "Varje minut",
+    "Every 5 minutes": "Var 5:e minut",
+    "Every 15 minutes": "Var 15:e minut",
+    "Every 30 minutes": "Var 30:e minut",
+    "Every hour": "Varje timme",
+    "Every day at midnight": "Dagligen vid midnatt",
+    "Every day at noon": "Dagligen vid middag",
+    "Every Sunday at midnight": "Varje sondag",
+    "Every Monday at 9 AM": "Varje mandag kl 9",
+    "First day of month": "Manadsvis",
+    "Every weekday at 9 AM": "Vardagar kl 9"
+  },
+  "pl": {
+    "presets": "Szybkie ustawienia",
+    "Every minute": "Co minute",
+    "Every 5 minutes": "Co 5 minut",
+    "Every 15 minutes": "Co 15 minut",
+    "Every 30 minutes": "Co 30 minut",
+    "Every hour": "Co godzine",
+    "Every day at midnight": "Codziennie o polnocy",
+    "Every day at noon": "Codziennie w poludnie",
+    "Every Sunday at midnight": "Kazda niedziela",
+    "Every Monday at 9 AM": "Kazdy poniedzialek o 9",
+    "First day of month": "Miesieczne",
+    "Every weekday at 9 AM": "Dni robocze o 9"
+  },
+  "vi": {
+    "presets": "Cai dat nhanh",
+    "Every minute": "Moi phut",
+    "Every 5 minutes": "Moi 5 phut",
+    "Every 15 minutes": "Moi 15 phut",
+    "Every 30 minutes": "Moi 30 phut",
+    "Every hour": "Moi gio",
+    "Every day at midnight": "Hang ngay luc nua dem",
+    "Every day at noon": "Hang ngay luc trua",
+    "Every Sunday at midnight": "Moi chu nhat",
+    "Every Monday at 9 AM": "Moi thu hai 9 gio",
+    "First day of month": "Hang thang",
+    "Every weekday at 9 AM": "Ngay thuong 9 gio"
+  },
+  "th": {
+    "presets": "การตั้งค่าด่วน",
+    "Every minute": "ทุกนาที",
+    "Every 5 minutes": "ทุก 5 นาที",
+    "Every 15 minutes": "ทุก 15 นาที",
+    "Every 30 minutes": "ทุก 30 นาที",
+    "Every hour": "ทุกชั่วโมง",
+    "Every day at midnight": "ทุกวันเที่ยงคืน",
+    "Every day at noon": "ทุกวันเที่ยง",
+    "Every Sunday at midnight": "ทุกวันอาทิตย์",
+    "Every Monday at 9 AM": "ทุกวันจันทร์ 9 โมง",
+    "First day of month": "รายเดือน",
+    "Every weekday at 9 AM": "วันทำงาน 9 โมง"
+  },
+  "id": {
+    "presets": "Preset Cepat",
+    "Every minute": "Setiap menit",
+    "Every 5 minutes": "Setiap 5 menit",
+    "Every 15 minutes": "Setiap 15 menit",
+    "Every 30 minutes": "Setiap 30 menit",
+    "Every hour": "Setiap jam",
+    "Every day at midnight": "Setiap hari tengah malam",
+    "Every day at noon": "Setiap hari siang",
+    "Every Sunday at midnight": "Setiap Minggu",
+    "Every Monday at 9 AM": "Setiap Senin jam 9",
+    "First day of month": "Bulanan",
+    "Every weekday at 9 AM": "Hari kerja jam 9"
+  },
+  "he": {
+    "presets": "הגדרות מהירות",
+    "Every minute": "כל דקה",
+    "Every 5 minutes": "כל 5 דקות",
+    "Every 15 minutes": "כל 15 דקות",
+    "Every 30 minutes": "כל 30 דקות",
+    "Every hour": "כל שעה",
+    "Every day at midnight": "יומי בחצות",
+    "Every day at noon": "יומי בצהריים",
+    "Every Sunday at midnight": "כל יום ראשון",
+    "Every Monday at 9 AM": "כל יום שני ב-9",
+    "First day of month": "חודשי",
+    "Every weekday at 9 AM": "ימי עבודה ב-9"
+  },
+  "ms": {
+    "presets": "Pratetap Pantas",
+    "Every minute": "Setiap minit",
+    "Every 5 minutes": "Setiap 5 minit",
+    "Every 15 minutes": "Setiap 15 minit",
+    "Every 30 minutes": "Setiap 30 minit",
+    "Every hour": "Setiap jam",
+    "Every day at midnight": "Setiap hari tengah malam",
+    "Every day at noon": "Setiap hari tengah hari",
+    "Every Sunday at midnight": "Setiap Ahad",
+    "Every Monday at 9 AM": "Setiap Isnin jam 9",
+    "First day of month": "Bulanan",
+    "Every weekday at 9 AM": "Hari bekerja jam 9"
+  },
+  "no": {
+    "presets": "Hurtigvalg",
+    "Every minute": "Hvert minutt",
+    "Every 5 minutes": "Hvert 5. minutt",
+    "Every 15 minutes": "Hvert 15. minutt",
+    "Every 30 minutes": "Hvert 30. minutt",
+    "Every hour": "Hver time",
+    "Every day at midnight": "Daglig ved midnatt",
+    "Every day at noon": "Daglig ved middag",
+    "Every Sunday at midnight": "Hver sondag",
+    "Every Monday at 9 AM": "Hver mandag kl 9",
+    "First day of month": "Manedlig",
+    "Every weekday at 9 AM": "Ukedager kl 9"
+  }
+}
+</i18n>

--- a/tools/time/cron-expression-generator/src/components/NextRunTimes.vue
+++ b/tools/time/cron-expression-generator/src/components/NextRunTimes.vue
@@ -1,0 +1,338 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-data-table
+      v-if="runTimes.length > 0"
+      :columns="columns"
+      :data="tableData"
+      :bordered="false"
+      size="small"
+    />
+    <n-text v-else depth="3">{{ t('noTimes') }}</n-text>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { NDataTable, NText } from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const props = defineProps<{
+  runTimes: Date[]
+}>()
+
+const { t, locale } = useI18n()
+
+const columns = computed(() => [
+  {
+    title: '#',
+    key: 'index',
+    width: 50,
+  },
+  {
+    title: t('dateTime'),
+    key: 'dateTime',
+  },
+  {
+    title: t('relative'),
+    key: 'relative',
+  },
+])
+
+const tableData = computed(() =>
+  props.runTimes.map((date, index) => ({
+    key: index,
+    index: index + 1,
+    dateTime: formatDateTime(date),
+    relative: formatRelative(date),
+  })),
+)
+
+function formatDateTime(date: Date): string {
+  return date.toLocaleString(locale.value, {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  })
+}
+
+function formatRelative(date: Date): string {
+  const now = new Date()
+  const diff = date.getTime() - now.getTime()
+  const seconds = Math.floor(diff / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  const days = Math.floor(hours / 24)
+
+  if (days > 0) {
+    return t('inDays', { n: days })
+  }
+  if (hours > 0) {
+    return t('inHours', { n: hours })
+  }
+  if (minutes > 0) {
+    return t('inMinutes', { n: minutes })
+  }
+  return t('inSeconds', { n: seconds })
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "Next Executions",
+    "dateTime": "Date & Time",
+    "relative": "Relative",
+    "noTimes": "Configure fields above to see execution times",
+    "inDays": "in {n} day(s)",
+    "inHours": "in {n} hour(s)",
+    "inMinutes": "in {n} minute(s)",
+    "inSeconds": "in {n} second(s)"
+  },
+  "zh": {
+    "title": "下次执行时间",
+    "dateTime": "日期和时间",
+    "relative": "相对时间",
+    "noTimes": "配置上方字段以查看执行时间",
+    "inDays": "{n} 天后",
+    "inHours": "{n} 小时后",
+    "inMinutes": "{n} 分钟后",
+    "inSeconds": "{n} 秒后"
+  },
+  "zh-CN": {
+    "title": "下次执行时间",
+    "dateTime": "日期和时间",
+    "relative": "相对时间",
+    "noTimes": "配置上方字段以查看执行时间",
+    "inDays": "{n} 天后",
+    "inHours": "{n} 小时后",
+    "inMinutes": "{n} 分钟后",
+    "inSeconds": "{n} 秒后"
+  },
+  "zh-TW": {
+    "title": "下次執行時間",
+    "dateTime": "日期和時間",
+    "relative": "相對時間",
+    "noTimes": "設定上方欄位以查看執行時間",
+    "inDays": "{n} 天後",
+    "inHours": "{n} 小時後",
+    "inMinutes": "{n} 分鐘後",
+    "inSeconds": "{n} 秒後"
+  },
+  "zh-HK": {
+    "title": "下次執行時間",
+    "dateTime": "日期和時間",
+    "relative": "相對時間",
+    "noTimes": "設定上方欄位以查看執行時間",
+    "inDays": "{n} 天後",
+    "inHours": "{n} 小時後",
+    "inMinutes": "{n} 分鐘後",
+    "inSeconds": "{n} 秒後"
+  },
+  "es": {
+    "title": "Próximas Ejecuciones",
+    "dateTime": "Fecha y Hora",
+    "relative": "Relativo",
+    "noTimes": "Configure los campos anteriores para ver los tiempos de ejecución",
+    "inDays": "en {n} día(s)",
+    "inHours": "en {n} hora(s)",
+    "inMinutes": "en {n} minuto(s)",
+    "inSeconds": "en {n} segundo(s)"
+  },
+  "fr": {
+    "title": "Prochaines Exécutions",
+    "dateTime": "Date et Heure",
+    "relative": "Relatif",
+    "noTimes": "Configurez les champs ci-dessus pour voir les temps d'exécution",
+    "inDays": "dans {n} jour(s)",
+    "inHours": "dans {n} heure(s)",
+    "inMinutes": "dans {n} minute(s)",
+    "inSeconds": "dans {n} seconde(s)"
+  },
+  "de": {
+    "title": "Nächste Ausführungen",
+    "dateTime": "Datum & Uhrzeit",
+    "relative": "Relativ",
+    "noTimes": "Konfigurieren Sie die obigen Felder, um Ausführungszeiten zu sehen",
+    "inDays": "in {n} Tag(en)",
+    "inHours": "in {n} Stunde(n)",
+    "inMinutes": "in {n} Minute(n)",
+    "inSeconds": "in {n} Sekunde(n)"
+  },
+  "it": {
+    "title": "Prossime Esecuzioni",
+    "dateTime": "Data e Ora",
+    "relative": "Relativo",
+    "noTimes": "Configura i campi sopra per vedere i tempi di esecuzione",
+    "inDays": "tra {n} giorno/i",
+    "inHours": "tra {n} ora/e",
+    "inMinutes": "tra {n} minuto/i",
+    "inSeconds": "tra {n} secondo/i"
+  },
+  "ja": {
+    "title": "次回の実行",
+    "dateTime": "日時",
+    "relative": "相対時間",
+    "noTimes": "実行時間を表示するには上のフィールドを設定してください",
+    "inDays": "{n} 日後",
+    "inHours": "{n} 時間後",
+    "inMinutes": "{n} 分後",
+    "inSeconds": "{n} 秒後"
+  },
+  "ko": {
+    "title": "다음 실행",
+    "dateTime": "날짜 및 시간",
+    "relative": "상대 시간",
+    "noTimes": "실행 시간을 보려면 위 필드를 구성하세요",
+    "inDays": "{n}일 후",
+    "inHours": "{n}시간 후",
+    "inMinutes": "{n}분 후",
+    "inSeconds": "{n}초 후"
+  },
+  "ru": {
+    "title": "Следующие выполнения",
+    "dateTime": "Дата и Время",
+    "relative": "Относительное",
+    "noTimes": "Настройте поля выше, чтобы увидеть время выполнения",
+    "inDays": "через {n} день/дней",
+    "inHours": "через {n} час/часов",
+    "inMinutes": "через {n} минуту/минут",
+    "inSeconds": "через {n} секунду/секунд"
+  },
+  "pt": {
+    "title": "Próximas Execuções",
+    "dateTime": "Data e Hora",
+    "relative": "Relativo",
+    "noTimes": "Configure os campos acima para ver os horários de execução",
+    "inDays": "em {n} dia(s)",
+    "inHours": "em {n} hora(s)",
+    "inMinutes": "em {n} minuto(s)",
+    "inSeconds": "em {n} segundo(s)"
+  },
+  "ar": {
+    "title": "عمليات التنفيذ التالية",
+    "dateTime": "التاريخ والوقت",
+    "relative": "نسبي",
+    "noTimes": "قم بتكوين الحقول أعلاه لرؤية أوقات التنفيذ",
+    "inDays": "بعد {n} يوم/أيام",
+    "inHours": "بعد {n} ساعة/ساعات",
+    "inMinutes": "بعد {n} دقيقة/دقائق",
+    "inSeconds": "بعد {n} ثانية/ثواني"
+  },
+  "hi": {
+    "title": "अगले निष्पादन",
+    "dateTime": "दिनांक और समय",
+    "relative": "सापेक्ष",
+    "noTimes": "निष्पादन समय देखने के लिए ऊपर के फ़ील्ड कॉन्फ़िगर करें",
+    "inDays": "{n} दिन में",
+    "inHours": "{n} घंटे में",
+    "inMinutes": "{n} मिनट में",
+    "inSeconds": "{n} सेकंड में"
+  },
+  "tr": {
+    "title": "Sonraki Çalıştırmalar",
+    "dateTime": "Tarih ve Saat",
+    "relative": "Göreli",
+    "noTimes": "Çalıştırma zamanlarını görmek için yukarıdaki alanları yapılandırın",
+    "inDays": "{n} gün içinde",
+    "inHours": "{n} saat içinde",
+    "inMinutes": "{n} dakika içinde",
+    "inSeconds": "{n} saniye içinde"
+  },
+  "nl": {
+    "title": "Volgende Uitvoeringen",
+    "dateTime": "Datum & Tijd",
+    "relative": "Relatief",
+    "noTimes": "Configureer de bovenstaande velden om uitvoeringstijden te zien",
+    "inDays": "over {n} dag(en)",
+    "inHours": "over {n} uur",
+    "inMinutes": "over {n} minuut/minuten",
+    "inSeconds": "over {n} seconde(n)"
+  },
+  "sv": {
+    "title": "Nästa Körningar",
+    "dateTime": "Datum & Tid",
+    "relative": "Relativt",
+    "noTimes": "Konfigurera fälten ovan för att se körningstider",
+    "inDays": "om {n} dag(ar)",
+    "inHours": "om {n} timme/timmar",
+    "inMinutes": "om {n} minut(er)",
+    "inSeconds": "om {n} sekund(er)"
+  },
+  "pl": {
+    "title": "Następne Wykonania",
+    "dateTime": "Data i Czas",
+    "relative": "Względny",
+    "noTimes": "Skonfiguruj powyższe pola, aby zobaczyć czasy wykonania",
+    "inDays": "za {n} dzień/dni",
+    "inHours": "za {n} godzinę/godzin",
+    "inMinutes": "za {n} minutę/minut",
+    "inSeconds": "za {n} sekundę/sekund"
+  },
+  "vi": {
+    "title": "Lần Thực Thi Tiếp Theo",
+    "dateTime": "Ngày & Giờ",
+    "relative": "Tương đối",
+    "noTimes": "Cấu hình các trường ở trên để xem thời gian thực thi",
+    "inDays": "trong {n} ngày",
+    "inHours": "trong {n} giờ",
+    "inMinutes": "trong {n} phút",
+    "inSeconds": "trong {n} giây"
+  },
+  "th": {
+    "title": "การดำเนินการถัดไป",
+    "dateTime": "วันที่และเวลา",
+    "relative": "สัมพัทธ์",
+    "noTimes": "กำหนดค่าฟิลด์ด้านบนเพื่อดูเวลาดำเนินการ",
+    "inDays": "ใน {n} วัน",
+    "inHours": "ใน {n} ชั่วโมง",
+    "inMinutes": "ใน {n} นาที",
+    "inSeconds": "ใน {n} วินาที"
+  },
+  "id": {
+    "title": "Eksekusi Berikutnya",
+    "dateTime": "Tanggal & Waktu",
+    "relative": "Relatif",
+    "noTimes": "Konfigurasikan bidang di atas untuk melihat waktu eksekusi",
+    "inDays": "dalam {n} hari",
+    "inHours": "dalam {n} jam",
+    "inMinutes": "dalam {n} menit",
+    "inSeconds": "dalam {n} detik"
+  },
+  "he": {
+    "title": "ההרצות הבאות",
+    "dateTime": "תאריך ושעה",
+    "relative": "יחסי",
+    "noTimes": "הגדר את השדות למעלה כדי לראות זמני הרצה",
+    "inDays": "בעוד {n} יום/ימים",
+    "inHours": "בעוד {n} שעה/שעות",
+    "inMinutes": "בעוד {n} דקה/דקות",
+    "inSeconds": "בעוד {n} שנייה/שניות"
+  },
+  "ms": {
+    "title": "Pelaksanaan Seterusnya",
+    "dateTime": "Tarikh & Masa",
+    "relative": "Relatif",
+    "noTimes": "Konfigurasikan medan di atas untuk melihat masa pelaksanaan",
+    "inDays": "dalam {n} hari",
+    "inHours": "dalam {n} jam",
+    "inMinutes": "dalam {n} minit",
+    "inSeconds": "dalam {n} saat"
+  },
+  "no": {
+    "title": "Neste Kjøringer",
+    "dateTime": "Dato og Tid",
+    "relative": "Relativ",
+    "noTimes": "Konfigurer feltene ovenfor for å se kjøretider",
+    "inDays": "om {n} dag(er)",
+    "inHours": "om {n} time(r)",
+    "inMinutes": "om {n} minutt(er)",
+    "inSeconds": "om {n} sekund(er)"
+  }
+}
+</i18n>

--- a/tools/time/cron-expression-generator/src/index.ts
+++ b/tools/time/cron-expression-generator/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/time/cron-expression-generator/src/info.ts
+++ b/tools/time/cron-expression-generator/src/info.ts
@@ -1,0 +1,109 @@
+export { Timer20Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'cron-expression-generator'
+export const path = '/tools/cron-expression-generator'
+export const tags = ['time', 'cron', 'scheduler', 'generator', 'unix']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Cron Expression Generator',
+    description: 'Visually build cron expressions with an interactive form',
+  },
+  zh: {
+    name: 'Cron 表达式生成器',
+    description: '通过可视化表单生成 cron 表达式',
+  },
+  'zh-CN': {
+    name: 'Cron 表达式生成器',
+    description: '通过可视化表单生成 cron 表达式',
+  },
+  'zh-TW': {
+    name: 'Cron 表達式產生器',
+    description: '透過視覺化表單產生 cron 表達式',
+  },
+  'zh-HK': {
+    name: 'Cron 表達式產生器',
+    description: '透過視覺化表單產生 cron 表達式',
+  },
+  es: {
+    name: 'Generador de expresiones Cron',
+    description: 'Construye expresiones cron visualmente con un formulario interactivo',
+  },
+  fr: {
+    name: 'Generateur expression Cron',
+    description: 'Construisez visuellement des expressions cron avec un formulaire interactif',
+  },
+  de: {
+    name: 'Cron-Ausdruck-Generator',
+    description: 'Erstellen Sie Cron-Ausdrucke visuell mit einem interaktiven Formular',
+  },
+  it: {
+    name: 'Generatore espressioni Cron',
+    description: 'Crea espressioni cron visivamente con un modulo interattivo',
+  },
+  ja: {
+    name: 'Cron 式ジェネレーター',
+    description: 'インタラクティブなフォームで cron 式を視覚的に作成',
+  },
+  ko: {
+    name: 'Cron 표현식 생성기',
+    description: '대화형 양식으로 cron 표현식을 시각적으로 작성',
+  },
+  ru: {
+    name: 'Генератор Cron-выражений',
+    description: 'Визуальное создание cron-выражений с помощью интерактивной формы',
+  },
+  pt: {
+    name: 'Gerador de expressoes Cron',
+    description: 'Construa expressoes cron visualmente com um formulario interativo',
+  },
+  ar: {
+    name: 'منشئ تعبيرات Cron',
+    description: 'قم ببناء تعبيرات cron بصريا باستخدام نموذج تفاعلي',
+  },
+  hi: {
+    name: 'Cron एक्सप्रेशन जनरेटर',
+    description: 'इंटरैक्टिव फॉर्म के साथ विजुअली cron एक्सप्रेशन बनाएं',
+  },
+  tr: {
+    name: 'Cron Ifadesi Olusturucu',
+    description: 'Etkilesimli bir form ile gorsel olarak cron ifadeleri olusturun',
+  },
+  nl: {
+    name: 'Cron-expressie generator',
+    description: 'Bouw visueel cron-expressies met een interactief formulier',
+  },
+  sv: {
+    name: 'Cron-uttrycksgenerator',
+    description: 'Bygg cron-uttryck visuellt med ett interaktivt formulär',
+  },
+  pl: {
+    name: 'Generator wyrazen Cron',
+    description: 'Twórz wizualnie wyrazenia cron za pomoca interaktywnego formularza',
+  },
+  vi: {
+    name: 'Trinh tao bieu thuc Cron',
+    description: 'Xây dung bieu thuc cron truc quan bang bieu mau tuong tac',
+  },
+  th: {
+    name: 'ตัวสร้างนิพจน์ Cron',
+    description: 'สร้างนิพจน์ cron แบบภาพด้วยแบบฟอร์มโต้ตอบ',
+  },
+  id: {
+    name: 'Generator Ekspresi Cron',
+    description: 'Buat ekspresi cron secara visual dengan formulir interaktif',
+  },
+  he: {
+    name: 'מחולל ביטויי Cron',
+    description: 'בנה ביטויי cron באופן חזותי עם טופס אינטראקטיבי',
+  },
+  ms: {
+    name: 'Penjana Ungkapan Cron',
+    description: 'Bina ungkapan cron secara visual dengan borang interaktif',
+  },
+  no: {
+    name: 'Cron-uttrykks generator',
+    description: 'Bygg cron-uttrykk visuelt med et interaktivt skjema',
+  },
+}

--- a/tools/time/cron-expression-generator/src/routes.ts
+++ b/tools/time/cron-expression-generator/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'cron-expression-generator',
+    path: '/tools/cron-expression-generator',
+    component: () => import('./CronExpressionGeneratorView.vue'),
+  },
+] as const


### PR DESCRIPTION
## Summary
- Add a visual cron expression builder tool that allows users to construct cron expressions through an interactive form
- Visual configuration for all 5 cron fields (minute, hour, day of month, month, day of week)
- 4 modes per field: Every (*), Interval (*/n), Specific values (n,m,o), Range (n-m)
- 11 quick preset buttons for common schedules
- Real-time expression generation with human-readable description (via cronstrue)
- Next 5 execution times preview
- State persistence to localStorage
- Full i18n support for all 25 languages

## Test plan
- [ ] Visit `/tools/cron-expression-generator`
- [ ] Test each field mode (Every, Interval, Specific, Range)
- [ ] Verify presets generate correct expressions
- [ ] Check human-readable descriptions match expressions
- [ ] Verify next run times are calculated correctly
- [ ] Test state persistence (refresh page, values should persist)
- [ ] Test different languages

🤖 Generated with [Claude Code](https://claude.com/claude-code)