### PR TITLE
feat(tools): add EXIF Viewer tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,6 +588,9 @@ importers:
       '@tools/dns-lookup':
         specifier: workspace:*
         version: link:../../tools/network/dns-lookup
+      '@tools/exif-viewer':
+        specifier: workspace:*
+        version: link:../../tools/image/exif-viewer
       '@tools/favicon-assets-generator':
         specifier: workspace:*
         version: link:../../tools/favicon/favicon-assets-generator
@@ -2038,6 +2041,36 @@ importers:
       vue-router:
         specifier: 'catalog:'
         version: 4.6.4(vue@3.5.26(typescript@5.9.3))
+
+  tools/image/exif-viewer:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      exifr:
+        specifier: ^7.1.3
+        version: 7.1.3
+      filesize:
+        specifier: 'catalog:'
+        version: 11.0.13
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
 
   tools/image/image-tools:
     dependencies:
@@ -6576,6 +6609,9 @@ packages:
 
   evtd@0.2.4:
     resolution: {integrity: sha512-qaeGN5bx63s/AXgQo8gj6fBkxge+OoLddLniox5qtLAEY5HSnuSlISXVPxnSae1dWblvTh4/HoMIB+mbMsvZzw==}
+
+  exifr@7.1.3:
+    resolution: {integrity: sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw==}
 
   exit-hook@2.2.1:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
@@ -11715,6 +11751,8 @@ snapshots:
   eventemitter3@5.0.1: {}
 
   evtd@0.2.4: {}
+
+  exifr@7.1.3: {}
 
   exit-hook@2.2.1: {}
 

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -35,6 +35,7 @@
     "@tools/data-uri-to-file-converter": "workspace:*",
     "@tools/device-information": "workspace:*",
     "@tools/dns-lookup": "workspace:*",
+    "@tools/exif-viewer": "workspace:*",
     "@tools/favicon-assets-generator": "workspace:*",
     "@tools/file-to-data-uri-converter": "workspace:*",
     "@tools/hash-tools": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -17,6 +17,7 @@ import { toolInfo as macToIPv6LinkLocalToolInfo } from '@tools/mac-to-ipv6-link-
 import { toolInfo as ipv6ToMacToolInfo } from '@tools/ipv6-to-mac'
 import { toolInfo as currentNetworkTimeToolInfo } from '@tools/current-network-time'
 import { toolInfo as pngOptimizerToolInfo } from '@tools/png-optimizer'
+import { toolInfo as exifViewerToolInfo } from '@tools/exif-viewer'
 import { toolInfo as networkToolsToolInfo } from '@tools/network-tools'
 import { toolInfo as pdfToolsToolInfo } from '@tools/pdf-tools'
 import { toolInfo as imageToolsToolInfo } from '@tools/image-tools'
