### PR TITLE
feat(tools): add Placeholder Image Generator tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -684,6 +684,9 @@ importers:
       '@tools/pdf-tools':
         specifier: workspace:*
         version: link:../../tools/pdf/pdf-tools
+      '@tools/placeholder-image-generator':
+        specifier: workspace:*
+        version: link:../../tools/image/placeholder-image-generator
       '@tools/png-optimizer':
         specifier: workspace:*
         version: link:../../tools/image/png-optimizer
@@ -2107,6 +2110,30 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
+
+  tools/image/placeholder-image-generator:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
 
   tools/image/png-optimizer:
     dependencies:

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -66,6 +66,7 @@
     "@tools/network-tools": "workspace:*",
     "@tools/number-base-converter": "workspace:*",
     "@tools/pdf-tools": "workspace:*",
+    "@tools/placeholder-image-generator": "workspace:*",
     "@tools/png-optimizer": "workspace:*",
     "@tools/port-number-lookup": "workspace:*",
     "@tools/qr-code-generator": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -85,6 +85,7 @@ import { toolInfo as mimeTypeLookupToolInfo } from '@tools/mime-type-lookup'
 import { toolInfo as textStatisticsToolInfo } from '@tools/text-statistics'
 import { toolInfo as loremIpsumGeneratorToolInfo } from '@tools/lorem-ipsum-generator'
 import { toolInfo as creditCardValidatorToolInfo } from '@tools/credit-card-validator'
+import { toolInfo as placeholderImageGeneratorToolInfo } from '@tools/placeholder-image-generator'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -115,6 +116,7 @@ export const tools: ToolInfo[] = [
   exifViewerToolInfo,
   qrCodeGeneratorToolInfo,
   barcodeGeneratorToolInfo,
+  placeholderImageGeneratorToolInfo,
   markdownToHtmlConverterToolInfo,
   htmlToMarkdownConverterToolInfo,
   jsonToYamlBuilderToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -83,6 +83,7 @@ import { routes as mimeTypeLookupRoutes } from '@tools/mime-type-lookup/routes'
 import { routes as textStatisticsRoutes } from '@tools/text-statistics/routes'
 import { routes as loremIpsumGeneratorRoutes } from '@tools/lorem-ipsum-generator/routes'
 import { routes as creditCardValidatorRoutes } from '@tools/credit-card-validator/routes'
+import { routes as placeholderImageGeneratorRoutes } from '@tools/placeholder-image-generator/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -169,4 +170,5 @@ export const routes: ToolRoute[] = [
   ...textStatisticsRoutes,
   ...loremIpsumGeneratorRoutes,
   ...creditCardValidatorRoutes,
+  ...placeholderImageGeneratorRoutes,
 ]

--- a/tools/image/placeholder-image-generator/package.json
+++ b/tools/image/placeholder-image-generator/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/placeholder-image-generator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/image/placeholder-image-generator/src/PlaceholderImageGeneratorView.vue
+++ b/tools/image/placeholder-image-generator/src/PlaceholderImageGeneratorView.vue
@@ -1,0 +1,11 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <PlaceholderImageGenerator />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import PlaceholderImageGenerator from './components/PlaceholderImageGenerator.vue'
+</script>

