### PR TITLE
fix(deps): replace mime-types with mime for browser compatibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,12 +231,12 @@ catalogs:
     marked:
       specifier: ^17.0.1
       version: 17.0.1
+    mime:
+      specifier: ^4.0.6
+      version: 4.1.0
     mime-db:
       specifier: ^1.54.0
       version: 1.54.0
-    mime-types:
-      specifier: ^3.0.2
-      version: 3.0.2
     monaco-editor:
       specifier: ^0.55.1
       version: 0.55.1
@@ -3312,9 +3312,9 @@ importers:
       '@shared/ui':
         specifier: workspace:*
         version: link:../../../shared/ui
-      mime-types:
+      mime:
         specifier: 'catalog:'
-        version: 3.0.2
+        version: 4.1.0
       naive-ui:
         specifier: 'catalog:'
         version: 2.43.2(vue@3.5.26(typescript@5.9.3))
@@ -3327,10 +3327,6 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
-    devDependencies:
-      '@types/mime-types':
-        specifier: ^3.0.1
-        version: 3.0.1
 
   tools/web/file-to-data-uri-converter:
     dependencies:
@@ -5519,9 +5515,6 @@ packages:
   '@types/mime-db@1.43.6':
     resolution: {integrity: sha512-r2cqxAt/Eo5yWBOQie1lyM1JZFCiORa5xtLlhSZI0w8RJggBPKw8c4g/fgQCzWydaDR5bL4imnmix2d1n52iBw==}
 
-  '@types/mime-types@3.0.1':
-    resolution: {integrity: sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==}
-
   '@types/node@20.19.27':
     resolution: {integrity: sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==}
 
@@ -7400,13 +7393,14 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
-  mime-types@3.0.2:
-    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
-    engines: {node: '>=18'}
-
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
     hasBin: true
 
   mimic-function@5.0.1:
@@ -10450,8 +10444,6 @@ snapshots:
 
   '@types/mime-db@1.43.6': {}
 
-  '@types/mime-types@3.0.1': {}
-
   '@types/node@20.19.27':
     dependencies:
       undici-types: 6.21.0
@@ -12478,11 +12470,9 @@ snapshots:
 
   mime-db@1.54.0: {}
 
-  mime-types@3.0.2:
-    dependencies:
-      mime-db: 1.54.0
-
   mime@3.0.0: {}
+
+  mime@4.1.0: {}
 
   mimic-function@5.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,8 +84,8 @@ catalog:
   jsdom: ^27.4.0
   lint-staged: ^16.2.7
   marked: ^17.0.1
+  mime: ^4.0.6
   mime-db: ^1.54.0
-  mime-types: ^3.0.2
   monaco-editor: ^0.55.1
   naive-ui: ^2.43.2
   npm-run-all2: ^8.0.4

--- a/tools/web/data-uri-to-file-converter/package.json
+++ b/tools/web/data-uri-to-file-converter/package.json
@@ -11,13 +11,10 @@
     "@shared/icons": "workspace:*",
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
-    "mime-types": "catalog:",
+    "mime": "catalog:",
     "naive-ui": "catalog:",
     "vue": "catalog:",
     "vue-i18n": "catalog:",
     "vue-router": "catalog:"
-  },
-  "devDependencies": {
-    "@types/mime-types": "^3.0.1"
   }
 }

--- a/tools/web/data-uri-to-file-converter/src/components/DataUriToFileConverter.vue
+++ b/tools/web/data-uri-to-file-converter/src/components/DataUriToFileConverter.vue
@@ -97,7 +97,7 @@ import {
 } from 'naive-ui'
 import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
 import { ArrowDownload16Regular } from '@shared/icons/fluent'
-import { extension as mimeExtension } from 'mime-types'
+import mime from 'mime'
 
 const { t } = useI18n()
 
@@ -278,8 +278,8 @@ function extensionForMime(mimeType: string): string | null {
   const normalized = mimeType.split(';')[0]?.trim().toLowerCase() ?? ''
   if (!normalized) return null
 
-  const inferred = mimeExtension(normalized)
-  if (typeof inferred === 'string' && inferred.trim() !== '') {
+  const inferred = mime.getExtension(normalized)
+  if (inferred) {
     return inferred
   }
 


### PR DESCRIPTION
## Summary
- Replace `mime-types` package with `mime` package in data-uri-to-file-converter tool
- The `mime-types` package uses Node.js `path` module which causes Vite build warnings
- The `mime` package is designed for browser environments without Node.js polyfills

## Test plan
- [x] Build passes without mime-types warning
- [x] Type check passes
- [x] Lint and format pass
- [x] Data URI to file converter correctly identifies file extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)