@@ -110,6 +111,7 @@ export const tools: ToolInfo[] = [
   imageToolsToolInfo,
   faviconAssetsGeneratorToolInfo,
   pngOptimizerToolInfo,
+  exifViewerToolInfo,
   qrCodeGeneratorToolInfo,
   barcodeGeneratorToolInfo,
   markdownToHtmlConverterToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -15,6 +15,7 @@ import { routes as macToIPv6LinkLocalRoutes } from '@tools/mac-to-ipv6-link-loca
 import { routes as ipv6ToMacRoutes } from '@tools/ipv6-to-mac/routes'
 import { routes as currentNetworkTimeRoutes } from '@tools/current-network-time/routes'
 import { routes as pngOptimizerRoutes } from '@tools/png-optimizer/routes'
+import { routes as exifViewerRoutes } from '@tools/exif-viewer/routes'
 import { routes as networkToolsRoutes } from '@tools/network-tools/routes'
 import { routes as pdfToolsRoutes } from '@tools/pdf-tools/routes'
 import { routes as imageToolsRoutes } from '@tools/image-tools/routes'
@@ -99,6 +100,7 @@ export const routes: ToolRoute[] = [
   ...ipv6ToMacRoutes,
   ...currentNetworkTimeRoutes,
   ...pngOptimizerRoutes,
+  ...exifViewerRoutes,
   ...networkToolsRoutes,
   ...pdfToolsRoutes,
   ...imageToolsRoutes,

--- a/tools/image/exif-viewer/package.json
+++ b/tools/image/exif-viewer/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@tools/exif-viewer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "exifr": "^7.1.3",
+    "filesize": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/image/exif-viewer/src/ExifViewerView.vue
+++ b/tools/image/exif-viewer/src/ExifViewerView.vue
@@ -1,0 +1,221 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <ImageUpload v-model:file="imageFile" />
+
+    <template v-if="imageFile">
+      <ImagePreview :file="imageFile" @clear="clearFile" />
+
+      <ExifDataDisplay v-if="exifData && !error" :data="exifData" :is-loading="isLoading" />
+
+      <ExifActions v-if="exifData && !error" :exif-data="exifData" />
+    </template>
+
+    <ToolSection v-if="error">
+      <n-alert type="warning" :title="t('error')">
+        {{ error }}
+      </n-alert>
+    </ToolSection>
+
+    <ToolSection v-if="imageFile && !isLoading && !exifData && !error">
+      <n-empty :description="t('noExifData')" />
+    </ToolSection>
+
+    <WhatIsExif />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import * as exifr from 'exifr'
+import { NAlert, NEmpty } from 'naive-ui'
+import { ToolDefaultPageLayout, ToolSection } from '@shared/ui/tool'
+import * as toolInfo from './info'
+import ImageUpload from './components/ImageUpload.vue'
+import ImagePreview from './components/ImagePreview.vue'
+import ExifDataDisplay from './components/ExifDataDisplay.vue'
+import ExifActions from './components/ExifActions.vue'
+import WhatIsExif from './components/WhatIsExif.vue'
+
+export interface ExifData {
+  [key: string]: unknown
+}
+
+const { t } = useI18n()
+
+const imageFile = ref<File | null>(null)
+const exifData = ref<ExifData | null>(null)
+const isLoading = ref(false)
+const error = ref('')
+
+function clearFile() {
+  imageFile.value = null
+  exifData.value = null
+  error.value = ''
+}
+
+watch(imageFile, async (file) => {
+  if (!file) {
+    exifData.value = null
+    error.value = ''
+    return
+  }
+
+  isLoading.value = true
+  error.value = ''
+
+  try {
+    const data = await exifr.parse(file, {
+      exif: true,
+      iptc: true,
+      xmp: true,
+      icc: true,
+      gps: true,
+      translateKeys: true,
+      translateValues: true,
+      reviveValues: true,
+    })
+
+    if (data && Object.keys(data).length > 0) {
+      exifData.value = data
+    } else {
+      exifData.value = null
+    }
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : t('parseError')
+    exifData.value = null
+  } finally {
+    isLoading.value = false
+  }
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "error": "Error",
+    "noExifData": "This image does not contain EXIF metadata",
+    "parseError": "Failed to parse image metadata"
+  },
+  "zh": {
+    "error": "错误",
+    "noExifData": "此图片不包含 EXIF 元数据",
+    "parseError": "解析图片元数据失败"
+  },
+  "zh-CN": {
+    "error": "错误",
+    "noExifData": "此图片不包含 EXIF 元数据",
+    "parseError": "解析图片元数据失败"
+  },
+  "zh-TW": {
+    "error": "錯誤",
+    "noExifData": "此圖片不包含 EXIF 元資料",
+    "parseError": "解析圖片元資料失敗"
+  },
+  "zh-HK": {
+    "error": "錯誤",
+    "noExifData": "此圖片不包含 EXIF 元資料",
+    "parseError": "解析圖片元資料失敗"
+  },
+  "es": {
+    "error": "Error",
+    "noExifData": "Esta imagen no contiene metadatos EXIF",
+    "parseError": "Error al analizar los metadatos de la imagen"
+  },
+  "fr": {
+    "error": "Erreur",
+    "noExifData": "Cette image ne contient pas de métadonnées EXIF",
+    "parseError": "Échec de l'analyse des métadonnées de l'image"
+  },
+  "de": {
+    "error": "Fehler",
+    "noExifData": "Dieses Bild enthält keine EXIF-Metadaten",
+    "parseError": "Fehler beim Analysieren der Bildmetadaten"
+  },
+  "it": {
+    "error": "Errore",
+    "noExifData": "Questa immagine non contiene metadati EXIF",
+    "parseError": "Impossibile analizzare i metadati dell'immagine"
+  },
+  "ja": {
+    "error": "エラー",
+    "noExifData": "この画像にはEXIFメタデータが含まれていません",
+    "parseError": "画像メタデータの解析に失敗しました"
+  },
+  "ko": {
+    "error": "오류",
+    "noExifData": "이 이미지에는 EXIF 메타데이터가 없습니다",
+    "parseError": "이미지 메타데이터 분석에 실패했습니다"
+  },
+  "ru": {
+    "error": "Ошибка",
+    "noExifData": "Это изображение не содержит метаданных EXIF",
+    "parseError": "Не удалось проанализировать метаданные изображения"
+  },
+  "pt": {
+    "error": "Erro",
+    "noExifData": "Esta imagem não contém metadados EXIF",
+    "parseError": "Falha ao analisar metadados da imagem"
+  },
+  "ar": {
+    "error": "خطأ",
+    "noExifData": "هذه الصورة لا تحتوي على بيانات EXIF",
+    "parseError": "فشل في تحليل بيانات الصورة"
+  },
+  "hi": {
+    "error": "त्रुटि",
+    "noExifData": "इस छवि में EXIF मेटाडेटा नहीं है",
+    "parseError": "छवि मेटाडेटा पार्स करने में विफल"
+  },
+  "tr": {
+    "error": "Hata",
+    "noExifData": "Bu görüntü EXIF meta verisi içermiyor",
+    "parseError": "Görüntü meta verisi ayrıştırılamadı"
+  },
+  "nl": {
+    "error": "Fout",
+    "noExifData": "Deze afbeelding bevat geen EXIF-metadata",
+    "parseError": "Kan metadata van afbeelding niet analyseren"
+  },
+  "sv": {
+    "error": "Fel",
+    "noExifData": "Denna bild innehåller inga EXIF-metadata",
+    "parseError": "Kunde inte analysera bildmetadata"
+  },
+  "pl": {
+    "error": "Błąd",
+    "noExifData": "Ten obraz nie zawiera metadanych EXIF",
+    "parseError": "Nie udało się przeanalizować metadanych obrazu"
+  },
+  "vi": {
+    "error": "Lỗi",
+    "noExifData": "Hình ảnh này không chứa dữ liệu EXIF",
+    "parseError": "Không thể phân tích dữ liệu hình ảnh"
+  },
+  "th": {
+    "error": "ข้อผิดพลาด",
+    "noExifData": "ภาพนี้ไม่มีข้อมูล EXIF",
+    "parseError": "ไม่สามารถวิเคราะห์ข้อมูลภาพได้"
+  },
+  "id": {
+    "error": "Kesalahan",
+    "noExifData": "Gambar ini tidak mengandung metadata EXIF",
+    "parseError": "Gagal menganalisis metadata gambar"
+  },
+  "he": {
+    "error": "שגיאה",
+    "noExifData": "תמונה זו אינה מכילה נתוני EXIF",
+    "parseError": "נכשל בניתוח נתוני התמונה"
+  },
+  "ms": {
+    "error": "Ralat",
+    "noExifData": "Imej ini tidak mengandungi metadata EXIF",
+    "parseError": "Gagal menganalisis metadata imej"
+  },
+  "no": {
+    "error": "Feil",
+    "noExifData": "Dette bildet inneholder ikke EXIF-metadata",
+    "parseError": "Kunne ikke analysere bildemetadata"
+  }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/ExifActions.vue
+++ b/tools/image/exif-viewer/src/components/ExifActions.vue
@@ -1,0 +1,70 @@
+<template>
+  <ToolSection>
+    <n-flex>
+      <CopyToClipboardButton :content="exifJson">
+        {{ t('copyAsJson') }}
+      </CopyToClipboardButton>
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NFlex } from 'naive-ui'
+import { ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+import type { ExifData } from '../ExifViewerView.vue'
+
+const props = defineProps<{
+  exifData: ExifData
+}>()
+
+const { t } = useI18n()
+
+const exifJson = computed(() => {
+  return JSON.stringify(
+    props.exifData,
+    (key, value) => {
+      if (value instanceof Date) {
+        return value.toISOString()
+      }
+      if (value instanceof ArrayBuffer || value instanceof Uint8Array) {
+        return `[Binary data: ${(value as ArrayBuffer).byteLength || (value as Uint8Array).length} bytes]`
+      }
+      return value
+    },
+    2,
+  )
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": { "copyAsJson": "Copy as JSON" },
+  "zh": { "copyAsJson": "复制为 JSON" },
+  "zh-CN": { "copyAsJson": "复制为 JSON" },
+  "zh-TW": { "copyAsJson": "複製為 JSON" },
+  "zh-HK": { "copyAsJson": "複製為 JSON" },
+  "es": { "copyAsJson": "Copiar como JSON" },
+  "fr": { "copyAsJson": "Copier en JSON" },
+  "de": { "copyAsJson": "Als JSON kopieren" },
+  "it": { "copyAsJson": "Copia come JSON" },
+  "ja": { "copyAsJson": "JSON としてコピー" },
+  "ko": { "copyAsJson": "JSON으로 복사" },
+  "ru": { "copyAsJson": "Копировать как JSON" },
+  "pt": { "copyAsJson": "Copiar como JSON" },
+  "ar": { "copyAsJson": "نسخ كـ JSON" },
+  "hi": { "copyAsJson": "JSON के रूप में कॉपी करें" },
+  "tr": { "copyAsJson": "JSON olarak kopyala" },
+  "nl": { "copyAsJson": "Kopiëren als JSON" },
+  "sv": { "copyAsJson": "Kopiera som JSON" },
+  "pl": { "copyAsJson": "Kopiuj jako JSON" },
+  "vi": { "copyAsJson": "Sao chép dạng JSON" },
+  "th": { "copyAsJson": "คัดลอกเป็น JSON" },
+  "id": { "copyAsJson": "Salin sebagai JSON" },
+  "he": { "copyAsJson": "העתק כ-JSON" },
+  "ms": { "copyAsJson": "Salin sebagai JSON" },
+  "no": { "copyAsJson": "Kopier som JSON" }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/ExifCategorySection.vue
+++ b/tools/image/exif-viewer/src/components/ExifCategorySection.vue
@@ -1,0 +1,54 @@
+<template>
+  <n-collapse-item :title="title" :name="name">
+    <n-descriptions label-placement="left" bordered :column="1">
+      <n-descriptions-item v-for="(value, key) in data" :key="key" :label="String(key)">
+        <n-flex align="center" justify="space-between" :wrap="false">
+          <n-text code style="word-break: break-all">{{ formatValue(value) }}</n-text>
+          <CopyToClipboardButton :content="String(formatValue(value))" />
+        </n-flex>
+      </n-descriptions-item>
+    </n-descriptions>
+    <slot name="extra" />
+  </n-collapse-item>
+</template>
+
+<script setup lang="ts">
+import { NCollapseItem, NDescriptions, NDescriptionsItem, NFlex, NText } from 'naive-ui'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+defineProps<{
+  name: string
+  title: string
+  data: Record<string, unknown>
+}>()
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '-'
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.join(', ')
+  }
+
+  if (typeof value === 'object') {
+    if (value instanceof ArrayBuffer || value instanceof Uint8Array) {
+      return `[Binary data: ${(value as ArrayBuffer).byteLength || (value as Uint8Array).length} bytes]`
+    }
+    return JSON.stringify(value)
+  }
+
+  if (typeof value === 'number') {
+    if (Number.isInteger(value)) {
+      return String(value)
+    }
+    return value.toFixed(4).replace(/\.?0+$/, '')
+  }
+
+  return String(value)
+}
+</script>

--- a/tools/image/exif-viewer/src/components/ExifDataDisplay.vue
+++ b/tools/image/exif-viewer/src/components/ExifDataDisplay.vue
@@ -1,0 +1,396 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('exifData') }}</ToolSectionHeader>
+
+    <n-spin :show="isLoading">
+      <n-collapse v-model:expanded-names="expandedCategories" display-directive="show">
+        <ExifCategorySection
+          v-if="basicInfo && Object.keys(basicInfo).length > 0"
+          name="basic"
+          :title="t('category.basic')"
+          :data="basicInfo"
+        />
+        <ExifCategorySection
+          v-if="cameraInfo && Object.keys(cameraInfo).length > 0"
+          name="camera"
+          :title="t('category.camera')"
+          :data="cameraInfo"
+        />
+        <ExifCategorySection
+          v-if="gpsInfo && Object.keys(gpsInfo).length > 0"
+          name="gps"
+          :title="t('category.gps')"
+          :data="gpsInfo"
+        >
+          <template #extra>
+            <n-flex v-if="gpsCoords" :wrap="false" style="margin-top: 12px">
+              <n-button tag="a" :href="googleMapsUrl" target="_blank" size="small" secondary>
+                Google Maps
+              </n-button>
+              <n-button tag="a" :href="amapUrl" target="_blank" size="small" secondary>
+                {{ t('amap') }}
+              </n-button>
+            </n-flex>
+          </template>
+        </ExifCategorySection>
+        <ExifCategorySection
+          v-if="advancedInfo && Object.keys(advancedInfo).length > 0"
+          name="advanced"
+          :title="t('category.advanced')"
+          :data="advancedInfo"
+        />
+      </n-collapse>
+    </n-spin>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NCollapse, NSpin, NFlex, NButton } from 'naive-ui'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import ExifCategorySection from './ExifCategorySection.vue'
+import type { ExifData } from '../ExifViewerView.vue'
+
+const props = defineProps<{
+  data: ExifData
+  isLoading: boolean
+}>()
+
+const { t } = useI18n()
+
+const expandedCategories = ref(['basic', 'camera', 'gps'])
+
+const basicFields = [
+  'ImageWidth',
+  'ImageHeight',
+  'ExifImageWidth',
+  'ExifImageHeight',
+  'Orientation',
+  'XResolution',
+  'YResolution',
+  'ResolutionUnit',
+  'Software',
+  'ModifyDate',
+  'Artist',
+  'Copyright',
+  'ColorSpace',
+  'BitsPerSample',
+  'Compression',
+]
+
+const cameraFields = [
+  'Make',
+  'Model',
+  'LensModel',
+  'LensMake',
+  'LensInfo',
+  'ExposureTime',
+  'FNumber',
+  'ISO',
+  'ISOSpeedRatings',
+  'FocalLength',
+  'FocalLengthIn35mmFormat',
+  'Flash',
+  'WhiteBalance',
+  'MeteringMode',
+  'ExposureProgram',
+  'ExposureCompensation',
+  'ExposureBiasValue',
+  'DateTimeOriginal',
+  'CreateDate',
+  'DateTimeDigitized',
+  'ShutterSpeedValue',
+  'ApertureValue',
+  'MaxApertureValue',
+  'SceneCaptureType',
+  'DigitalZoomRatio',
+  'Contrast',
+  'Saturation',
+  'Sharpness',
+]
+
+const gpsFields = [
+  'latitude',
+  'longitude',
+  'GPSLatitude',
+  'GPSLongitude',
+  'GPSLatitudeRef',
+  'GPSLongitudeRef',
+  'GPSAltitude',
+  'GPSAltitudeRef',
+  'GPSImgDirection',
+  'GPSImgDirectionRef',
+  'GPSSpeed',
+  'GPSSpeedRef',
+  'GPSDateStamp',
+  'GPSTimeStamp',
+]
+
+const basicInfo = computed(() => {
+  const result: Record<string, unknown> = {}
+  for (const field of basicFields) {
+    if (props.data[field] !== undefined) {
+      result[field] = props.data[field]
+    }
+  }
+  return result
+})
+
+const cameraInfo = computed(() => {
+  const result: Record<string, unknown> = {}
+  for (const field of cameraFields) {
+    if (props.data[field] !== undefined) {
+      result[field] = props.data[field]
+    }
+  }
+  return result
+})
+
+const gpsInfo = computed(() => {
+  const result: Record<string, unknown> = {}
+  for (const field of gpsFields) {
+    if (props.data[field] !== undefined) {
+      result[field] = props.data[field]
+    }
+  }
+  return result
+})
+
+const advancedInfo = computed(() => {
+  const usedFields = new Set([...basicFields, ...cameraFields, ...gpsFields])
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(props.data)) {
+    if (!usedFields.has(key) && value !== undefined) {
+      result[key] = value
+    }
+  }
+  return result
+})
+
+const gpsCoords = computed(() => {
+  const lat = props.data.latitude as number | undefined
+  const lng = props.data.longitude as number | undefined
+  if (lat !== undefined && lng !== undefined) {
+    return { lat, lng }
+  }
+  return null
+})
+
+const googleMapsUrl = computed(() => {
+  if (!gpsCoords.value) return ''
+  const { lat, lng } = gpsCoords.value
+  return `https://www.google.com/maps?q=${lat},${lng}`
+})
+
+const amapUrl = computed(() => {
+  if (!gpsCoords.value) return ''
+  const { lat, lng } = gpsCoords.value
+  return `https://uri.amap.com/marker?position=${lng},${lat}`
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "exifData": "EXIF Data",
+    "category.basic": "Basic Information",
+    "category.camera": "Camera Information",
+    "category.gps": "GPS Location",
+    "category.advanced": "Advanced Information",
+    "amap": "Amap"
+  },
+  "zh": {
+    "exifData": "EXIF 数据",
+    "category.basic": "基本信息",
+    "category.camera": "相机信息",
+    "category.gps": "GPS 位置",
+    "category.advanced": "高级信息",
+    "amap": "高德地图"
+  },
+  "zh-CN": {
+    "exifData": "EXIF 数据",
+    "category.basic": "基本信息",
+    "category.camera": "相机信息",
+    "category.gps": "GPS 位置",
+    "category.advanced": "高级信息",
+    "amap": "高德地图"
+  },
+  "zh-TW": {
+    "exifData": "EXIF 資料",
+    "category.basic": "基本資訊",
+    "category.camera": "相機資訊",
+    "category.gps": "GPS 位置",
+    "category.advanced": "進階資訊",
+    "amap": "高德地圖"
+  },
+  "zh-HK": {
+    "exifData": "EXIF 資料",
+    "category.basic": "基本資訊",
+    "category.camera": "相機資訊",
+    "category.gps": "GPS 位置",
+    "category.advanced": "進階資訊",
+    "amap": "高德地圖"
+  },
+  "es": {
+    "exifData": "Datos EXIF",
+    "category.basic": "Información básica",
+    "category.camera": "Información de la cámara",
+    "category.gps": "Ubicación GPS",
+    "category.advanced": "Información avanzada",
+    "amap": "Amap"
+  },
+  "fr": {
+    "exifData": "Données EXIF",
+    "category.basic": "Informations de base",
+    "category.camera": "Informations de l'appareil photo",
+    "category.gps": "Position GPS",
+    "category.advanced": "Informations avancées",
+    "amap": "Amap"
+  },
+  "de": {
+    "exifData": "EXIF-Daten",
+    "category.basic": "Grundinformationen",
+    "category.camera": "Kamerainformationen",
+    "category.gps": "GPS-Standort",
+    "category.advanced": "Erweiterte Informationen",
+    "amap": "Amap"
+  },
+  "it": {
+    "exifData": "Dati EXIF",
+    "category.basic": "Informazioni di base",
+    "category.camera": "Informazioni fotocamera",
+    "category.gps": "Posizione GPS",
+    "category.advanced": "Informazioni avanzate",
+    "amap": "Amap"
+  },
+  "ja": {
+    "exifData": "EXIF データ",
+    "category.basic": "基本情報",
+    "category.camera": "カメラ情報",
+    "category.gps": "GPS 位置",
+    "category.advanced": "詳細情報",
+    "amap": "高德地図"
+  },
+  "ko": {
+    "exifData": "EXIF 데이터",
+    "category.basic": "기본 정보",
+    "category.camera": "카메라 정보",
+    "category.gps": "GPS 위치",
+    "category.advanced": "고급 정보",
+    "amap": "Amap"
+  },
+  "ru": {
+    "exifData": "Данные EXIF",
+    "category.basic": "Основная информация",
+    "category.camera": "Информация о камере",
+    "category.gps": "GPS местоположение",
+    "category.advanced": "Дополнительная информация",
+    "amap": "Amap"
+  },
+  "pt": {
+    "exifData": "Dados EXIF",
+    "category.basic": "Informações básicas",
+    "category.camera": "Informações da câmera",
+    "category.gps": "Localização GPS",
+    "category.advanced": "Informações avançadas",
+    "amap": "Amap"
+  },
+  "ar": {
+    "exifData": "بيانات EXIF",
+    "category.basic": "المعلومات الأساسية",
+    "category.camera": "معلومات الكاميرا",
+    "category.gps": "موقع GPS",
+    "category.advanced": "معلومات متقدمة",
+    "amap": "Amap"
+  },
+  "hi": {
+    "exifData": "EXIF डेटा",
+    "category.basic": "बुनियादी जानकारी",
+    "category.camera": "कैमरा जानकारी",
+    "category.gps": "GPS स्थान",
+    "category.advanced": "उन्नत जानकारी",
+    "amap": "Amap"
+  },
+  "tr": {
+    "exifData": "EXIF Verileri",
+    "category.basic": "Temel Bilgiler",
+    "category.camera": "Kamera Bilgileri",
+    "category.gps": "GPS Konumu",
+    "category.advanced": "Gelişmiş Bilgiler",
+    "amap": "Amap"
+  },
+  "nl": {
+    "exifData": "EXIF-gegevens",
+    "category.basic": "Basisinformatie",
+    "category.camera": "Camera-informatie",
+    "category.gps": "GPS-locatie",
+    "category.advanced": "Geavanceerde informatie",
+    "amap": "Amap"
+  },
+  "sv": {
+    "exifData": "EXIF-data",
+    "category.basic": "Grundläggande information",
+    "category.camera": "Kamerainformation",
+    "category.gps": "GPS-plats",
+    "category.advanced": "Avancerad information",
+    "amap": "Amap"
+  },
+  "pl": {
+    "exifData": "Dane EXIF",
+    "category.basic": "Podstawowe informacje",
+    "category.camera": "Informacje o aparacie",
+    "category.gps": "Lokalizacja GPS",
+    "category.advanced": "Zaawansowane informacje",
+    "amap": "Amap"
+  },
+  "vi": {
+    "exifData": "Dữ liệu EXIF",
+    "category.basic": "Thông tin cơ bản",
+    "category.camera": "Thông tin máy ảnh",
+    "category.gps": "Vị trí GPS",
+    "category.advanced": "Thông tin nâng cao",
+    "amap": "Amap"
+  },
+  "th": {
+    "exifData": "ข้อมูล EXIF",
+    "category.basic": "ข้อมูลพื้นฐาน",
+    "category.camera": "ข้อมูลกล้อง",
+    "category.gps": "ตำแหน่ง GPS",
+    "category.advanced": "ข้อมูลขั้นสูง",
+    "amap": "Amap"
+  },
+  "id": {
+    "exifData": "Data EXIF",
+    "category.basic": "Informasi Dasar",
+    "category.camera": "Informasi Kamera",
+    "category.gps": "Lokasi GPS",
+    "category.advanced": "Informasi Lanjutan",
+    "amap": "Amap"
+  },
+  "he": {
+    "exifData": "נתוני EXIF",
+    "category.basic": "מידע בסיסי",
+    "category.camera": "מידע על המצלמה",
+    "category.gps": "מיקום GPS",
+    "category.advanced": "מידע מתקדם",
+    "amap": "Amap"
+  },
+  "ms": {
+    "exifData": "Data EXIF",
+    "category.basic": "Maklumat Asas",
+    "category.camera": "Maklumat Kamera",
+    "category.gps": "Lokasi GPS",
+    "category.advanced": "Maklumat Lanjutan",
+    "amap": "Amap"
+  },
+  "no": {
+    "exifData": "EXIF-data",
+    "category.basic": "Grunnleggende informasjon",
+    "category.camera": "Kamerainformasjon",
+    "category.gps": "GPS-plassering",
+    "category.advanced": "Avansert informasjon",
+    "amap": "Amap"
+  }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/ImagePreview.vue
+++ b/tools/image/exif-viewer/src/components/ImagePreview.vue
@@ -1,0 +1,79 @@
+<template>
+  <ToolSection>
+    <n-flex align="center" :wrap="false">
+      <n-image
+        v-if="imagePreview"
+        :src="imagePreview"
+        height="100"
+        style="border-radius: 4px; flex-shrink: 0"
+        object-fit="contain"
+      />
+      <n-flex vertical style="flex: 1; min-width: 0">
+        <n-text strong style="word-break: break-all">{{ file.name }}</n-text>
+        <n-text depth="3">{{ formattedSize }}</n-text>
+      </n-flex>
+      <n-button tertiary type="error" @click="emit('clear')">
+        <template #icon>
+          <n-icon>
+            <DeleteIcon />
+          </n-icon>
+        </template>
+        {{ t('remove') }}
+      </n-button>
+    </n-flex>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useObjectUrl } from '@vueuse/core'
+import { filesize } from 'filesize'
+import { NImage, NFlex, NText, NButton, NIcon } from 'naive-ui'
+import { Delete24Regular as DeleteIcon } from '@shared/icons/fluent'
+import { ToolSection } from '@shared/ui/tool'
+
+const props = defineProps<{
+  file: File
+}>()
+
+const emit = defineEmits<{
+  clear: []
+}>()
+
+const { t } = useI18n()
+
+const imagePreview = useObjectUrl(() => props.file)
+
+const formattedSize = computed(() => filesize(props.file.size))
+</script>
+
+<i18n lang="json">
+{
+  "en": { "remove": "Remove" },
+  "zh": { "remove": "移除" },
+  "zh-CN": { "remove": "移除" },
+  "zh-TW": { "remove": "移除" },
+  "zh-HK": { "remove": "移除" },
+  "es": { "remove": "Eliminar" },
+  "fr": { "remove": "Supprimer" },
+  "de": { "remove": "Entfernen" },
+  "it": { "remove": "Rimuovi" },
+  "ja": { "remove": "削除" },
+  "ko": { "remove": "제거" },
+  "ru": { "remove": "Удалить" },
+  "pt": { "remove": "Remover" },
+  "ar": { "remove": "إزالة" },
+  "hi": { "remove": "हटाएं" },
+  "tr": { "remove": "Kaldır" },
+  "nl": { "remove": "Verwijderen" },
+  "sv": { "remove": "Ta bort" },
+  "pl": { "remove": "Usuń" },
+  "vi": { "remove": "Xóa" },
+  "th": { "remove": "ลบ" },
+  "id": { "remove": "Hapus" },
+  "he": { "remove": "הסר" },
+  "ms": { "remove": "Buang" },
+  "no": { "remove": "Fjern" }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/ImageUpload.vue
+++ b/tools/image/exif-viewer/src/components/ImageUpload.vue
@@ -1,0 +1,155 @@
+<template>
+  <ToolSection>
+    <n-upload
+      :show-file-list="false"
+      accept="image/jpeg,image/png,image/heic,image/heif,image/tiff,image/webp,image/gif"
+      :max="1"
+      @before-upload="handleBeforeUpload"
+    >
+      <n-upload-dragger>
+        <div style="margin-bottom: 12px">
+          <n-icon size="48" :depth="3">
+            <ImageIcon />
+          </n-icon>
+        </div>
+        <n-text style="font-size: 16px">
+          {{ t('dragDropOrClick') }}
+        </n-text>
+        <n-p depth="3" style="margin: 8px 0 0 0">
+          {{ t('supportedFormats') }}
+        </n-p>
+      </n-upload-dragger>
+    </n-upload>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import type { UploadFileInfo } from 'naive-ui'
+import { NUpload, NUploadDragger, NIcon, NText, NP } from 'naive-ui'
+import { Image24Regular as ImageIcon } from '@shared/icons/fluent'
+import { ToolSection } from '@shared/ui/tool'
+
+defineProps<{
+  file: File | null
+}>()
+
+const emit = defineEmits<{
+  'update:file': [file: File | null]
+}>()
+
+const { t } = useI18n()
+
+function handleBeforeUpload(data: { file: UploadFileInfo; fileList: UploadFileInfo[] }) {
+  const file = data.file.file
+  if (!file) return false
+
+  emit('update:file', file)
+  return false
+}
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "dragDropOrClick": "Click or drag image to upload",
+    "supportedFormats": "Supports JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "zh": {
+    "dragDropOrClick": "点击或拖拽图片上传",
+    "supportedFormats": "支持 JPEG、PNG、HEIC、TIFF、WebP、GIF"
+  },
+  "zh-CN": {
+    "dragDropOrClick": "点击或拖拽图片上传",
+    "supportedFormats": "支持 JPEG、PNG、HEIC、TIFF、WebP、GIF"
+  },
+  "zh-TW": {
+    "dragDropOrClick": "點擊或拖曳圖片上傳",
+    "supportedFormats": "支援 JPEG、PNG、HEIC、TIFF、WebP、GIF"
+  },
+  "zh-HK": {
+    "dragDropOrClick": "點擊或拖曳圖片上傳",
+    "supportedFormats": "支援 JPEG、PNG、HEIC、TIFF、WebP、GIF"
+  },
+  "es": {
+    "dragDropOrClick": "Haga clic o arrastre la imagen para cargar",
+    "supportedFormats": "Soporta JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "fr": {
+    "dragDropOrClick": "Cliquez ou déposez l'image pour télécharger",
+    "supportedFormats": "Prend en charge JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "de": {
+    "dragDropOrClick": "Klicken oder Bild hierher ziehen",
+    "supportedFormats": "Unterstützt JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "it": {
+    "dragDropOrClick": "Clicca o trascina l'immagine per caricarla",
+    "supportedFormats": "Supporta JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "ja": {
+    "dragDropOrClick": "クリックまたは画像をドラッグしてアップロード",
+    "supportedFormats": "JPEG、PNG、HEIC、TIFF、WebP、GIF をサポート"
+  },
+  "ko": {
+    "dragDropOrClick": "클릭하거나 이미지를 드래그하여 업로드",
+    "supportedFormats": "JPEG, PNG, HEIC, TIFF, WebP, GIF 지원"
+  },
+  "ru": {
+    "dragDropOrClick": "Нажмите или перетащите изображение для загрузки",
+    "supportedFormats": "Поддерживает JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "pt": {
+    "dragDropOrClick": "Clique ou arraste a imagem para fazer upload",
+    "supportedFormats": "Suporta JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "ar": {
+    "dragDropOrClick": "انقر أو اسحب الصورة للتحميل",
+    "supportedFormats": "يدعم JPEG، PNG، HEIC، TIFF، WebP، GIF"
+  },
+  "hi": {
+    "dragDropOrClick": "अपलोड करने के लिए क्लिक करें या छवि खींचें",
+    "supportedFormats": "JPEG, PNG, HEIC, TIFF, WebP, GIF समर्थित"
+  },
+  "tr": {
+    "dragDropOrClick": "Yüklemek için tıklayın veya görüntüyü sürükleyin",
+    "supportedFormats": "JPEG, PNG, HEIC, TIFF, WebP, GIF desteklenir"
+  },
+  "nl": {
+    "dragDropOrClick": "Klik of sleep afbeelding om te uploaden",
+    "supportedFormats": "Ondersteunt JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "sv": {
+    "dragDropOrClick": "Klicka eller dra bild för att ladda upp",
+    "supportedFormats": "Stöder JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "pl": {
+    "dragDropOrClick": "Kliknij lub przeciągnij obraz, aby przesłać",
+    "supportedFormats": "Obsługuje JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "vi": {
+    "dragDropOrClick": "Nhấp hoặc kéo hình ảnh để tải lên",
+    "supportedFormats": "Hỗ trợ JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "th": {
+    "dragDropOrClick": "คลิกหรือลากภาพเพื่ออัปโหลด",
+    "supportedFormats": "รองรับ JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "id": {
+    "dragDropOrClick": "Klik atau seret gambar untuk mengunggah",
+    "supportedFormats": "Mendukung JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "he": {
+    "dragDropOrClick": "לחץ או גרור תמונה להעלאה",
+    "supportedFormats": "תומך ב-JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "ms": {
+    "dragDropOrClick": "Klik atau seret imej untuk muat naik",
+    "supportedFormats": "Menyokong JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  },
+  "no": {
+    "dragDropOrClick": "Klikk eller dra bilde for å laste opp",
+    "supportedFormats": "Støtter JPEG, PNG, HEIC, TIFF, WebP, GIF"
+  }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/WhatIsExif.vue
+++ b/tools/image/exif-viewer/src/components/WhatIsExif.vue
@@ -1,0 +1,330 @@
+<template>
+  <ToolSection>
+    <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+    <n-p>{{ t('description') }}</n-p>
+    <n-p>{{ t('contains') }}</n-p>
+    <n-ul>
+      <n-li>{{ t('item.camera') }}</n-li>
+      <n-li>{{ t('item.settings') }}</n-li>
+      <n-li>{{ t('item.date') }}</n-li>
+      <n-li>{{ t('item.gps') }}</n-li>
+      <n-li>{{ t('item.software') }}</n-li>
+    </n-ul>
+    <n-alert type="warning" :title="t('privacy.title')" style="margin-top: 16px">
+      {{ t('privacy.description') }}
+    </n-alert>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { NP, NUl, NLi, NAlert } from 'naive-ui'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) is a standard that specifies formats for images and sounds used by digital cameras and other systems.",
+    "contains": "EXIF data typically contains:",
+    "item.camera": "Camera make and model",
+    "item.settings": "Camera settings (aperture, shutter speed, ISO, focal length)",
+    "item.date": "Date and time the photo was taken",
+    "item.gps": "GPS coordinates (location where photo was taken)",
+    "item.software": "Software used to edit the image",
+    "privacy.title": "Privacy Notice",
+    "privacy.description": "EXIF data may contain sensitive information such as GPS location, device serial numbers, and timestamps. Consider removing EXIF data before sharing photos publicly."
+  },
+  "zh": {
+    "title": "什么是 EXIF？",
+    "description": "EXIF（可交换图像文件格式）是一种标准，用于规定数码相机和其他系统使用的图像和声音格式。",
+    "contains": "EXIF 数据通常包含：",
+    "item.camera": "相机制造商和型号",
+    "item.settings": "相机设置（光圈、快门速度、ISO、焦距）",
+    "item.date": "拍摄日期和时间",
+    "item.gps": "GPS 坐标（拍摄地点）",
+    "item.software": "用于编辑图像的软件",
+    "privacy.title": "隐私提示",
+    "privacy.description": "EXIF 数据可能包含敏感信息，如 GPS 位置、设备序列号和时间戳。在公开分享照片前，请考虑移除 EXIF 数据。"
+  },
+  "zh-CN": {
+    "title": "什么是 EXIF？",
+    "description": "EXIF（可交换图像文件格式）是一种标准，用于规定数码相机和其他系统使用的图像和声音格式。",
+    "contains": "EXIF 数据通常包含：",
+    "item.camera": "相机制造商和型号",
+    "item.settings": "相机设置（光圈、快门速度、ISO、焦距）",
+    "item.date": "拍摄日期和时间",
+    "item.gps": "GPS 坐标（拍摄地点）",
+    "item.software": "用于编辑图像的软件",
+    "privacy.title": "隐私提示",
+    "privacy.description": "EXIF 数据可能包含敏感信息，如 GPS 位置、设备序列号和时间戳。在公开分享照片前，请考虑移除 EXIF 数据。"
+  },
+  "zh-TW": {
+    "title": "什麼是 EXIF？",
+    "description": "EXIF（可交換圖像檔案格式）是一種標準，用於規定數位相機和其他系統使用的影像和聲音格式。",
+    "contains": "EXIF 資料通常包含：",
+    "item.camera": "相機製造商和型號",
+    "item.settings": "相機設定（光圈、快門速度、ISO、焦距）",
+    "item.date": "拍攝日期和時間",
+    "item.gps": "GPS 座標（拍攝地點）",
+    "item.software": "用於編輯圖像的軟體",
+    "privacy.title": "隱私提示",
+    "privacy.description": "EXIF 資料可能包含敏感資訊，如 GPS 位置、裝置序號和時間戳記。在公開分享照片前，請考慮移除 EXIF 資料。"
+  },
+  "zh-HK": {
+    "title": "什麼是 EXIF？",
+    "description": "EXIF（可交換圖像檔案格式）是一種標準，用於規定數碼相機和其他系統使用的影像和聲音格式。",
+    "contains": "EXIF 資料通常包含：",
+    "item.camera": "相機製造商和型號",
+    "item.settings": "相機設定（光圈、快門速度、ISO、焦距）",
+    "item.date": "拍攝日期和時間",
+    "item.gps": "GPS 座標（拍攝地點）",
+    "item.software": "用於編輯圖像的軟件",
+    "privacy.title": "私隱提示",
+    "privacy.description": "EXIF 資料可能包含敏感資訊，如 GPS 位置、裝置序號和時間戳記。在公開分享相片前，請考慮移除 EXIF 資料。"
+  },
+  "es": {
+    "title": "¿Qué es EXIF?",
+    "description": "EXIF (Formato de Archivo de Imagen Intercambiable) es un estándar que especifica formatos para imágenes y sonidos utilizados por cámaras digitales y otros sistemas.",
+    "contains": "Los datos EXIF típicamente contienen:",
+    "item.camera": "Marca y modelo de la cámara",
+    "item.settings": "Configuración de la cámara (apertura, velocidad de obturación, ISO, distancia focal)",
+    "item.date": "Fecha y hora en que se tomó la foto",
+    "item.gps": "Coordenadas GPS (ubicación donde se tomó la foto)",
+    "item.software": "Software utilizado para editar la imagen",
+    "privacy.title": "Aviso de privacidad",
+    "privacy.description": "Los datos EXIF pueden contener información sensible como ubicación GPS, números de serie del dispositivo y marcas de tiempo. Considere eliminar los datos EXIF antes de compartir fotos públicamente."
+  },
+  "fr": {
+    "title": "Qu'est-ce que l'EXIF ?",
+    "description": "EXIF (Exchangeable Image File Format) est une norme qui spécifie les formats d'images et de sons utilisés par les appareils photo numériques et autres systèmes.",
+    "contains": "Les données EXIF contiennent généralement :",
+    "item.camera": "Marque et modèle de l'appareil photo",
+    "item.settings": "Paramètres de l'appareil photo (ouverture, vitesse d'obturation, ISO, distance focale)",
+    "item.date": "Date et heure de prise de la photo",
+    "item.gps": "Coordonnées GPS (lieu de prise de la photo)",
+    "item.software": "Logiciel utilisé pour éditer l'image",
+    "privacy.title": "Avis de confidentialité",
+    "privacy.description": "Les données EXIF peuvent contenir des informations sensibles telles que la localisation GPS, les numéros de série de l'appareil et les horodatages. Pensez à supprimer les données EXIF avant de partager des photos publiquement."
+  },
+  "de": {
+    "title": "Was ist EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) ist ein Standard, der Formate für Bilder und Töne spezifiziert, die von Digitalkameras und anderen Systemen verwendet werden.",
+    "contains": "EXIF-Daten enthalten typischerweise:",
+    "item.camera": "Kameramarke und -modell",
+    "item.settings": "Kameraeinstellungen (Blende, Verschlusszeit, ISO, Brennweite)",
+    "item.date": "Datum und Uhrzeit der Aufnahme",
+    "item.gps": "GPS-Koordinaten (Aufnahmeort)",
+    "item.software": "Software zur Bildbearbeitung",
+    "privacy.title": "Datenschutzhinweis",
+    "privacy.description": "EXIF-Daten können sensible Informationen wie GPS-Standort, Geräte-Seriennummern und Zeitstempel enthalten. Erwägen Sie, EXIF-Daten zu entfernen, bevor Sie Fotos öffentlich teilen."
+  },
+  "it": {
+    "title": "Cos'è l'EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) è uno standard che specifica i formati per immagini e suoni utilizzati dalle fotocamere digitali e altri sistemi.",
+    "contains": "I dati EXIF tipicamente contengono:",
+    "item.camera": "Marca e modello della fotocamera",
+    "item.settings": "Impostazioni della fotocamera (apertura, velocità dell'otturatore, ISO, lunghezza focale)",
+    "item.date": "Data e ora dello scatto",
+    "item.gps": "Coordinate GPS (luogo dello scatto)",
+    "item.software": "Software utilizzato per modificare l'immagine",
+    "privacy.title": "Avviso sulla privacy",
+    "privacy.description": "I dati EXIF possono contenere informazioni sensibili come posizione GPS, numeri di serie del dispositivo e timestamp. Considera di rimuovere i dati EXIF prima di condividere foto pubblicamente."
+  },
+  "ja": {
+    "title": "EXIFとは？",
+    "description": "EXIF（Exchangeable Image File Format）は、デジタルカメラやその他のシステムで使用される画像と音声のフォーマットを規定する標準規格です。",
+    "contains": "EXIFデータには通常以下が含まれます：",
+    "item.camera": "カメラのメーカーとモデル",
+    "item.settings": "カメラ設定（絞り、シャッタースピード、ISO、焦点距離）",
+    "item.date": "撮影日時",
+    "item.gps": "GPS座標（撮影場所）",
+    "item.software": "画像編集に使用したソフトウェア",
+    "privacy.title": "プライバシーに関する注意",
+    "privacy.description": "EXIFデータには、GPS位置情報、デバイスのシリアル番号、タイムスタンプなどの機密情報が含まれている場合があります。写真を公開で共有する前に、EXIFデータの削除を検討してください。"
+  },
+  "ko": {
+    "title": "EXIF란?",
+    "description": "EXIF(교환 이미지 파일 형식)는 디지털 카메라 및 기타 시스템에서 사용하는 이미지와 사운드 형식을 지정하는 표준입니다.",
+    "contains": "EXIF 데이터에는 일반적으로 다음이 포함됩니다:",
+    "item.camera": "카메라 제조사 및 모델",
+    "item.settings": "카메라 설정 (조리개, 셔터 속도, ISO, 초점 거리)",
+    "item.date": "사진 촬영 날짜와 시간",
+    "item.gps": "GPS 좌표 (사진 촬영 위치)",
+    "item.software": "이미지 편집에 사용된 소프트웨어",
+    "privacy.title": "개인정보 보호 알림",
+    "privacy.description": "EXIF 데이터에는 GPS 위치, 장치 일련번호, 타임스탬프와 같은 민감한 정보가 포함될 수 있습니다. 사진을 공개적으로 공유하기 전에 EXIF 데이터 제거를 고려하세요."
+  },
+  "ru": {
+    "title": "Что такое EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) — это стандарт, определяющий форматы изображений и звуков, используемых цифровыми камерами и другими системами.",
+    "contains": "Данные EXIF обычно содержат:",
+    "item.camera": "Производитель и модель камеры",
+    "item.settings": "Настройки камеры (диафрагма, выдержка, ISO, фокусное расстояние)",
+    "item.date": "Дата и время съёмки",
+    "item.gps": "GPS-координаты (место съёмки)",
+    "item.software": "Программное обеспечение для редактирования изображения",
+    "privacy.title": "Уведомление о конфиденциальности",
+    "privacy.description": "Данные EXIF могут содержать конфиденциальную информацию, такую как GPS-местоположение, серийные номера устройств и временные метки. Рассмотрите возможность удаления данных EXIF перед публичным распространением фотографий."
+  },
+  "pt": {
+    "title": "O que é EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) é um padrão que especifica formatos para imagens e sons usados por câmeras digitais e outros sistemas.",
+    "contains": "Os dados EXIF geralmente contêm:",
+    "item.camera": "Marca e modelo da câmera",
+    "item.settings": "Configurações da câmera (abertura, velocidade do obturador, ISO, distância focal)",
+    "item.date": "Data e hora em que a foto foi tirada",
+    "item.gps": "Coordenadas GPS (local onde a foto foi tirada)",
+    "item.software": "Software usado para editar a imagem",
+    "privacy.title": "Aviso de Privacidade",
+    "privacy.description": "Os dados EXIF podem conter informações sensíveis como localização GPS, números de série do dispositivo e timestamps. Considere remover os dados EXIF antes de compartilhar fotos publicamente."
+  },
+  "ar": {
+    "title": "ما هو EXIF؟",
+    "description": "EXIF (تنسيق ملف الصورة القابل للتبادل) هو معيار يحدد تنسيقات الصور والأصوات المستخدمة بواسطة الكاميرات الرقمية والأنظمة الأخرى.",
+    "contains": "تحتوي بيانات EXIF عادةً على:",
+    "item.camera": "الشركة المصنعة وطراز الكاميرا",
+    "item.settings": "إعدادات الكاميرا (فتحة العدسة، سرعة الغالق، ISO، البعد البؤري)",
+    "item.date": "تاريخ ووقت التقاط الصورة",
+    "item.gps": "إحداثيات GPS (موقع التقاط الصورة)",
+    "item.software": "البرنامج المستخدم لتحرير الصورة",
+    "privacy.title": "إشعار الخصوصية",
+    "privacy.description": "قد تحتوي بيانات EXIF على معلومات حساسة مثل موقع GPS وأرقام تسلسل الجهاز والطوابع الزمنية. فكر في إزالة بيانات EXIF قبل مشاركة الصور علنياً."
+  },
+  "hi": {
+    "title": "EXIF क्या है?",
+    "description": "EXIF (एक्सचेंजेबल इमेज फाइल फॉर्मेट) एक मानक है जो डिजिटल कैमरों और अन्य सिस्टम द्वारा उपयोग की जाने वाली छवियों और ध्वनियों के प्रारूप निर्दिष्ट करता है।",
+    "contains": "EXIF डेटा में आमतौर पर शामिल होता है:",
+    "item.camera": "कैमरा निर्माता और मॉडल",
+    "item.settings": "कैमरा सेटिंग्स (एपर्चर, शटर स्पीड, ISO, फोकल लंबाई)",
+    "item.date": "फोटो लेने की तारीख और समय",
+    "item.gps": "GPS निर्देशांक (फोटो लेने का स्थान)",
+    "item.software": "छवि संपादन के लिए उपयोग किया गया सॉफ्टवेयर",
+    "privacy.title": "गोपनीयता सूचना",
+    "privacy.description": "EXIF डेटा में संवेदनशील जानकारी जैसे GPS स्थान, डिवाइस सीरियल नंबर और टाइमस्टैम्प शामिल हो सकती है। फ़ोटो सार्वजनिक रूप से साझा करने से पहले EXIF डेटा हटाने पर विचार करें।"
+  },
+  "tr": {
+    "title": "EXIF Nedir?",
+    "description": "EXIF (Değiştirilebilir Görüntü Dosyası Formatı), dijital kameralar ve diğer sistemler tarafından kullanılan görüntü ve ses formatlarını belirleyen bir standarttır.",
+    "contains": "EXIF verileri genellikle şunları içerir:",
+    "item.camera": "Kamera markası ve modeli",
+    "item.settings": "Kamera ayarları (diyafram, enstantane hızı, ISO, odak uzaklığı)",
+    "item.date": "Fotoğrafın çekildiği tarih ve saat",
+    "item.gps": "GPS koordinatları (fotoğrafın çekildiği konum)",
+    "item.software": "Görüntüyü düzenlemek için kullanılan yazılım",
+    "privacy.title": "Gizlilik Uyarısı",
+    "privacy.description": "EXIF verileri GPS konumu, cihaz seri numaraları ve zaman damgaları gibi hassas bilgiler içerebilir. Fotoğrafları herkese açık paylaşmadan önce EXIF verilerini kaldırmayı düşünün."
+  },
+  "nl": {
+    "title": "Wat is EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) is een standaard die formaten specificeert voor afbeeldingen en geluiden die worden gebruikt door digitale camera's en andere systemen.",
+    "contains": "EXIF-gegevens bevatten doorgaans:",
+    "item.camera": "Cameramerk en -model",
+    "item.settings": "Camera-instellingen (diafragma, sluitertijd, ISO, brandpuntsafstand)",
+    "item.date": "Datum en tijd waarop de foto is genomen",
+    "item.gps": "GPS-coördinaten (locatie waar de foto is genomen)",
+    "item.software": "Software gebruikt om de afbeelding te bewerken",
+    "privacy.title": "Privacymelding",
+    "privacy.description": "EXIF-gegevens kunnen gevoelige informatie bevatten zoals GPS-locatie, serienummers van apparaten en tijdstempels. Overweeg EXIF-gegevens te verwijderen voordat u foto's openbaar deelt."
+  },
+  "sv": {
+    "title": "Vad är EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) är en standard som specificerar format för bilder och ljud som används av digitalkameror och andra system.",
+    "contains": "EXIF-data innehåller vanligtvis:",
+    "item.camera": "Kameramärke och modell",
+    "item.settings": "Kamerainställningar (bländare, slutartid, ISO, brännvidd)",
+    "item.date": "Datum och tid då fotot togs",
+    "item.gps": "GPS-koordinater (plats där fotot togs)",
+    "item.software": "Programvara som användes för att redigera bilden",
+    "privacy.title": "Integritetsmeddelande",
+    "privacy.description": "EXIF-data kan innehålla känslig information som GPS-plats, enhetens serienummer och tidsstämplar. Överväg att ta bort EXIF-data innan du delar foton offentligt."
+  },
+  "pl": {
+    "title": "Czym jest EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) to standard określający formaty obrazów i dźwięków używanych przez aparaty cyfrowe i inne systemy.",
+    "contains": "Dane EXIF zazwyczaj zawierają:",
+    "item.camera": "Producent i model aparatu",
+    "item.settings": "Ustawienia aparatu (przysłona, czas naświetlania, ISO, ogniskowa)",
+    "item.date": "Data i godzina wykonania zdjęcia",
+    "item.gps": "Współrzędne GPS (miejsce wykonania zdjęcia)",
+    "item.software": "Oprogramowanie użyte do edycji obrazu",
+    "privacy.title": "Informacja o prywatności",
+    "privacy.description": "Dane EXIF mogą zawierać wrażliwe informacje, takie jak lokalizacja GPS, numery seryjne urządzeń i znaczniki czasu. Rozważ usunięcie danych EXIF przed publicznym udostępnieniem zdjęć."
+  },
+  "vi": {
+    "title": "EXIF là gì?",
+    "description": "EXIF (Định dạng Tệp Hình ảnh Có thể Trao đổi) là một tiêu chuẩn quy định các định dạng cho hình ảnh và âm thanh được sử dụng bởi máy ảnh kỹ thuật số và các hệ thống khác.",
+    "contains": "Dữ liệu EXIF thường chứa:",
+    "item.camera": "Hãng và model máy ảnh",
+    "item.settings": "Cài đặt máy ảnh (khẩu độ, tốc độ màn trập, ISO, tiêu cự)",
+    "item.date": "Ngày và giờ chụp ảnh",
+    "item.gps": "Tọa độ GPS (vị trí chụp ảnh)",
+    "item.software": "Phần mềm được sử dụng để chỉnh sửa hình ảnh",
+    "privacy.title": "Thông báo về quyền riêng tư",
+    "privacy.description": "Dữ liệu EXIF có thể chứa thông tin nhạy cảm như vị trí GPS, số seri thiết bị và dấu thời gian. Hãy cân nhắc xóa dữ liệu EXIF trước khi chia sẻ ảnh công khai."
+  },
+  "th": {
+    "title": "EXIF คืออะไร?",
+    "description": "EXIF (Exchangeable Image File Format) เป็นมาตรฐานที่กำหนดรูปแบบสำหรับภาพและเสียงที่ใช้โดยกล้องดิจิทัลและระบบอื่นๆ",
+    "contains": "ข้อมูล EXIF โดยทั่วไปประกอบด้วย:",
+    "item.camera": "ยี่ห้อและรุ่นกล้อง",
+    "item.settings": "การตั้งค่ากล้อง (รูรับแสง ความเร็วชัตเตอร์ ISO ความยาวโฟกัส)",
+    "item.date": "วันที่และเวลาที่ถ่ายภาพ",
+    "item.gps": "พิกัด GPS (สถานที่ถ่ายภาพ)",
+    "item.software": "ซอฟต์แวร์ที่ใช้แก้ไขภาพ",
+    "privacy.title": "ประกาศความเป็นส่วนตัว",
+    "privacy.description": "ข้อมูล EXIF อาจมีข้อมูลที่ละเอียดอ่อน เช่น ตำแหน่ง GPS หมายเลขซีเรียลของอุปกรณ์ และเวลา พิจารณาลบข้อมูล EXIF ก่อนแชร์รูปภาพต่อสาธารณะ"
+  },
+  "id": {
+    "title": "Apa itu EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) adalah standar yang menentukan format untuk gambar dan suara yang digunakan oleh kamera digital dan sistem lainnya.",
+    "contains": "Data EXIF biasanya berisi:",
+    "item.camera": "Merek dan model kamera",
+    "item.settings": "Pengaturan kamera (apertur, kecepatan rana, ISO, panjang fokus)",
+    "item.date": "Tanggal dan waktu pengambilan foto",
+    "item.gps": "Koordinat GPS (lokasi pengambilan foto)",
+    "item.software": "Perangkat lunak yang digunakan untuk mengedit gambar",
+    "privacy.title": "Pemberitahuan Privasi",
+    "privacy.description": "Data EXIF mungkin berisi informasi sensitif seperti lokasi GPS, nomor seri perangkat, dan stempel waktu. Pertimbangkan untuk menghapus data EXIF sebelum membagikan foto secara publik."
+  },
+  "he": {
+    "title": "מה זה EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) הוא תקן המגדיר פורמטים לתמונות וצלילים המשמשים מצלמות דיגיטליות ומערכות אחרות.",
+    "contains": "נתוני EXIF בדרך כלל מכילים:",
+    "item.camera": "יצרן ודגם המצלמה",
+    "item.settings": "הגדרות מצלמה (צמצם, מהירות תריס, ISO, אורך מוקד)",
+    "item.date": "תאריך ושעת צילום התמונה",
+    "item.gps": "קואורדינטות GPS (מיקום צילום התמונה)",
+    "item.software": "תוכנה ששימשה לעריכת התמונה",
+    "privacy.title": "הודעת פרטיות",
+    "privacy.description": "נתוני EXIF עשויים להכיל מידע רגיש כמו מיקום GPS, מספרים סידוריים של מכשירים וחותמות זמן. שקול להסיר נתוני EXIF לפני שיתוף תמונות באופן ציבורי."
+  },
+  "ms": {
+    "title": "Apakah EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) adalah standard yang menentukan format untuk imej dan bunyi yang digunakan oleh kamera digital dan sistem lain.",
+    "contains": "Data EXIF biasanya mengandungi:",
+    "item.camera": "Jenama dan model kamera",
+    "item.settings": "Tetapan kamera (apertur, kelajuan pengatup, ISO, jarak fokus)",
+    "item.date": "Tarikh dan masa foto diambil",
+    "item.gps": "Koordinat GPS (lokasi foto diambil)",
+    "item.software": "Perisian yang digunakan untuk menyunting imej",
+    "privacy.title": "Notis Privasi",
+    "privacy.description": "Data EXIF mungkin mengandungi maklumat sensitif seperti lokasi GPS, nombor siri peranti dan cap masa. Pertimbangkan untuk membuang data EXIF sebelum berkongsi foto secara awam."
+  },
+  "no": {
+    "title": "Hva er EXIF?",
+    "description": "EXIF (Exchangeable Image File Format) er en standard som spesifiserer formater for bilder og lyder som brukes av digitale kameraer og andre systemer.",
+    "contains": "EXIF-data inneholder vanligvis:",
+    "item.camera": "Kameramerke og -modell",
+    "item.settings": "Kamerainnstillinger (blenderåpning, lukkerhastighet, ISO, brennvidde)",
+    "item.date": "Dato og tidspunkt da bildet ble tatt",
+    "item.gps": "GPS-koordinater (stedet der bildet ble tatt)",
+    "item.software": "Programvare brukt til å redigere bildet",
+    "privacy.title": "Personvernvarsel",
+    "privacy.description": "EXIF-data kan inneholde sensitiv informasjon som GPS-plassering, enhetens serienumre og tidsstempler. Vurder å fjerne EXIF-data før du deler bilder offentlig."
+  }
+}
+</i18n>