--- a/tools/image/placeholder-image-generator/src/components/PlaceholderDownloadButtons.vue
+++ b/tools/image/placeholder-image-generator/src/components/PlaceholderDownloadButtons.vue
@@ -1,0 +1,438 @@
+<template>
+  <n-flex vertical :size="16">
+    <!-- Scale Selector -->
+    <n-flex align="center" :size="12">
+      <span>{{ t('scale') }}:</span>
+      <n-radio-group v-model:value="scale" size="small">
+        <n-radio-button :value="1">1x</n-radio-button>
+        <n-radio-button :value="2">2x</n-radio-button>
+        <n-radio-button :value="3">3x</n-radio-button>
+      </n-radio-group>
+    </n-flex>
+
+    <!-- Quality Slider (for JPG/WebP) -->
+    <n-flex align="center" :size="12">
+      <span>{{ t('quality') }}:</span>
+      <n-slider
+        v-model:value="quality"
+        :min="0.1"
+        :max="1"
+        :step="0.1"
+        :format-tooltip="(v) => `${Math.round(v * 100)}%`"
+        style="width: 150px"
+      />
+    </n-flex>
+
+    <!-- Download Buttons -->
+    <n-flex :size="8" wrap>
+      <n-button tertiary @click="downloadPNG">
+        <template #icon>
+          <n-icon><ImageIcon /></n-icon>
+        </template>
+        PNG
+      </n-button>
+      <n-button tertiary @click="downloadJPG">
+        <template #icon>
+          <n-icon><ImageIcon /></n-icon>
+        </template>
+        JPG
+      </n-button>
+      <n-button tertiary @click="downloadWebP">
+        <template #icon>
+          <n-icon><ImageIcon /></n-icon>
+        </template>
+        WebP
+      </n-button>
+      <n-button tertiary @click="downloadSVG">
+        <template #icon>
+          <n-icon><CodeIcon /></n-icon>
+        </template>
+        SVG
+      </n-button>
+    </n-flex>
+
+    <!-- Copy to Clipboard -->
+    <n-button @click="copyToClipboard">
+      <template #icon>
+        <n-icon><CopyIcon /></n-icon>
+      </template>
+      {{ t('copy-to-clipboard') }}
+    </n-button>
+  </n-flex>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NFlex, NButton, NIcon, NRadioGroup, NRadioButton, NSlider, useMessage } from 'naive-ui'
+import {
+  Image24Regular as ImageIcon,
+  Code24Regular as CodeIcon,
+  Copy24Regular as CopyIcon,
+} from '@shared/icons/fluent'
+import type { PlaceholderOptions } from './PlaceholderPreview.vue'
+
+const { t } = useI18n()
+const message = useMessage()
+
+const props = defineProps<{
+  options: PlaceholderOptions
+}>()
+
+const scale = ref(1)
+const quality = ref(0.9)
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function generateSVG(options: PlaceholderOptions, svgScale = 1): string {
+  const w = options.width * svgScale
+  const h = options.height * svgScale
+  const text = options.customText || `${options.width} × ${options.height}`
+  const baseFontSize = options.fontSize || Math.min(options.width, options.height) / 8
+  const fontSize = baseFontSize * svgScale
+
+  let defs = ''
+  let fill = options.bgColor
+
+  if (options.bgType === 'linear-gradient') {
+    const angle = options.gradientAngle
+    defs = `<defs>
+      <linearGradient id="grad" gradientTransform="rotate(${angle}, 0.5, 0.5)">
+        <stop offset="0%" stop-color="${options.gradientColor1}"/>
+        <stop offset="100%" stop-color="${options.gradientColor2}"/>
+      </linearGradient>
+    </defs>`
+    fill = 'url(#grad)'
+  } else if (options.bgType === 'radial-gradient') {
+    defs = `<defs>
+      <radialGradient id="grad" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stop-color="${options.gradientColor1}"/>
+        <stop offset="100%" stop-color="${options.gradientColor2}"/>
+      </radialGradient>
+    </defs>`
+    fill = 'url(#grad)'
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
+  ${defs}
+  <rect width="100%" height="100%" fill="${fill}"/>
+  <text x="50%" y="50%" fill="${options.textColor}" font-size="${fontSize}"
+        font-family="sans-serif" text-anchor="middle" dominant-baseline="middle">
+    ${escapeXml(text)}
+  </text>
+</svg>`
+}
+
+function drawToCanvas(canvas: HTMLCanvasElement, options: PlaceholderOptions, canvasScale = 1) {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+
+  const w = options.width * canvasScale
+  const h = options.height * canvasScale
+  canvas.width = w
+  canvas.height = h
+
+  // Background
+  if (options.bgType === 'solid') {
+    ctx.fillStyle = options.bgColor
+  } else if (options.bgType === 'linear-gradient') {
+    const angle = (options.gradientAngle * Math.PI) / 180
+    const x1 = w / 2 - Math.cos(angle) * (w / 2)
+    const y1 = h / 2 - Math.sin(angle) * (h / 2)
+    const x2 = w / 2 + Math.cos(angle) * (w / 2)
+    const y2 = h / 2 + Math.sin(angle) * (h / 2)
+    const gradient = ctx.createLinearGradient(x1, y1, x2, y2)
+    gradient.addColorStop(0, options.gradientColor1)
+    gradient.addColorStop(1, options.gradientColor2)
+    ctx.fillStyle = gradient
+  } else if (options.bgType === 'radial-gradient') {
+    const gradient = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) / 2)
+    gradient.addColorStop(0, options.gradientColor1)
+    gradient.addColorStop(1, options.gradientColor2)
+    ctx.fillStyle = gradient
+  }
+  ctx.fillRect(0, 0, w, h)
+
+  // Text
+  const text = options.customText || `${options.width} × ${options.height}`
+  const baseFontSize = options.fontSize || Math.min(options.width, options.height) / 8
+  const fontSize = baseFontSize * canvasScale
+  ctx.fillStyle = options.textColor
+  ctx.font = `${fontSize}px sans-serif`
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, w / 2, h / 2)
+}
+
+function downloadBlob(file: File) {
+  const url = URL.createObjectURL(file)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = file.name
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function getFilename(ext: string): string {
+  const { width, height } = props.options
+  const scaleStr = scale.value > 1 ? `@${scale.value}x` : ''
+  return `placeholder-${width}x${height}${scaleStr}.${ext}`
+}
+
+async function downloadPNG() {
+  const canvas = document.createElement('canvas')
+  drawToCanvas(canvas, props.options, scale.value)
+  await new Promise<void>((resolve) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        downloadBlob(new File([blob], getFilename('png'), { type: 'image/png' }))
+      }
+      resolve()
+    }, 'image/png')
+  })
+}
+
+async function downloadJPG() {
+  const canvas = document.createElement('canvas')
+  drawToCanvas(canvas, props.options, scale.value)
+  await new Promise<void>((resolve) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          downloadBlob(new File([blob], getFilename('jpg'), { type: 'image/jpeg' }))
+        }
+        resolve()
+      },
+      'image/jpeg',
+      quality.value,
+    )
+  })
+}
+
+async function downloadWebP() {
+  const canvas = document.createElement('canvas')
+  drawToCanvas(canvas, props.options, scale.value)
+  await new Promise<void>((resolve) => {
+    canvas.toBlob(
+      (blob) => {
+        if (blob) {
+          downloadBlob(new File([blob], getFilename('webp'), { type: 'image/webp' }))
+        }
+        resolve()
+      },
+      'image/webp',
+      quality.value,
+    )
+  })
+}
+
+function downloadSVG() {
+  const svg = generateSVG(props.options, scale.value)
+  downloadBlob(new File([svg], getFilename('svg'), { type: 'image/svg+xml' }))
+}
+
+async function copyToClipboard() {
+  try {
+    const canvas = document.createElement('canvas')
+    drawToCanvas(canvas, props.options, scale.value)
+    const blob = await new Promise<Blob | null>((resolve) => {
+      canvas.toBlob(resolve, 'image/png')
+    })
+    if (!blob) {
+      message.error(t('copy-failed'))
+      return
+    }
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })])
+    message.success(t('copy-success'))
+  } catch {
+    message.error(t('copy-failed'))
+  }
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "scale": "Scale",
+    "quality": "Quality",
+    "copy-to-clipboard": "Copy to Clipboard",
+    "copy-success": "Image copied to clipboard",
+    "copy-failed": "Failed to copy image"
+  },
+  "zh": {
+    "scale": "倍率",
+    "quality": "质量",
+    "copy-to-clipboard": "复制到剪贴板",
+    "copy-success": "图片已复制到剪贴板",
+    "copy-failed": "复制图片失败"
+  },
+  "zh-CN": {
+    "scale": "倍率",
+    "quality": "质量",
+    "copy-to-clipboard": "复制到剪贴板",
+    "copy-success": "图片已复制到剪贴板",
+    "copy-failed": "复制图片失败"
+  },
+  "zh-TW": {
+    "scale": "倍率",
+    "quality": "品質",
+    "copy-to-clipboard": "複製到剪貼簿",
+    "copy-success": "圖片已複製到剪貼簿",
+    "copy-failed": "複製圖片失敗"
+  },
+  "zh-HK": {
+    "scale": "倍率",
+    "quality": "質素",
+    "copy-to-clipboard": "複製到剪貼簿",
+    "copy-success": "圖片已複製到剪貼簿",
+    "copy-failed": "複製圖片失敗"
+  },
+  "es": {
+    "scale": "Escala",
+    "quality": "Calidad",
+    "copy-to-clipboard": "Copiar al portapapeles",
+    "copy-success": "Imagen copiada al portapapeles",
+    "copy-failed": "Error al copiar imagen"
+  },
+  "fr": {
+    "scale": "Échelle",
+    "quality": "Qualité",
+    "copy-to-clipboard": "Copier dans le presse-papiers",
+    "copy-success": "Image copiée dans le presse-papiers",
+    "copy-failed": "Échec de la copie de l'image"
+  },
+  "de": {
+    "scale": "Skalierung",
+    "quality": "Qualität",
+    "copy-to-clipboard": "In Zwischenablage kopieren",
+    "copy-success": "Bild in Zwischenablage kopiert",
+    "copy-failed": "Fehler beim Kopieren des Bildes"
+  },
+  "it": {
+    "scale": "Scala",
+    "quality": "Qualità",
+    "copy-to-clipboard": "Copia negli appunti",
+    "copy-success": "Immagine copiata negli appunti",
+    "copy-failed": "Impossibile copiare l'immagine"
+  },
+  "ja": {
+    "scale": "スケール",
+    "quality": "品質",
+    "copy-to-clipboard": "クリップボードにコピー",
+    "copy-success": "画像をクリップボードにコピーしました",
+    "copy-failed": "画像のコピーに失敗しました"
+  },
+  "ko": {
+    "scale": "배율",
+    "quality": "품질",
+    "copy-to-clipboard": "클립보드에 복사",
+    "copy-success": "이미지가 클립보드에 복사되었습니다",
+    "copy-failed": "이미지 복사 실패"
+  },
+  "ru": {
+    "scale": "Масштаб",
+    "quality": "Качество",
+    "copy-to-clipboard": "Копировать в буфер обмена",
+    "copy-success": "Изображение скопировано в буфер обмена",
+    "copy-failed": "Не удалось скопировать изображение"
+  },
+  "pt": {
+    "scale": "Escala",
+    "quality": "Qualidade",
+    "copy-to-clipboard": "Copiar para a área de transferência",
+    "copy-success": "Imagem copiada para a área de transferência",
+    "copy-failed": "Falha ao copiar imagem"
+  },
+  "ar": {
+    "scale": "المقياس",
+    "quality": "الجودة",
+    "copy-to-clipboard": "نسخ إلى الحافظة",
+    "copy-success": "تم نسخ الصورة إلى الحافظة",
+    "copy-failed": "فشل نسخ الصورة"
+  },
+  "hi": {
+    "scale": "स्केल",
+    "quality": "गुणवत्ता",
+    "copy-to-clipboard": "क्लिपबोर्ड पर कॉपी करें",
+    "copy-success": "छवि क्लिपबोर्ड पर कॉपी की गई",
+    "copy-failed": "छवि कॉपी करने में विफल"
+  },
+  "tr": {
+    "scale": "Ölçek",
+    "quality": "Kalite",
+    "copy-to-clipboard": "Panoya kopyala",
+    "copy-success": "Görüntü panoya kopyalandı",
+    "copy-failed": "Görüntü kopyalanamadı"
+  },
+  "nl": {
+    "scale": "Schaal",
+    "quality": "Kwaliteit",
+    "copy-to-clipboard": "Kopiëren naar klembord",
+    "copy-success": "Afbeelding gekopieerd naar klembord",
+    "copy-failed": "Afbeelding kopiëren mislukt"
+  },
+  "sv": {
+    "scale": "Skala",
+    "quality": "Kvalitet",
+    "copy-to-clipboard": "Kopiera till urklipp",
+    "copy-success": "Bilden kopierades till urklipp",
+    "copy-failed": "Kunde inte kopiera bilden"
+  },
+  "pl": {
+    "scale": "Skala",
+    "quality": "Jakość",
+    "copy-to-clipboard": "Kopiuj do schowka",
+    "copy-success": "Obraz skopiowany do schowka",
+    "copy-failed": "Nie udało się skopiować obrazu"
+  },
+  "vi": {
+    "scale": "Tỷ lệ",
+    "quality": "Chất lượng",
+    "copy-to-clipboard": "Sao chép vào clipboard",
+    "copy-success": "Đã sao chép hình ảnh vào clipboard",
+    "copy-failed": "Không thể sao chép hình ảnh"
+  },
+  "th": {
+    "scale": "มาตราส่วน",
+    "quality": "คุณภาพ",
+    "copy-to-clipboard": "คัดลอกไปยังคลิปบอร์ด",
+    "copy-success": "คัดลอกรูปภาพไปยังคลิปบอร์ดแล้ว",
+    "copy-failed": "ไม่สามารถคัดลอกรูปภาพได้"
+  },
+  "id": {
+    "scale": "Skala",
+    "quality": "Kualitas",
+    "copy-to-clipboard": "Salin ke clipboard",
+    "copy-success": "Gambar disalin ke clipboard",
+    "copy-failed": "Gagal menyalin gambar"
+  },
+  "he": {
+    "scale": "קנה מידה",
+    "quality": "איכות",
+    "copy-to-clipboard": "העתק ללוח",
+    "copy-success": "התמונה הועתקה ללוח",
+    "copy-failed": "העתקת התמונה נכשלה"
+  },
+  "ms": {
+    "scale": "Skala",
+    "quality": "Kualiti",
+    "copy-to-clipboard": "Salin ke papan keratan",
+    "copy-success": "Imej disalin ke papan keratan",
+    "copy-failed": "Gagal menyalin imej"
+  },
+  "no": {
+    "scale": "Skala",
+    "quality": "Kvalitet",
+    "copy-to-clipboard": "Kopier til utklippstavle",
+    "copy-success": "Bilde kopiert til utklippstavle",
+    "copy-failed": "Kunne ikke kopiere bilde"
+  }
+}
+</i18n>

--- a/tools/image/placeholder-image-generator/src/components/PlaceholderImageGenerator.vue
+++ b/tools/image/placeholder-image-generator/src/components/PlaceholderImageGenerator.vue
@@ -1,0 +1,212 @@
+<template>
+  <n-grid cols="2 l:4" responsive="screen" :x-gap="40" :y-gap="20">
+    <n-gi span="2 l:3">
+      <ToolSectionHeader>{{ t('options') }}</ToolSectionHeader>
+      <ToolSection>
+        <PlaceholderOptionsForm
+          v-model:width="width"
+          v-model:height="height"
+          v-model:bg-type="bgType"
+          v-model:bg-color="bgColor"
+          v-model:gradient-color1="gradientColor1"
+          v-model:gradient-color2="gradientColor2"
+          v-model:gradient-angle="gradientAngle"
+          v-model:text-color="textColor"
+          v-model:custom-text="customText"
+          v-model:font-size="fontSize"
+        />
+      </ToolSection>
+    </n-gi>
+    <n-gi span="2 l:1">
+      <ToolSectionHeader>{{ t('preview') }}</ToolSectionHeader>
+      <ToolSection>
+        <PlaceholderPreview
+          :width="width"
+          :height="height"
+          :bg-type="bgType"
+          :bg-color="bgColor"
+          :gradient-color1="gradientColor1"
+          :gradient-color2="gradientColor2"
+          :gradient-angle="gradientAngle"
+          :text-color="textColor"
+          :custom-text="customText"
+          :font-size="fontSize"
+        />
+      </ToolSection>
+      <ToolSectionHeader>{{ t('export') }}</ToolSectionHeader>
+      <ToolSection>
+        <PlaceholderDownloadButtons :options="options" />
+      </ToolSection>
+    </n-gi>
+  </n-grid>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useStorage } from '@vueuse/core'
+import { useI18n } from 'vue-i18n'
+import { NGrid, NGi } from 'naive-ui'
+import { ToolSectionHeader, ToolSection } from '@shared/ui/tool'
+import PlaceholderOptionsForm from './PlaceholderOptionsForm.vue'
+import PlaceholderPreview from './PlaceholderPreview.vue'
+import PlaceholderDownloadButtons from './PlaceholderDownloadButtons.vue'
+
+const { t } = useI18n()
+
+const width = useStorage<number>('tools:placeholder:width', 800)
+const height = useStorage<number>('tools:placeholder:height', 600)
+const bgType = useStorage<'solid' | 'linear-gradient' | 'radial-gradient'>(
+  'tools:placeholder:bgType',
+  'solid',
+)
+const bgColor = useStorage<string>('tools:placeholder:bgColor', '#CCCCCC')
+const gradientColor1 = useStorage<string>('tools:placeholder:gradientColor1', '#667eea')
+const gradientColor2 = useStorage<string>('tools:placeholder:gradientColor2', '#764ba2')
+const gradientAngle = useStorage<number>('tools:placeholder:gradientAngle', 45)
+const textColor = useStorage<string>('tools:placeholder:textColor', '#969696')
+const customText = useStorage<string>('tools:placeholder:customText', '')
+const fontSize = useStorage<number>('tools:placeholder:fontSize', 0)
+
+const options = computed(() => ({
+  width: width.value,
+  height: height.value,
+  bgType: bgType.value,
+  bgColor: bgColor.value,
+  gradientColor1: gradientColor1.value,
+  gradientColor2: gradientColor2.value,
+  gradientAngle: gradientAngle.value,
+  textColor: textColor.value,
+  customText: customText.value,
+  fontSize: fontSize.value,
+}))
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "options": "Options",
+    "preview": "Preview",
+    "export": "Export"
+  },
+  "zh": {
+    "options": "选项",
+    "preview": "预览",
+    "export": "导出"
+  },
+  "zh-CN": {
+    "options": "选项",
+    "preview": "预览",
+    "export": "导出"
+  },
+  "zh-TW": {
+    "options": "選項",
+    "preview": "預覽",
+    "export": "匯出"
+  },
+  "zh-HK": {
+    "options": "選項",
+    "preview": "預覽",
+    "export": "匯出"
+  },
+  "es": {
+    "options": "Opciones",
+    "preview": "Vista previa",
+    "export": "Exportar"
+  },
+  "fr": {
+    "options": "Options",
+    "preview": "Aperçu",
+    "export": "Exporter"
+  },
+  "de": {
+    "options": "Optionen",
+    "preview": "Vorschau",
+    "export": "Exportieren"
+  },
+  "it": {
+    "options": "Opzioni",
+    "preview": "Anteprima",
+    "export": "Esporta"
+  },
+  "ja": {
+    "options": "オプション",
+    "preview": "プレビュー",
+    "export": "エクスポート"
+  },
+  "ko": {
+    "options": "옵션",
+    "preview": "미리보기",
+    "export": "내보내기"
+  },
+  "ru": {
+    "options": "Параметры",
+    "preview": "Предпросмотр",
+    "export": "Экспорт"
+  },
+  "pt": {
+    "options": "Opções",
+    "preview": "Pré-visualização",
+    "export": "Exportar"
+  },
+  "ar": {
+    "options": "الخيارات",
+    "preview": "معاينة",
+    "export": "تصدير"
+  },
+  "hi": {
+    "options": "विकल्प",
+    "preview": "पूर्वावलोकन",
+    "export": "निर्यात"
+  },
+  "tr": {
+    "options": "Seçenekler",
+    "preview": "Önizleme",
+    "export": "Dışa aktar"
+  },
+  "nl": {
+    "options": "Opties",
+    "preview": "Voorbeeld",
+    "export": "Exporteren"
+  },
+  "sv": {
+    "options": "Alternativ",
+    "preview": "Förhandsvisning",
+    "export": "Exportera"
+  },
+  "pl": {
+    "options": "Opcje",
+    "preview": "Podgląd",
+    "export": "Eksportuj"
+  },
+  "vi": {
+    "options": "Tùy chọn",
+    "preview": "Xem trước",
+    "export": "Xuất"
+  },
+  "th": {
+    "options": "ตัวเลือก",
+    "preview": "ดูตัวอย่าง",
+    "export": "ส่งออก"
+  },
+  "id": {
+    "options": "Opsi",
+    "preview": "Pratinjau",
+    "export": "Ekspor"
+  },
+  "he": {
+    "options": "אפשרויות",
+    "preview": "תצוגה מקדימה",
+    "export": "ייצוא"
+  },
+  "ms": {
+    "options": "Pilihan",
+    "preview": "Pratonton",
+    "export": "Eksport"
+  },
+  "no": {
+    "options": "Alternativer",
+    "preview": "Forhåndsvisning",
+    "export": "Eksporter"
+  }
+}
+</i18n>

--- a/tools/image/placeholder-image-generator/src/components/PlaceholderOptionsForm.vue
+++ b/tools/image/placeholder-image-generator/src/components/PlaceholderOptionsForm.vue
@@ -1,0 +1,659 @@
+<template>
+  <n-grid cols="1 s:2 m:3" responsive="screen" :x-gap="20" :y-gap="20">
+    <!-- Presets -->
+    <n-form-item-gi :label="t('preset')" :show-feedback="false">
+      <n-select
+        :value="currentPresetIndex"
+        :options="presetOptions"
+        :placeholder="t('preset-placeholder')"
+        clearable
+        @update:value="applyPreset"
+      />
+    </n-form-item-gi>
+
+    <!-- Width -->
+    <n-form-item-gi :label="t('width')" :show-feedback="false">
+      <n-input-number
+        :value="width"
+        :min="1"
+        :max="4096"
+        :step="1"
+        style="width: 100%"
+        @update:value="(v) => $emit('update:width', v ?? 800)"
+      />
+    </n-form-item-gi>
+
+    <!-- Height -->
+    <n-form-item-gi :label="t('height')" :show-feedback="false">
+      <n-input-number
+        :value="height"
+        :min="1"
+        :max="4096"
+        :step="1"
+        style="width: 100%"
+        @update:value="(v) => $emit('update:height', v ?? 600)"
+      />
+    </n-form-item-gi>
+
+    <!-- Background Type -->
+    <n-form-item-gi :label="t('bg-type')" :show-feedback="false" span="1 s:2 m:3">
+      <n-radio-group :value="bgType" @update:value="(v) => $emit('update:bgType', v)">
+        <n-radio-button value="solid">{{ t('solid') }}</n-radio-button>
+        <n-radio-button value="linear-gradient">{{ t('linear-gradient') }}</n-radio-button>
+        <n-radio-button value="radial-gradient">{{ t('radial-gradient') }}</n-radio-button>
+      </n-radio-group>
+    </n-form-item-gi>
+
+    <!-- Solid Color -->
+    <n-form-item-gi v-if="bgType === 'solid'" :label="t('bg-color')" :show-feedback="false">
+      <n-color-picker
+        :value="bgColor"
+        :modes="['hex']"
+        :show-alpha="true"
+        @update:value="(v) => $emit('update:bgColor', v)"
+      />
+    </n-form-item-gi>
+
+    <!-- Gradient Colors -->
+    <template v-if="bgType !== 'solid'">
+      <n-form-item-gi :label="t('gradient-color-1')" :show-feedback="false">
+        <n-color-picker
+          :value="gradientColor1"
+          :modes="['hex']"
+          :show-alpha="true"
+          @update:value="(v) => $emit('update:gradientColor1', v)"
+        />
+      </n-form-item-gi>
+      <n-form-item-gi :label="t('gradient-color-2')" :show-feedback="false">
+        <n-color-picker
+          :value="gradientColor2"
+          :modes="['hex']"
+          :show-alpha="true"
+          @update:value="(v) => $emit('update:gradientColor2', v)"
+        />
+      </n-form-item-gi>
+    </template>
+
+    <!-- Gradient Angle (linear only) -->
+    <n-form-item-gi
+      v-if="bgType === 'linear-gradient'"
+      :label="t('gradient-angle')"
+      :show-feedback="false"
+    >
+      <n-slider
+        :value="gradientAngle"
+        :min="0"
+        :max="360"
+        :step="1"
+        :format-tooltip="(v) => `${v}°`"
+        @update:value="(v) => $emit('update:gradientAngle', v)"
+      />
+    </n-form-item-gi>
+
+    <!-- Text Color -->
+    <n-form-item-gi :label="t('text-color')" :show-feedback="false">
+      <n-color-picker
+        :value="textColor"
+        :modes="['hex']"
+        :show-alpha="true"
+        @update:value="(v) => $emit('update:textColor', v)"
+      />
+    </n-form-item-gi>
+
+    <!-- Custom Text -->
+    <n-form-item-gi :label="t('custom-text')" :show-feedback="false" span="1 s:2">
+      <n-input
+        :value="customText"
+        :placeholder="`${width} × ${height}`"
+        clearable
+        @update:value="(v) => $emit('update:customText', v ?? '')"
+      />
+    </n-form-item-gi>
+
+    <!-- Font Size -->
+    <n-form-item-gi :label="t('font-size')" :show-feedback="false">
+      <n-input-number
+        :value="fontSize"
+        :min="0"
+        :max="500"
+        :step="1"
+        :placeholder="t('auto')"
+        style="width: 100%"
+        clearable
+        @update:value="(v) => $emit('update:fontSize', v ?? 0)"
+      />
+    </n-form-item-gi>
+  </n-grid>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import {
+  NGrid,
+  NFormItemGi,
+  NInputNumber,
+  NInput,
+  NSelect,
+  NColorPicker,
+  NSlider,
+  NRadioGroup,
+  NRadioButton,
+} from 'naive-ui'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  width: number
+  height: number
+  bgType: 'solid' | 'linear-gradient' | 'radial-gradient'
+  bgColor: string
+  gradientColor1: string
+  gradientColor2: string
+  gradientAngle: number
+  textColor: string
+  customText: string
+  fontSize: number
+}>()
+
+const emit = defineEmits<{
+  'update:width': [value: number]
+  'update:height': [value: number]
+  'update:bgType': [value: 'solid' | 'linear-gradient' | 'radial-gradient']
+  'update:bgColor': [value: string]
+  'update:gradientColor1': [value: string]
+  'update:gradientColor2': [value: string]
+  'update:gradientAngle': [value: number]
+  'update:textColor': [value: string]
+  'update:customText': [value: string]
+  'update:fontSize': [value: number]
+}>()
+
+const presets = [
+  { label: 'HD (1280×720)', width: 1280, height: 720 },
+  { label: 'Full HD (1920×1080)', width: 1920, height: 1080 },
+  { label: '4K (3840×2160)', width: 3840, height: 2160 },
+  { label: 'Square (500×500)', width: 500, height: 500 },
+  { label: 'Instagram Post (1080×1080)', width: 1080, height: 1080 },
+  { label: 'Instagram Story (1080×1920)', width: 1080, height: 1920 },
+  { label: 'Facebook Cover (820×312)', width: 820, height: 312 },
+  { label: 'Twitter Header (1500×500)', width: 1500, height: 500 },
+  { label: 'Thumbnail (150×150)', width: 150, height: 150 },
+  { label: 'Banner (728×90)', width: 728, height: 90 },
+]
+
+const presetOptions = computed(() =>
+  presets.map((p, i) => ({
+    label: p.label,
+    value: i,
+  })),
+)
+
+const currentPresetIndex = computed(() => {
+  const index = presets.findIndex((p) => p.width === props.width && p.height === props.height)
+  return index === -1 ? null : index
+})
+
+function applyPreset(index: number | null) {
+  if (index === null) return
+  const preset = presets[index]
+  if (!preset) return
+  emit('update:width', preset.width)
+  emit('update:height', preset.height)
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "preset": "Preset",
+    "preset-placeholder": "Select a preset size",
+    "width": "Width (px)",
+    "height": "Height (px)",
+    "bg-type": "Background Type",
+    "solid": "Solid",
+    "linear-gradient": "Linear Gradient",
+    "radial-gradient": "Radial Gradient",
+    "bg-color": "Background Color",
+    "gradient-color-1": "Gradient Color 1",
+    "gradient-color-2": "Gradient Color 2",
+    "gradient-angle": "Gradient Angle",
+    "text-color": "Text Color",
+    "custom-text": "Custom Text",
+    "font-size": "Font Size (px)",
+    "auto": "Auto"
+  },
+  "zh": {
+    "preset": "预设",
+    "preset-placeholder": "选择预设尺寸",
+    "width": "宽度 (px)",
+    "height": "高度 (px)",
+    "bg-type": "背景类型",
+    "solid": "纯色",
+    "linear-gradient": "线性渐变",
+    "radial-gradient": "径向渐变",
+    "bg-color": "背景颜色",
+    "gradient-color-1": "渐变颜色 1",
+    "gradient-color-2": "渐变颜色 2",
+    "gradient-angle": "渐变角度",
+    "text-color": "文字颜色",
+    "custom-text": "自定义文字",
+    "font-size": "字体大小 (px)",
+    "auto": "自动"
+  },
+  "zh-CN": {
+    "preset": "预设",
+    "preset-placeholder": "选择预设尺寸",
+    "width": "宽度 (px)",
+    "height": "高度 (px)",
+    "bg-type": "背景类型",
+    "solid": "纯色",
+    "linear-gradient": "线性渐变",
+    "radial-gradient": "径向渐变",
+    "bg-color": "背景颜色",
+    "gradient-color-1": "渐变颜色 1",
+    "gradient-color-2": "渐变颜色 2",
+    "gradient-angle": "渐变角度",
+    "text-color": "文字颜色",
+    "custom-text": "自定义文字",
+    "font-size": "字体大小 (px)",
+    "auto": "自动"
+  },
+  "zh-TW": {
+    "preset": "預設",
+    "preset-placeholder": "選擇預設尺寸",
+    "width": "寬度 (px)",
+    "height": "高度 (px)",
+    "bg-type": "背景類型",
+    "solid": "純色",
+    "linear-gradient": "線性漸層",
+    "radial-gradient": "徑向漸層",
+    "bg-color": "背景顏色",
+    "gradient-color-1": "漸層顏色 1",
+    "gradient-color-2": "漸層顏色 2",
+    "gradient-angle": "漸層角度",
+    "text-color": "文字顏色",
+    "custom-text": "自訂文字",
+    "font-size": "字體大小 (px)",
+    "auto": "自動"
+  },
+  "zh-HK": {
+    "preset": "預設",
+    "preset-placeholder": "選擇預設尺寸",
+    "width": "寬度 (px)",
+    "height": "高度 (px)",
+    "bg-type": "背景類型",
+    "solid": "純色",
+    "linear-gradient": "線性漸變",
+    "radial-gradient": "徑向漸變",
+    "bg-color": "背景顏色",
+    "gradient-color-1": "漸變顏色 1",
+    "gradient-color-2": "漸變顏色 2",
+    "gradient-angle": "漸變角度",
+    "text-color": "文字顏色",
+    "custom-text": "自訂文字",
+    "font-size": "字體大小 (px)",
+    "auto": "自動"
+  },
+  "es": {
+    "preset": "Preajuste",
+    "preset-placeholder": "Seleccionar un tamaño preajustado",
+    "width": "Ancho (px)",
+    "height": "Alto (px)",
+    "bg-type": "Tipo de fondo",
+    "solid": "Sólido",
+    "linear-gradient": "Degradado lineal",
+    "radial-gradient": "Degradado radial",
+    "bg-color": "Color de fondo",
+    "gradient-color-1": "Color de degradado 1",
+    "gradient-color-2": "Color de degradado 2",
+    "gradient-angle": "Ángulo del degradado",
+    "text-color": "Color del texto",
+    "custom-text": "Texto personalizado",
+    "font-size": "Tamaño de fuente (px)",
+    "auto": "Automático"
+  },
+  "fr": {
+    "preset": "Prédéfini",
+    "preset-placeholder": "Sélectionner une taille prédéfinie",
+    "width": "Largeur (px)",
+    "height": "Hauteur (px)",
+    "bg-type": "Type de fond",
+    "solid": "Uni",
+    "linear-gradient": "Dégradé linéaire",
+    "radial-gradient": "Dégradé radial",
+    "bg-color": "Couleur de fond",
+    "gradient-color-1": "Couleur de dégradé 1",
+    "gradient-color-2": "Couleur de dégradé 2",
+    "gradient-angle": "Angle du dégradé",
+    "text-color": "Couleur du texte",
+    "custom-text": "Texte personnalisé",
+    "font-size": "Taille de police (px)",
+    "auto": "Auto"
+  },
+  "de": {
+    "preset": "Voreinstellung",
+    "preset-placeholder": "Voreingestellte Größe wählen",
+    "width": "Breite (px)",
+    "height": "Höhe (px)",
+    "bg-type": "Hintergrundtyp",
+    "solid": "Einfarbig",
+    "linear-gradient": "Linearer Verlauf",
+    "radial-gradient": "Radialer Verlauf",
+    "bg-color": "Hintergrundfarbe",
+    "gradient-color-1": "Verlaufsfarbe 1",
+    "gradient-color-2": "Verlaufsfarbe 2",
+    "gradient-angle": "Verlaufswinkel",
+    "text-color": "Textfarbe",
+    "custom-text": "Benutzerdefinierter Text",
+    "font-size": "Schriftgröße (px)",
+    "auto": "Auto"
+  },
+  "it": {
+    "preset": "Preimpostazione",
+    "preset-placeholder": "Seleziona una dimensione preimpostata",
+    "width": "Larghezza (px)",
+    "height": "Altezza (px)",
+    "bg-type": "Tipo di sfondo",
+    "solid": "Solido",
+    "linear-gradient": "Gradiente lineare",
+    "radial-gradient": "Gradiente radiale",
+    "bg-color": "Colore di sfondo",
+    "gradient-color-1": "Colore gradiente 1",
+    "gradient-color-2": "Colore gradiente 2",
+    "gradient-angle": "Angolo del gradiente",
+    "text-color": "Colore del testo",
+    "custom-text": "Testo personalizzato",
+    "font-size": "Dimensione carattere (px)",
+    "auto": "Auto"
+  },
+  "ja": {
+    "preset": "プリセット",
+    "preset-placeholder": "プリセットサイズを選択",
+    "width": "幅 (px)",
+    "height": "高さ (px)",
+    "bg-type": "背景タイプ",
+    "solid": "単色",
+    "linear-gradient": "線形グラデーション",
+    "radial-gradient": "放射状グラデーション",
+    "bg-color": "背景色",
+    "gradient-color-1": "グラデーション色 1",
+    "gradient-color-2": "グラデーション色 2",
+    "gradient-angle": "グラデーション角度",
+    "text-color": "テキスト色",
+    "custom-text": "カスタムテキスト",
+    "font-size": "フォントサイズ (px)",
+    "auto": "自動"
+  },
+  "ko": {
+    "preset": "프리셋",
+    "preset-placeholder": "프리셋 크기 선택",
+    "width": "너비 (px)",
+    "height": "높이 (px)",
+    "bg-type": "배경 유형",
+    "solid": "단색",
+    "linear-gradient": "선형 그라데이션",
+    "radial-gradient": "방사형 그라데이션",
+    "bg-color": "배경색",
+    "gradient-color-1": "그라데이션 색상 1",
+    "gradient-color-2": "그라데이션 색상 2",
+    "gradient-angle": "그라데이션 각도",
+    "text-color": "텍스트 색상",
+    "custom-text": "사용자 정의 텍스트",
+    "font-size": "글꼴 크기 (px)",
+    "auto": "자동"
+  },
+  "ru": {
+    "preset": "Пресет",
+    "preset-placeholder": "Выберите предустановленный размер",
+    "width": "Ширина (px)",
+    "height": "Высота (px)",
+    "bg-type": "Тип фона",
+    "solid": "Сплошной",
+    "linear-gradient": "Линейный градиент",
+    "radial-gradient": "Радиальный градиент",
+    "bg-color": "Цвет фона",
+    "gradient-color-1": "Цвет градиента 1",
+    "gradient-color-2": "Цвет градиента 2",
+    "gradient-angle": "Угол градиента",
+    "text-color": "Цвет текста",
+    "custom-text": "Пользовательский текст",
+    "font-size": "Размер шрифта (px)",
+    "auto": "Авто"
+  },
+  "pt": {
+    "preset": "Predefinição",
+    "preset-placeholder": "Selecionar tamanho predefinido",
+    "width": "Largura (px)",
+    "height": "Altura (px)",
+    "bg-type": "Tipo de fundo",
+    "solid": "Sólido",
+    "linear-gradient": "Gradiente linear",
+    "radial-gradient": "Gradiente radial",
+    "bg-color": "Cor de fundo",
+    "gradient-color-1": "Cor do gradiente 1",
+    "gradient-color-2": "Cor do gradiente 2",
+    "gradient-angle": "Ângulo do gradiente",
+    "text-color": "Cor do texto",
+    "custom-text": "Texto personalizado",
+    "font-size": "Tamanho da fonte (px)",
+    "auto": "Auto"
+  },
+  "ar": {
+    "preset": "إعداد مسبق",
+    "preset-placeholder": "اختر حجمًا مسبقًا",
+    "width": "العرض (px)",
+    "height": "الارتفاع (px)",
+    "bg-type": "نوع الخلفية",
+    "solid": "صلب",
+    "linear-gradient": "تدرج خطي",
+    "radial-gradient": "تدرج شعاعي",
+    "bg-color": "لون الخلفية",
+    "gradient-color-1": "لون التدرج 1",
+    "gradient-color-2": "لون التدرج 2",
+    "gradient-angle": "زاوية التدرج",
+    "text-color": "لون النص",
+    "custom-text": "نص مخصص",
+    "font-size": "حجم الخط (px)",
+    "auto": "تلقائي"
+  },
+  "hi": {
+    "preset": "प्रीसेट",
+    "preset-placeholder": "प्रीसेट आकार चुनें",
+    "width": "चौड़ाई (px)",
+    "height": "ऊंचाई (px)",
+    "bg-type": "पृष्ठभूमि प्रकार",
+    "solid": "ठोस",
+    "linear-gradient": "रैखिक ग्रेडिएंट",
+    "radial-gradient": "रेडियल ग्रेडिएंट",
+    "bg-color": "पृष्ठभूमि रंग",
+    "gradient-color-1": "ग्रेडिएंट रंग 1",
+    "gradient-color-2": "ग्रेडिएंट रंग 2",
+    "gradient-angle": "ग्रेडिएंट कोण",
+    "text-color": "टेक्स्ट रंग",
+    "custom-text": "कस्टम टेक्स्ट",
+    "font-size": "फ़ॉन्ट आकार (px)",
+    "auto": "स्वचालित"
+  },
+  "tr": {
+    "preset": "Ön ayar",
+    "preset-placeholder": "Ön ayarlı boyut seçin",
+    "width": "Genişlik (px)",
+    "height": "Yükseklik (px)",
+    "bg-type": "Arka plan türü",
+    "solid": "Düz",
+    "linear-gradient": "Doğrusal degrade",
+    "radial-gradient": "Radyal degrade",
+    "bg-color": "Arka plan rengi",
+    "gradient-color-1": "Degrade rengi 1",
+    "gradient-color-2": "Degrade rengi 2",
+    "gradient-angle": "Degrade açısı",
+    "text-color": "Metin rengi",
+    "custom-text": "Özel metin",
+    "font-size": "Yazı tipi boyutu (px)",
+    "auto": "Otomatik"
+  },
+  "nl": {
+    "preset": "Voorinstelling",
+    "preset-placeholder": "Selecteer een vooringestelde grootte",
+    "width": "Breedte (px)",
+    "height": "Hoogte (px)",
+    "bg-type": "Achtergrondtype",
+    "solid": "Effen",
+    "linear-gradient": "Lineair verloop",
+    "radial-gradient": "Radiaal verloop",
+    "bg-color": "Achtergrondkleur",
+    "gradient-color-1": "Verloopkleur 1",
+    "gradient-color-2": "Verloopkleur 2",
+    "gradient-angle": "Verloophoek",
+    "text-color": "Tekstkleur",
+    "custom-text": "Aangepaste tekst",
+    "font-size": "Lettergrootte (px)",
+    "auto": "Auto"
+  },
+  "sv": {
+    "preset": "Förinställning",
+    "preset-placeholder": "Välj en förinställd storlek",
+    "width": "Bredd (px)",
+    "height": "Höjd (px)",
+    "bg-type": "Bakgrundstyp",
+    "solid": "Enfärgad",
+    "linear-gradient": "Linjär gradient",
+    "radial-gradient": "Radiell gradient",
+    "bg-color": "Bakgrundsfärg",
+    "gradient-color-1": "Gradientfärg 1",
+    "gradient-color-2": "Gradientfärg 2",
+    "gradient-angle": "Gradientvinkel",
+    "text-color": "Textfärg",
+    "custom-text": "Anpassad text",
+    "font-size": "Teckenstorlek (px)",
+    "auto": "Auto"
+  },
+  "pl": {
+    "preset": "Preset",
+    "preset-placeholder": "Wybierz rozmiar predefiniowany",
+    "width": "Szerokość (px)",
+    "height": "Wysokość (px)",
+    "bg-type": "Typ tła",
+    "solid": "Jednolity",
+    "linear-gradient": "Gradient liniowy",
+    "radial-gradient": "Gradient radialny",
+    "bg-color": "Kolor tła",
+    "gradient-color-1": "Kolor gradientu 1",
+    "gradient-color-2": "Kolor gradientu 2",
+    "gradient-angle": "Kąt gradientu",
+    "text-color": "Kolor tekstu",
+    "custom-text": "Własny tekst",
+    "font-size": "Rozmiar czcionki (px)",
+    "auto": "Auto"
+  },
+  "vi": {
+    "preset": "Cài đặt sẵn",
+    "preset-placeholder": "Chọn kích thước cài đặt sẵn",
+    "width": "Chiều rộng (px)",
+    "height": "Chiều cao (px)",
+    "bg-type": "Loại nền",
+    "solid": "Màu đặc",
+    "linear-gradient": "Gradient tuyến tính",
+    "radial-gradient": "Gradient xuyên tâm",
+    "bg-color": "Màu nền",
+    "gradient-color-1": "Màu gradient 1",
+    "gradient-color-2": "Màu gradient 2",
+    "gradient-angle": "Góc gradient",
+    "text-color": "Màu chữ",
+    "custom-text": "Văn bản tùy chỉnh",
+    "font-size": "Cỡ chữ (px)",
+    "auto": "Tự động"
+  },
+  "th": {
+    "preset": "ค่าที่ตั้งไว้ล่วงหน้า",
+    "preset-placeholder": "เลือกขนาดที่ตั้งไว้ล่วงหน้า",
+    "width": "ความกว้าง (px)",
+    "height": "ความสูง (px)",
+    "bg-type": "ประเภทพื้นหลัง",
+    "solid": "สีเดียว",
+    "linear-gradient": "การไล่ระดับสีเชิงเส้น",
+    "radial-gradient": "การไล่ระดับสีแบบรัศมี",
+    "bg-color": "สีพื้นหลัง",
+    "gradient-color-1": "สีไล่ระดับ 1",
+    "gradient-color-2": "สีไล่ระดับ 2",
+    "gradient-angle": "มุมการไล่ระดับ",
+    "text-color": "สีข้อความ",
+    "custom-text": "ข้อความที่กำหนดเอง",
+    "font-size": "ขนาดตัวอักษร (px)",
+    "auto": "อัตโนมัติ"
+  },
+  "id": {
+    "preset": "Preset",
+    "preset-placeholder": "Pilih ukuran preset",
+    "width": "Lebar (px)",
+    "height": "Tinggi (px)",
+    "bg-type": "Jenis latar belakang",
+    "solid": "Solid",
+    "linear-gradient": "Gradien linier",
+    "radial-gradient": "Gradien radial",
+    "bg-color": "Warna latar belakang",
+    "gradient-color-1": "Warna gradien 1",
+    "gradient-color-2": "Warna gradien 2",
+    "gradient-angle": "Sudut gradien",
+    "text-color": "Warna teks",
+    "custom-text": "Teks kustom",
+    "font-size": "Ukuran font (px)",
+    "auto": "Otomatis"
+  },
+  "he": {
+    "preset": "הגדרה קבועה מראש",
+    "preset-placeholder": "בחר גודל קבוע מראש",
+    "width": "רוחב (px)",
+    "height": "גובה (px)",
+    "bg-type": "סוג רקע",
+    "solid": "אחיד",
+    "linear-gradient": "מעבר צבע ליניארי",
+    "radial-gradient": "מעבר צבע רדיאלי",
+    "bg-color": "צבע רקע",
+    "gradient-color-1": "צבע מעבר 1",
+    "gradient-color-2": "צבע מעבר 2",
+    "gradient-angle": "זווית מעבר",
+    "text-color": "צבע טקסט",
+    "custom-text": "טקסט מותאם אישית",
+    "font-size": "גודל גופן (px)",
+    "auto": "אוטומטי"
+  },
+  "ms": {
+    "preset": "Pratetap",
+    "preset-placeholder": "Pilih saiz pratetap",
+    "width": "Lebar (px)",
+    "height": "Tinggi (px)",
+    "bg-type": "Jenis latar belakang",
+    "solid": "Pepejal",
+    "linear-gradient": "Kecerunan linear",
+    "radial-gradient": "Kecerunan jejari",
+    "bg-color": "Warna latar belakang",
+    "gradient-color-1": "Warna kecerunan 1",
+    "gradient-color-2": "Warna kecerunan 2",
+    "gradient-angle": "Sudut kecerunan",
+    "text-color": "Warna teks",
+    "custom-text": "Teks tersuai",
+    "font-size": "Saiz fon (px)",
+    "auto": "Auto"
+  },
+  "no": {
+    "preset": "Forhåndsinnstilling",
+    "preset-placeholder": "Velg en forhåndsinnstilt størrelse",
+    "width": "Bredde (px)",
+    "height": "Høyde (px)",
+    "bg-type": "Bakgrunnstype",
+    "solid": "Ensfarget",
+    "linear-gradient": "Lineær gradient",
+    "radial-gradient": "Radiell gradient",
+    "bg-color": "Bakgrunnsfarge",
+    "gradient-color-1": "Gradientfarge 1",
+    "gradient-color-2": "Gradientfarge 2",
+    "gradient-angle": "Gradientvinkel",
+    "text-color": "Tekstfarge",
+    "custom-text": "Egendefinert tekst",
+    "font-size": "Skriftstørrelse (px)",
+    "auto": "Auto"
+  }
+}
+</i18n>

--- a/tools/image/placeholder-image-generator/src/components/PlaceholderPreview.vue
+++ b/tools/image/placeholder-image-generator/src/components/PlaceholderPreview.vue
@@ -1,0 +1,145 @@
+<template>
+  <n-flex align="center" vertical :size="12">
+    <img
+      :src="svgDataUri"
+      :style="{ maxWidth: '100%', border: '1px solid var(--n-border-color)' }"
+    />
+  </n-flex>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useDebounce } from '@vueuse/core'
+import { NFlex } from 'naive-ui'
+
+export interface PlaceholderOptions {
+  width: number
+  height: number
+  bgType: 'solid' | 'linear-gradient' | 'radial-gradient'
+  bgColor: string
+  gradientColor1: string
+  gradientColor2: string
+  gradientAngle: number
+  textColor: string
+  customText: string
+  fontSize: number
+}
+
+const props = defineProps<PlaceholderOptions>()
+
+const input = computed(() => ({
+  width: props.width,
+  height: props.height,
+  bgType: props.bgType,
+  bgColor: props.bgColor,
+  gradientColor1: props.gradientColor1,
+  gradientColor2: props.gradientColor2,
+  gradientAngle: props.gradientAngle,
+  textColor: props.textColor,
+  customText: props.customText,
+  fontSize: props.fontSize,
+}))
+
+const debouncedInput = useDebounce(input, 150)
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+function generateSVG(options: PlaceholderOptions, scale = 1): string {
+  const w = options.width * scale
+  const h = options.height * scale
+  const text = options.customText || `${options.width} × ${options.height}`
+  const baseFontSize = options.fontSize || Math.min(options.width, options.height) / 8
+  const fontSize = baseFontSize * scale
+
+  let defs = ''
+  let fill = options.bgColor
+
+  if (options.bgType === 'linear-gradient') {
+    const angle = options.gradientAngle
+    defs = `<defs>
+      <linearGradient id="grad" gradientTransform="rotate(${angle}, 0.5, 0.5)">
+        <stop offset="0%" stop-color="${options.gradientColor1}"/>
+        <stop offset="100%" stop-color="${options.gradientColor2}"/>
+      </linearGradient>
+    </defs>`
+    fill = 'url(#grad)'
+  } else if (options.bgType === 'radial-gradient') {
+    defs = `<defs>
+      <radialGradient id="grad" cx="50%" cy="50%" r="50%">
+        <stop offset="0%" stop-color="${options.gradientColor1}"/>
+        <stop offset="100%" stop-color="${options.gradientColor2}"/>
+      </radialGradient>
+    </defs>`
+    fill = 'url(#grad)'
+  }
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">
+  ${defs}
+  <rect width="100%" height="100%" fill="${fill}"/>
+  <text x="50%" y="50%" fill="${options.textColor}" font-size="${fontSize}"
+        font-family="sans-serif" text-anchor="middle" dominant-baseline="middle">
+    ${escapeXml(text)}
+  </text>
+</svg>`
+}
+
+const svgDataUri = computed(() => {
+  const svg = generateSVG(debouncedInput.value)
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+})
+
+// Expose functions for external use (download buttons)
+defineExpose({
+  drawToCanvas: (canvas: HTMLCanvasElement, scale = 1) => {
+    const options = input.value
+    const w = options.width * scale
+    const h = options.height * scale
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    canvas.width = w
+    canvas.height = h
+
+    // Background
+    if (options.bgType === 'solid') {
+      ctx.fillStyle = options.bgColor
+    } else if (options.bgType === 'linear-gradient') {
+      const angle = (options.gradientAngle * Math.PI) / 180
+      const x1 = w / 2 - Math.cos(angle) * (w / 2)
+      const y1 = h / 2 - Math.sin(angle) * (h / 2)
+      const x2 = w / 2 + Math.cos(angle) * (w / 2)
+      const y2 = h / 2 + Math.sin(angle) * (h / 2)
+      const gradient = ctx.createLinearGradient(x1, y1, x2, y2)
+      gradient.addColorStop(0, options.gradientColor1)
+      gradient.addColorStop(1, options.gradientColor2)
+      ctx.fillStyle = gradient
+    } else if (options.bgType === 'radial-gradient') {
+      const gradient = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) / 2)
+      gradient.addColorStop(0, options.gradientColor1)
+      gradient.addColorStop(1, options.gradientColor2)
+      ctx.fillStyle = gradient
+    }
+    ctx.fillRect(0, 0, w, h)
+
+    // Text
+    const text = options.customText || `${options.width} × ${options.height}`
+    const baseFontSize = options.fontSize || Math.min(options.width, options.height) / 8
+    const fontSize = baseFontSize * scale
+    ctx.fillStyle = options.textColor
+    ctx.font = `${fontSize}px sans-serif`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(text, w / 2, h / 2)
+  },
+  generateSVG: (scale = 1) => generateSVG(input.value, scale),
+  getOptions: () => input.value,
+})
+</script>