--- a/tools/image/exif-viewer/src/components/index.ts
+++ b/tools/image/exif-viewer/src/components/index.ts
@@ -1,0 +1,6 @@
+export { default as ImageUpload } from './ImageUpload.vue'
+export { default as ImagePreview } from './ImagePreview.vue'
+export { default as ExifDataDisplay } from './ExifDataDisplay.vue'
+export { default as ExifCategorySection } from './ExifCategorySection.vue'
+export { default as ExifActions } from './ExifActions.vue'
+export { default as WhatIsExif } from './WhatIsExif.vue'

--- a/tools/image/exif-viewer/src/index.ts
+++ b/tools/image/exif-viewer/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/image/exif-viewer/src/info.ts
+++ b/tools/image/exif-viewer/src/info.ts
@@ -1,0 +1,133 @@
+export const toolID = 'exif-viewer'
+export { Image24Regular as icon } from '@shared/icons/fluent'
+export const path = '/tools/exif-viewer'
+export const tags = ['image', 'exif', 'metadata', 'photo', 'gps']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'EXIF Viewer',
+    description:
+      'View and analyze EXIF metadata from images. Extract camera settings, GPS coordinates, timestamps, and other embedded information from photos.',
+  },
+  zh: {
+    name: 'EXIF 查看器',
+    description:
+      '查看和分析图片中的 EXIF 元数据。提取相机设置、GPS 坐标、时间戳和照片中嵌入的其他信息。',
+  },
+  'zh-CN': {
+    name: 'EXIF 查看器',
+    description:
+      '查看和分析图片中的 EXIF 元数据。提取相机设置、GPS 坐标、时间戳和照片中嵌入的其他信息。',
+  },
+  'zh-TW': {
+    name: 'EXIF 檢視器',
+    description:
+      '檢視和分析圖片中的 EXIF 元資料。擷取相機設定、GPS 座標、時間戳記和照片中嵌入的其他資訊。',
+  },
+  'zh-HK': {
+    name: 'EXIF 檢視器',
+    description:
+      '檢視和分析圖片中的 EXIF 元資料。擷取相機設定、GPS 座標、時間戳記和照片中嵌入的其他資訊。',
+  },
+  es: {
+    name: 'Visor EXIF',
+    description:
+      'Ver y analizar metadatos EXIF de imágenes. Extraer configuraciones de cámara, coordenadas GPS, marcas de tiempo y otra información incrustada en las fotos.',
+  },
+  fr: {
+    name: 'Visionneuse EXIF',
+    description:
+      "Visualiser et analyser les métadonnées EXIF des images. Extraire les paramètres de l'appareil photo, les coordonnées GPS, les horodatages et autres informations intégrées aux photos.",
+  },
+  de: {
+    name: 'EXIF-Viewer',
+    description:
+      'EXIF-Metadaten aus Bildern anzeigen und analysieren. Kameraeinstellungen, GPS-Koordinaten, Zeitstempel und andere eingebettete Informationen aus Fotos extrahieren.',
+  },
+  it: {
+    name: 'Visualizzatore EXIF',
+    description:
+      'Visualizza e analizza i metadati EXIF delle immagini. Estrai le impostazioni della fotocamera, le coordinate GPS, i timestamp e altre informazioni incorporate nelle foto.',
+  },
+  ja: {
+    name: 'EXIF ビューアー',
+    description:
+      '画像からEXIFメタデータを表示・分析します。カメラ設定、GPS座標、タイムスタンプ、写真に埋め込まれたその他の情報を抽出します。',
+  },
+  ko: {
+    name: 'EXIF 뷰어',
+    description:
+      '이미지에서 EXIF 메타데이터를 보고 분석합니다. 카메라 설정, GPS 좌표, 타임스탬프 및 사진에 포함된 기타 정보를 추출합니다.',
+  },
+  ru: {
+    name: 'Просмотр EXIF',
+    description:
+      'Просмотр и анализ метаданных EXIF из изображений. Извлечение настроек камеры, GPS-координат, временных меток и другой встроенной информации из фотографий.',
+  },
+  pt: {
+    name: 'Visualizador EXIF',
+    description:
+      'Visualize e analise metadados EXIF de imagens. Extraia configurações de câmera, coordenadas GPS, timestamps e outras informações incorporadas nas fotos.',
+  },
+  ar: {
+    name: 'عارض EXIF',
+    description:
+      'عرض وتحليل بيانات EXIF الوصفية من الصور. استخراج إعدادات الكاميرا وإحداثيات GPS والطوابع الزمنية والمعلومات الأخرى المضمنة في الصور.',
+  },
+  hi: {
+    name: 'EXIF व्यूअर',
+    description:
+      'छवियों से EXIF मेटाडेटा देखें और विश्लेषण करें। कैमरा सेटिंग्स, GPS निर्देशांक, टाइमस्टैम्प और फ़ोटो में एम्बेड की गई अन्य जानकारी निकालें।',
+  },
+  tr: {
+    name: 'EXIF Görüntüleyici',
+    description:
+      'Görüntülerden EXIF meta verilerini görüntüleyin ve analiz edin. Kamera ayarlarını, GPS koordinatlarını, zaman damgalarını ve fotoğraflara gömülü diğer bilgileri çıkarın.',
+  },
+  nl: {
+    name: 'EXIF Viewer',
+    description:
+      "Bekijk en analyseer EXIF-metadata van afbeeldingen. Extraheer camera-instellingen, GPS-coördinaten, timestamps en andere ingebedde informatie uit foto's.",
+  },
+  sv: {
+    name: 'EXIF-visare',
+    description:
+      'Visa och analysera EXIF-metadata från bilder. Extrahera kamerainställningar, GPS-koordinater, tidsstämplar och annan inbäddad information från foton.',
+  },
+  pl: {
+    name: 'Przeglądarka EXIF',
+    description:
+      'Przeglądaj i analizuj metadane EXIF ze zdjęć. Wyodrębnij ustawienia aparatu, współrzędne GPS, znaczniki czasu i inne osadzone informacje ze zdjęć.',
+  },
+  vi: {
+    name: 'Trình xem EXIF',
+    description:
+      'Xem và phân tích dữ liệu EXIF từ hình ảnh. Trích xuất cài đặt máy ảnh, tọa độ GPS, dấu thời gian và thông tin khác được nhúng trong ảnh.',
+  },
+  th: {
+    name: 'ตัวดู EXIF',
+    description:
+      'ดูและวิเคราะห์ข้อมูล EXIF จากภาพ สกัดการตั้งค่ากล้อง พิกัด GPS เวลา และข้อมูลอื่นๆ ที่ฝังอยู่ในรูปภาพ',
+  },
+  id: {
+    name: 'Penampil EXIF',
+    description:
+      'Lihat dan analisis metadata EXIF dari gambar. Ekstrak pengaturan kamera, koordinat GPS, timestamp, dan informasi lain yang tertanam dalam foto.',
+  },
+  he: {
+    name: 'מציג EXIF',
+    description:
+      'צפה ונתח נתוני EXIF מתמונות. חלץ הגדרות מצלמה, קואורדינטות GPS, חותמות זמן ומידע מוטמע אחר מתצלומים.',
+  },
+  ms: {
+    name: 'Pemapar EXIF',
+    description:
+      'Lihat dan analisis metadata EXIF daripada imej. Ekstrak tetapan kamera, koordinat GPS, cap masa dan maklumat lain yang dibenamkan dalam foto.',
+  },
+  no: {
+    name: 'EXIF-visning',
+    description:
+      'Vis og analyser EXIF-metadata fra bilder. Trekk ut kamerainnstillinger, GPS-koordinater, tidsstempler og annen innebygd informasjon fra bilder.',
+  },
+}

--- a/tools/image/exif-viewer/src/routes.ts
+++ b/tools/image/exif-viewer/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'exif-viewer',
+    path: '/tools/exif-viewer',
+    component: () => import('./ExifViewerView.vue'),
+  },
+] as const


### PR DESCRIPTION
## Summary
- Add new EXIF Viewer tool to extract and display image metadata
- Support JPEG, PNG, HEIC, TIFF, WebP, GIF formats
- Categorized display: Basic Info, Camera Info, GPS Location, Advanced Info
- GPS coordinates with links to Google Maps and Amap
- Copy all EXIF data as JSON
- Privacy notice warning about sensitive metadata

## Test plan
- [x] Upload various image formats (JPEG with EXIF, PNG, etc.)
- [x] Verify EXIF data is correctly parsed and displayed
- [x] Test GPS location links
- [x] Test copy JSON functionality
- [x] Verify all 25 languages display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)