--- a/tools/image/placeholder-image-generator/src/index.ts
+++ b/tools/image/placeholder-image-generator/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/image/placeholder-image-generator/src/info.ts
+++ b/tools/image/placeholder-image-generator/src/info.ts
@@ -1,0 +1,146 @@
+export const toolID = 'placeholder-image-generator'
+export { ImageCopy24Regular as icon } from '@shared/icons/fluent'
+export const path = '/tools/placeholder-image-generator'
+export const tags = [
+  'placeholder',
+  'image',
+  'generator',
+  'dummy',
+  'mockup',
+  'design',
+  'png',
+  'jpg',
+  'svg',
+  'webp',
+  'gradient',
+  'retina',
+]
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Placeholder Image Generator',
+    description:
+      'Generate placeholder images with custom dimensions, colors, gradients, and text. Export as PNG, JPG, SVG, or WebP with Retina support.',
+  },
+  zh: {
+    name: '占位图生成器',
+    description:
+      '生成自定义尺寸、颜色、渐变和文字的占位图。支持 PNG、JPG、SVG、WebP 格式及 Retina 高清输出。',
+  },
+  'zh-CN': {
+    name: '占位图生成器',
+    description:
+      '生成自定义尺寸、颜色、渐变和文字的占位图。支持 PNG、JPG、SVG、WebP 格式及 Retina 高清输出。',
+  },
+  'zh-TW': {
+    name: '佔位圖產生器',
+    description:
+      '產生自訂尺寸、顏色、漸層和文字的佔位圖。支援 PNG、JPG、SVG、WebP 格式及 Retina 高清輸出。',
+  },
+  'zh-HK': {
+    name: '佔位圖產生器',
+    description:
+      '產生自訂尺寸、顏色、漸變和文字的佔位圖。支援 PNG、JPG、SVG、WebP 格式及 Retina 高清輸出。',
+  },
+  es: {
+    name: 'Generador de Imágenes de Marcador',
+    description:
+      'Genera imágenes de marcador con dimensiones, colores, degradados y texto personalizados. Exporta como PNG, JPG, SVG o WebP con soporte Retina.',
+  },
+  fr: {
+    name: "Générateur d'Images Placeholder",
+    description:
+      'Générez des images placeholder avec dimensions, couleurs, dégradés et texte personnalisés. Exportez en PNG, JPG, SVG ou WebP avec support Retina.',
+  },
+  de: {
+    name: 'Platzhalter-Bildgenerator',
+    description:
+      'Erstellen Sie Platzhalterbilder mit benutzerdefinierten Abmessungen, Farben, Verläufen und Text. Export als PNG, JPG, SVG oder WebP mit Retina-Unterstützung.',
+  },
+  it: {
+    name: 'Generatore di Immagini Segnaposto',
+    description:
+      'Genera immagini segnaposto con dimensioni, colori, sfumature e testo personalizzati. Esporta come PNG, JPG, SVG o WebP con supporto Retina.',
+  },
+  ja: {
+    name: 'プレースホルダー画像ジェネレーター',
+    description:
+      'カスタムサイズ、色、グラデーション、テキストのプレースホルダー画像を生成。PNG、JPG、SVG、WebP形式でRetina対応出力。',
+  },
+  ko: {
+    name: '플레이스홀더 이미지 생성기',
+    description:
+      '사용자 정의 크기, 색상, 그라데이션 및 텍스트로 플레이스홀더 이미지를 생성합니다. Retina 지원 PNG, JPG, SVG, WebP로 내보내기.',
+  },
+  ru: {
+    name: 'Генератор изображений-заполнителей',
+    description:
+      'Создавайте изображения-заполнители с настраиваемыми размерами, цветами, градиентами и текстом. Экспорт в PNG, JPG, SVG или WebP с поддержкой Retina.',
+  },
+  pt: {
+    name: 'Gerador de Imagens Placeholder',
+    description:
+      'Gere imagens placeholder com dimensões, cores, gradientes e texto personalizados. Exporte como PNG, JPG, SVG ou WebP com suporte Retina.',
+  },
+  ar: {
+    name: 'مولد الصور النائبة',
+    description:
+      'أنشئ صور نائبة بأبعاد وألوان وتدرجات ونص مخصص. صدّر بصيغ PNG أو JPG أو SVG أو WebP مع دعم Retina.',
+  },
+  hi: {
+    name: 'प्लेसहोल्डर छवि जनरेटर',
+    description:
+      'कस्टम आयाम, रंग, ग्रेडिएंट और टेक्स्ट के साथ प्लेसहोल्डर छवियाँ बनाएँ। Retina समर्थन के साथ PNG, JPG, SVG या WebP में निर्यात करें।',
+  },
+  tr: {
+    name: 'Yer Tutucu Görüntü Oluşturucu',
+    description:
+      'Özel boyutlar, renkler, degradeler ve metin ile yer tutucu görüntüler oluşturun. Retina desteğiyle PNG, JPG, SVG veya WebP olarak dışa aktarın.',
+  },
+  nl: {
+    name: 'Plaatshouder Afbeelding Generator',
+    description:
+      'Genereer plaatshouder afbeeldingen met aangepaste afmetingen, kleuren, verlopen en tekst. Exporteer als PNG, JPG, SVG of WebP met Retina-ondersteuning.',
+  },
+  sv: {
+    name: 'Platshållarbildgenerator',
+    description:
+      'Generera platshållarbilder med anpassade dimensioner, färger, gradienter och text. Exportera som PNG, JPG, SVG eller WebP med Retina-stöd.',
+  },
+  pl: {
+    name: 'Generator obrazów zastępczych',
+    description:
+      'Generuj obrazy zastępcze z niestandardowymi wymiarami, kolorami, gradientami i tekstem. Eksportuj jako PNG, JPG, SVG lub WebP z obsługą Retina.',
+  },
+  vi: {
+    name: 'Trình tạo ảnh giữ chỗ',
+    description:
+      'Tạo ảnh giữ chỗ với kích thước, màu sắc, gradient và văn bản tùy chỉnh. Xuất dưới dạng PNG, JPG, SVG hoặc WebP với hỗ trợ Retina.',
+  },
+  th: {
+    name: 'ตัวสร้างภาพตัวยึดตำแหน่ง',
+    description:
+      'สร้างภาพตัวยึดตำแหน่งด้วยขนาด สี การไล่ระดับสี และข้อความที่กำหนดเอง ส่งออกเป็น PNG, JPG, SVG หรือ WebP พร้อมรองรับ Retina',
+  },
+  id: {
+    name: 'Generator Gambar Placeholder',
+    description:
+      'Buat gambar placeholder dengan dimensi, warna, gradien, dan teks khusus. Ekspor sebagai PNG, JPG, SVG, atau WebP dengan dukungan Retina.',
+  },
+  he: {
+    name: 'מחולל תמונות שומר מקום',
+    description:
+      'צרו תמונות שומר מקום עם ממדים, צבעים, מעברי צבע וטקסט מותאמים אישית. ייצוא כ-PNG, JPG, SVG או WebP עם תמיכת Retina.',
+  },
+  ms: {
+    name: 'Penjana Imej Pemegang Tempat',
+    description:
+      'Jana imej pemegang tempat dengan dimensi, warna, kecerunan dan teks tersuai. Eksport sebagai PNG, JPG, SVG atau WebP dengan sokongan Retina.',
+  },
+  no: {
+    name: 'Plassholder-bildegenerator',
+    description:
+      'Generer plassholderbilder med tilpassede dimensjoner, farger, gradienter og tekst. Eksporter som PNG, JPG, SVG eller WebP med Retina-støtte.',
+  },
+}

--- a/tools/image/placeholder-image-generator/src/routes.ts
+++ b/tools/image/placeholder-image-generator/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'placeholder-image-generator',
+    path: '/tools/placeholder-image-generator',
+    component: () => import('./PlaceholderImageGeneratorView.vue'),
+  },
+] as const


### PR DESCRIPTION
## Summary
- Add new Placeholder Image Generator tool for creating customizable placeholder images
- Support solid colors and gradients (linear/radial) with alpha transparency
- Export to PNG, JPG, WebP, SVG with quality and scale options (1x/2x/3x)
- Copy to clipboard functionality
- SVG-based preview for crisp rendering
- Full i18n support (25 languages)

## Features
- Customizable dimensions with presets (HD, Full HD, 4K, Instagram, Facebook, Twitter, etc.)
- Background: solid color or gradient with alpha support
- Custom text or auto-generated dimension display
- Adjustable font size
- Retina export support

## Test plan
- [ ] Verify preview updates in real-time
- [ ] Test all preset sizes
- [ ] Test gradient backgrounds (linear and radial)
- [ ] Test alpha transparency on colors
- [ ] Download all formats (PNG, JPG, WebP, SVG)
- [ ] Test copy to clipboard
- [ ] Test scale options (1x, 2x, 3x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)