### PR TITLE
feat(tools): add slug generator tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,9 @@ importers:
       '@tools/sha512-hash-text-or-file':
         specifier: workspace:*
         version: link:../../tools/hash/sha512-hash-text-or-file
+      '@tools/slug-generator':
+        specifier: workspace:*
+        version: link:../../tools/web/slug-generator
       '@tools/sri-hash-generator':
         specifier: workspace:*
         version: link:../../tools/hash/sri-hash-generator
@@ -3573,6 +3576,33 @@ importers:
       naive-ui:
         specifier: 'catalog:'
         version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
+
+  tools/web/slug-generator:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      transliteration:
+        specifier: ^2.6.0
+        version: 2.6.0
       vue:
         specifier: 'catalog:'
         version: 3.5.26(typescript@5.9.3)
@@ -8215,6 +8245,11 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  transliteration@2.6.0:
+    resolution: {integrity: sha512-T6frfMj7N5xNK0l+duIzIWKxkc9ewG72uv7NeOs4dIoysqTnYpwxeVEE5qYdKKmy7hby55ah0wNUoMaLsB2Zjw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
 
   treemate@0.3.11:
     resolution: {integrity: sha512-M8RGFoKtZ8dF+iwJfAJTOH/SM4KluKOKRJpjCMhI8bG3qB74zrFoArKZ62ll0Fr3mqkMJiQOmWYkdYgDeITYQg==}
@@ -13373,6 +13408,8 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  transliteration@2.6.0: {}
 
   treemate@0.3.11: {}
 

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -81,6 +81,7 @@
     "@tools/sha256-hash-text-or-file": "workspace:*",
     "@tools/sha384-hash-text-or-file": "workspace:*",
     "@tools/sha512-hash-text-or-file": "workspace:*",
+    "@tools/slug-generator": "workspace:*",
     "@tools/sri-hash-generator": "workspace:*",
     "@tools/text-diff": "workspace:*",
     "@tools/text-statistics": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -86,6 +86,7 @@ import { toolInfo as textStatisticsToolInfo } from '@tools/text-statistics'
 import { toolInfo as loremIpsumGeneratorToolInfo } from '@tools/lorem-ipsum-generator'
 import { toolInfo as creditCardValidatorToolInfo } from '@tools/credit-card-validator'
 import { toolInfo as placeholderImageGeneratorToolInfo } from '@tools/placeholder-image-generator'
+import { toolInfo as slugGeneratorToolInfo } from '@tools/slug-generator'
 
 export const tools: ToolInfo[] = [
   // Network Tools
@@ -116,7 +117,6 @@ export const tools: ToolInfo[] = [
   exifViewerToolInfo,
   qrCodeGeneratorToolInfo,
   barcodeGeneratorToolInfo,
-  placeholderImageGeneratorToolInfo,
   markdownToHtmlConverterToolInfo,
   htmlToMarkdownConverterToolInfo,
   jsonToYamlBuilderToolInfo,
@@ -207,4 +207,10 @@ export const tools: ToolInfo[] = [
 
   // Validator Tools
   creditCardValidatorToolInfo,
+
+  // Web Tools (Slug)
+  slugGeneratorToolInfo,
+
+  // Image Tools (Placeholder)
+  placeholderImageGeneratorToolInfo,
 ]

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -84,6 +84,7 @@ import { routes as textStatisticsRoutes } from '@tools/text-statistics/routes'
 import { routes as loremIpsumGeneratorRoutes } from '@tools/lorem-ipsum-generator/routes'
 import { routes as creditCardValidatorRoutes } from '@tools/credit-card-validator/routes'
 import { routes as placeholderImageGeneratorRoutes } from '@tools/placeholder-image-generator/routes'
+import { routes as slugGeneratorRoutes } from '@tools/slug-generator/routes'
 
 export const routes: ToolRoute[] = [
   ...faviconAssetsGeneratorRoutes,
@@ -171,4 +172,5 @@ export const routes: ToolRoute[] = [
   ...loremIpsumGeneratorRoutes,
   ...creditCardValidatorRoutes,
   ...placeholderImageGeneratorRoutes,
+  ...slugGeneratorRoutes,
 ]

--- a/tools/web/slug-generator/package.json
+++ b/tools/web/slug-generator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/slug-generator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "transliteration": "^2.6.0",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/web/slug-generator/src/SlugGeneratorView.vue
+++ b/tools/web/slug-generator/src/SlugGeneratorView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <SlugGenerator />
+    <WhatIsSlug />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import * as toolInfo from './info'
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import SlugGenerator from './components/SlugGenerator.vue'
+import WhatIsSlug from './components/WhatIsSlug.vue'
+</script>

--- a/tools/web/slug-generator/src/components/SlugGenerator.vue
+++ b/tools/web/slug-generator/src/components/SlugGenerator.vue
@@ -1,0 +1,441 @@
+<template>
+  <ToolSection>
+    <n-flex justify="space-between" align="center" style="margin-bottom: 8px">
+      <span class="section-label">{{ t('input') }}</span>
+      <n-button size="small" quaternary @click="inputText = ''">
+        {{ t('clear') }}
+      </n-button>
+    </n-flex>
+    <n-input
+      v-model:value="inputText"
+      type="textarea"
+      :placeholder="t('inputPlaceholder')"
+      :autosize="{ minRows: 3, maxRows: 8 }"
+    />
+  </ToolSection>
+
+  <ToolSection>
+    <n-flex :gap="24" :wrap="true">
+      <n-form-item :label="t('separator')" :show-feedback="false">
+        <n-radio-group v-model:value="separator">
+          <n-radio-button value="-">- ({{ t('hyphen') }})</n-radio-button>
+          <n-radio-button value="_">_ ({{ t('underscore') }})</n-radio-button>
+          <n-radio-button value=".">. ({{ t('dot') }})</n-radio-button>
+        </n-radio-group>
+      </n-form-item>
+      <n-form-item :label="t('case')" :show-feedback="false">
+        <n-radio-group v-model:value="caseOption">
+          <n-radio-button value="lower">{{ t('lowercase') }}</n-radio-button>
+          <n-radio-button value="preserve">{{ t('preserve') }}</n-radio-button>
+        </n-radio-group>
+      </n-form-item>
+    </n-flex>
+  </ToolSection>
+
+  <ToolSection>
+    <n-flex justify="space-between" align="center" style="margin-bottom: 8px">
+      <span class="section-label">{{ t('output') }}</span>
+      <CopyToClipboardButton :content="slugOutput" />
+    </n-flex>
+    <n-card embedded :content-style="{ padding: '12px 16px' }">
+      <n-text v-if="slugOutput" code>{{ slugOutput }}</n-text>
+      <n-text v-else depth="3">{{ t('outputPlaceholder') }}</n-text>
+    </n-card>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useStorage } from '@vueuse/core'
+import {
+  NInput,
+  NButton,
+  NFlex,
+  NFormItem,
+  NRadioGroup,
+  NRadioButton,
+  NCard,
+  NText,
+} from 'naive-ui'
+import { slugify } from 'transliteration'
+import { ToolSection } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+const { t } = useI18n()
+
+const inputText = useStorage('tools:slug-generator:input', 'Hello World Example')
+const separator = useStorage<'-' | '_' | '.'>('tools:slug-generator:separator', '-')
+const caseOption = useStorage<'lower' | 'preserve'>('tools:slug-generator:case', 'lower')
+
+const slugOutput = computed(() => {
+  if (!inputText.value.trim()) return ''
+
+  return slugify(inputText.value, {
+    separator: separator.value,
+    lowercase: caseOption.value === 'lower',
+    trim: true,
+  })
+})
+</script>
+
+<style scoped>
+.section-label {
+  font-weight: 500;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "input": "Input Text",
+    "inputPlaceholder": "Enter text to convert to slug...",
+    "output": "Generated Slug",
+    "outputPlaceholder": "Slug will appear here...",
+    "separator": "Separator",
+    "hyphen": "hyphen",
+    "underscore": "underscore",
+    "dot": "dot",
+    "case": "Case",
+    "lowercase": "Lowercase",
+    "preserve": "Preserve",
+    "clear": "Clear"
+  },
+  "zh": {
+    "input": "输入文本",
+    "inputPlaceholder": "输入要转换为 slug 的文本...",
+    "output": "生成的 Slug",
+    "outputPlaceholder": "Slug 将显示在这里...",
+    "separator": "分隔符",
+    "hyphen": "连字符",
+    "underscore": "下划线",
+    "dot": "点",
+    "case": "大小写",
+    "lowercase": "小写",
+    "preserve": "保留原样",
+    "clear": "清空"
+  },
+  "zh-CN": {
+    "input": "输入文本",
+    "inputPlaceholder": "输入要转换为 slug 的文本...",
+    "output": "生成的 Slug",
+    "outputPlaceholder": "Slug 将显示在这里...",
+    "separator": "分隔符",
+    "hyphen": "连字符",
+    "underscore": "下划线",
+    "dot": "点",
+    "case": "大小写",
+    "lowercase": "小写",
+    "preserve": "保留原样",
+    "clear": "清空"
+  },
+  "zh-TW": {
+    "input": "輸入文字",
+    "inputPlaceholder": "輸入要轉換為 slug 的文字...",
+    "output": "產生的 Slug",
+    "outputPlaceholder": "Slug 將顯示在這裡...",
+    "separator": "分隔符",
+    "hyphen": "連字符",
+    "underscore": "底線",
+    "dot": "點",
+    "case": "大小寫",
+    "lowercase": "小寫",
+    "preserve": "保留原樣",
+    "clear": "清除"
+  },
+  "zh-HK": {
+    "input": "輸入文字",
+    "inputPlaceholder": "輸入要轉換為 slug 的文字...",
+    "output": "產生的 Slug",
+    "outputPlaceholder": "Slug 將顯示在這裡...",
+    "separator": "分隔符",
+    "hyphen": "連字符",
+    "underscore": "底線",
+    "dot": "點",
+    "case": "大小寫",
+    "lowercase": "小寫",
+    "preserve": "保留原樣",
+    "clear": "清除"
+  },
+  "es": {
+    "input": "Texto de entrada",
+    "inputPlaceholder": "Ingrese texto para convertir a slug...",
+    "output": "Slug generado",
+    "outputPlaceholder": "El slug aparecerá aquí...",
+    "separator": "Separador",
+    "hyphen": "guion",
+    "underscore": "guion bajo",
+    "dot": "punto",
+    "case": "Mayúsculas",
+    "lowercase": "Minúsculas",
+    "preserve": "Preservar",
+    "clear": "Limpiar"
+  },
+  "fr": {
+    "input": "Texte d'entrée",
+    "inputPlaceholder": "Entrez le texte à convertir en slug...",
+    "output": "Slug généré",
+    "outputPlaceholder": "Le slug apparaîtra ici...",
+    "separator": "Séparateur",
+    "hyphen": "tiret",
+    "underscore": "underscore",
+    "dot": "point",
+    "case": "Casse",
+    "lowercase": "Minuscules",
+    "preserve": "Préserver",
+    "clear": "Effacer"
+  },
+  "de": {
+    "input": "Eingabetext",
+    "inputPlaceholder": "Text zur Umwandlung in Slug eingeben...",
+    "output": "Generierter Slug",
+    "outputPlaceholder": "Slug wird hier angezeigt...",
+    "separator": "Trennzeichen",
+    "hyphen": "Bindestrich",
+    "underscore": "Unterstrich",
+    "dot": "Punkt",
+    "case": "Groß-/Kleinschreibung",
+    "lowercase": "Kleinbuchstaben",
+    "preserve": "Beibehalten",
+    "clear": "Leeren"
+  },
+  "it": {
+    "input": "Testo di input",
+    "inputPlaceholder": "Inserisci il testo da convertire in slug...",
+    "output": "Slug generato",
+    "outputPlaceholder": "Lo slug apparirà qui...",
+    "separator": "Separatore",
+    "hyphen": "trattino",
+    "underscore": "underscore",
+    "dot": "punto",
+    "case": "Maiuscole/minuscole",
+    "lowercase": "Minuscolo",
+    "preserve": "Mantieni",
+    "clear": "Cancella"
+  },
+  "ja": {
+    "input": "入力テキスト",
+    "inputPlaceholder": "slugに変換するテキストを入力...",
+    "output": "生成されたSlug",
+    "outputPlaceholder": "Slugがここに表示されます...",
+    "separator": "区切り文字",
+    "hyphen": "ハイフン",
+    "underscore": "アンダースコア",
+    "dot": "ドット",
+    "case": "大文字/小文字",
+    "lowercase": "小文字",
+    "preserve": "維持",
+    "clear": "クリア"
+  },
+  "ko": {
+    "input": "입력 텍스트",
+    "inputPlaceholder": "slug로 변환할 텍스트를 입력하세요...",
+    "output": "생성된 Slug",
+    "outputPlaceholder": "Slug가 여기에 표시됩니다...",
+    "separator": "구분자",
+    "hyphen": "하이픈",
+    "underscore": "밑줄",
+    "dot": "점",
+    "case": "대소문자",
+    "lowercase": "소문자",
+    "preserve": "유지",
+    "clear": "지우기"
+  },
+  "ru": {
+    "input": "Входной текст",
+    "inputPlaceholder": "Введите текст для преобразования в slug...",
+    "output": "Сгенерированный Slug",
+    "outputPlaceholder": "Slug появится здесь...",
+    "separator": "Разделитель",
+    "hyphen": "дефис",
+    "underscore": "подчёркивание",
+    "dot": "точка",
+    "case": "Регистр",
+    "lowercase": "Нижний регистр",
+    "preserve": "Сохранить",
+    "clear": "Очистить"
+  },
+  "pt": {
+    "input": "Texto de entrada",
+    "inputPlaceholder": "Digite o texto para converter em slug...",
+    "output": "Slug gerado",
+    "outputPlaceholder": "O slug aparecerá aqui...",
+    "separator": "Separador",
+    "hyphen": "hífen",
+    "underscore": "sublinhado",
+    "dot": "ponto",
+    "case": "Maiúsculas/Minúsculas",
+    "lowercase": "Minúsculas",
+    "preserve": "Preservar",
+    "clear": "Limpar"
+  },
+  "ar": {
+    "input": "نص الإدخال",
+    "inputPlaceholder": "أدخل النص للتحويل إلى slug...",
+    "output": "Slug المُنشأ",
+    "outputPlaceholder": "سيظهر الـ slug هنا...",
+    "separator": "الفاصل",
+    "hyphen": "شرطة",
+    "underscore": "شرطة سفلية",
+    "dot": "نقطة",
+    "case": "حالة الأحرف",
+    "lowercase": "أحرف صغيرة",
+    "preserve": "الحفاظ",
+    "clear": "مسح"
+  },
+  "hi": {
+    "input": "इनपुट टेक्स्ट",
+    "inputPlaceholder": "slug में बदलने के लिए टेक्स्ट दर्ज करें...",
+    "output": "जनरेट किया गया Slug",
+    "outputPlaceholder": "Slug यहाँ दिखाई देगा...",
+    "separator": "विभाजक",
+    "hyphen": "हाइफ़न",
+    "underscore": "अंडरस्कोर",
+    "dot": "डॉट",
+    "case": "केस",
+    "lowercase": "लोअरकेस",
+    "preserve": "संरक्षित करें",
+    "clear": "साफ़ करें"
+  },
+  "tr": {
+    "input": "Giriş Metni",
+    "inputPlaceholder": "Slug'a dönüştürülecek metni girin...",
+    "output": "Oluşturulan Slug",
+    "outputPlaceholder": "Slug burada görünecek...",
+    "separator": "Ayırıcı",
+    "hyphen": "tire",
+    "underscore": "alt çizgi",
+    "dot": "nokta",
+    "case": "Büyük/Küçük Harf",
+    "lowercase": "Küçük harf",
+    "preserve": "Koru",
+    "clear": "Temizle"
+  },
+  "nl": {
+    "input": "Invoertekst",
+    "inputPlaceholder": "Voer tekst in om naar slug te converteren...",
+    "output": "Gegenereerde Slug",
+    "outputPlaceholder": "Slug verschijnt hier...",
+    "separator": "Scheidingsteken",
+    "hyphen": "koppelteken",
+    "underscore": "underscore",
+    "dot": "punt",
+    "case": "Hoofdletters",
+    "lowercase": "Kleine letters",
+    "preserve": "Behouden",
+    "clear": "Wissen"
+  },
+  "sv": {
+    "input": "Inmatningstext",
+    "inputPlaceholder": "Ange text att konvertera till slug...",
+    "output": "Genererad Slug",
+    "outputPlaceholder": "Slug visas här...",
+    "separator": "Separator",
+    "hyphen": "bindestreck",
+    "underscore": "understreck",
+    "dot": "punkt",
+    "case": "Skiftläge",
+    "lowercase": "Gemener",
+    "preserve": "Bevara",
+    "clear": "Rensa"
+  },
+  "pl": {
+    "input": "Tekst wejściowy",
+    "inputPlaceholder": "Wprowadź tekst do konwersji na slug...",
+    "output": "Wygenerowany Slug",
+    "outputPlaceholder": "Slug pojawi się tutaj...",
+    "separator": "Separator",
+    "hyphen": "myślnik",
+    "underscore": "podkreślenie",
+    "dot": "kropka",
+    "case": "Wielkość liter",
+    "lowercase": "Małe litery",
+    "preserve": "Zachowaj",
+    "clear": "Wyczyść"
+  },
+  "vi": {
+    "input": "Văn bản đầu vào",
+    "inputPlaceholder": "Nhập văn bản để chuyển đổi thành slug...",
+    "output": "Slug đã tạo",
+    "outputPlaceholder": "Slug sẽ xuất hiện ở đây...",
+    "separator": "Dấu phân cách",
+    "hyphen": "gạch ngang",
+    "underscore": "gạch dưới",
+    "dot": "chấm",
+    "case": "Chữ hoa/thường",
+    "lowercase": "Chữ thường",
+    "preserve": "Giữ nguyên",
+    "clear": "Xóa"
+  },
+  "th": {
+    "input": "ข้อความนำเข้า",
+    "inputPlaceholder": "ป้อนข้อความเพื่อแปลงเป็น slug...",
+    "output": "Slug ที่สร้างขึ้น",
+    "outputPlaceholder": "Slug จะปรากฏที่นี่...",
+    "separator": "ตัวคั่น",
+    "hyphen": "ขีด",
+    "underscore": "ขีดล่าง",
+    "dot": "จุด",
+    "case": "ตัวพิมพ์",
+    "lowercase": "ตัวพิมพ์เล็ก",
+    "preserve": "คงไว้",
+    "clear": "ล้าง"
+  },
+  "id": {
+    "input": "Teks Masukan",
+    "inputPlaceholder": "Masukkan teks untuk dikonversi ke slug...",
+    "output": "Slug yang Dihasilkan",
+    "outputPlaceholder": "Slug akan muncul di sini...",
+    "separator": "Pemisah",
+    "hyphen": "tanda hubung",
+    "underscore": "garis bawah",
+    "dot": "titik",
+    "case": "Huruf Besar/Kecil",
+    "lowercase": "Huruf kecil",
+    "preserve": "Pertahankan",
+    "clear": "Hapus"
+  },
+  "he": {
+    "input": "טקסט קלט",
+    "inputPlaceholder": "הזן טקסט להמרה ל-slug...",
+    "output": "Slug שנוצר",
+    "outputPlaceholder": "ה-slug יופיע כאן...",
+    "separator": "מפריד",
+    "hyphen": "מקף",
+    "underscore": "קו תחתון",
+    "dot": "נקודה",
+    "case": "רישיות",
+    "lowercase": "אותיות קטנות",
+    "preserve": "שמור",
+    "clear": "נקה"
+  },
+  "ms": {
+    "input": "Teks Input",
+    "inputPlaceholder": "Masukkan teks untuk ditukar kepada slug...",
+    "output": "Slug yang Dijana",
+    "outputPlaceholder": "Slug akan muncul di sini...",
+    "separator": "Pemisah",
+    "hyphen": "sempang",
+    "underscore": "garis bawah",
+    "dot": "titik",
+    "case": "Huruf Besar/Kecil",
+    "lowercase": "Huruf kecil",
+    "preserve": "Kekalkan",
+    "clear": "Kosongkan"
+  },
+  "no": {
+    "input": "Inndatatekst",
+    "inputPlaceholder": "Skriv inn tekst for å konvertere til slug...",
+    "output": "Generert Slug",
+    "outputPlaceholder": "Slug vises her...",
+    "separator": "Skilletegn",
+    "hyphen": "bindestrek",
+    "underscore": "understrek",
+    "dot": "punktum",
+    "case": "Store/små bokstaver",
+    "lowercase": "Små bokstaver",
+    "preserve": "Bevar",
+    "clear": "Tøm"
+  }
+}
+</i18n>

--- a/tools/web/slug-generator/src/components/WhatIsSlug.vue
+++ b/tools/web/slug-generator/src/components/WhatIsSlug.vue
@@ -1,0 +1,225 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-text>{{ t('description') }}</n-text>
+    <n-ul style="margin-top: 12px">
+      <n-li>{{ t('example1') }}</n-li>
+      <n-li>{{ t('example2') }}</n-li>
+      <n-li>{{ t('example3') }}</n-li>
+    </n-ul>
+    <n-text style="margin-top: 12px; display: block">{{ t('benefits') }}</n-text>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { NText, NUl, NLi } from 'naive-ui'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is a Slug?",
+    "description": "A slug is a URL-friendly version of a string, typically used for creating human-readable and SEO-friendly URLs. It converts text by removing special characters, replacing spaces with hyphens, and converting to lowercase.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"My Blog Post Title\" → \"my-blog-post-title\"",
+    "example3": "\"Product: iPhone 15 Pro\" → \"product-iphone-15-pro\"",
+    "benefits": "Slugs improve URL readability, help with SEO, and make links easier to share and remember."
+  },
+  "zh": {
+    "title": "什么是 Slug？",
+    "description": "Slug 是字符串的 URL 友好版本，通常用于创建人类可读且对 SEO 友好的 URL。它通过移除特殊字符、用连字符替换空格并转换为小写来转换文本。",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"我的博客文章标题\" → \"wo-de-bo-ke-wen-zhang-biao-ti\"",
+    "example3": "\"产品：iPhone 15 Pro\" → \"chan-pin-iphone-15-pro\"",
+    "benefits": "Slug 提高了 URL 的可读性，有助于 SEO，并使链接更容易分享和记忆。"
+  },
+  "zh-CN": {
+    "title": "什么是 Slug？",
+    "description": "Slug 是字符串的 URL 友好版本，通常用于创建人类可读且对 SEO 友好的 URL。它通过移除特殊字符、用连字符替换空格并转换为小写来转换文本。",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"我的博客文章标题\" → \"wo-de-bo-ke-wen-zhang-biao-ti\"",
+    "example3": "\"产品：iPhone 15 Pro\" → \"chan-pin-iphone-15-pro\"",
+    "benefits": "Slug 提高了 URL 的可读性，有助于 SEO，并使链接更容易分享和记忆。"
+  },
+  "zh-TW": {
+    "title": "什麼是 Slug？",
+    "description": "Slug 是字串的網址友善版本，通常用於建立人類可讀且對 SEO 友善的網址。它透過移除特殊字元、用連字符取代空格並轉換為小寫來轉換文字。",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"我的部落格文章標題\" → \"wo-de-bu-luo-ge-wen-zhang-biao-ti\"",
+    "example3": "\"產品：iPhone 15 Pro\" → \"chan-pin-iphone-15-pro\"",
+    "benefits": "Slug 提高了網址的可讀性，有助於 SEO，並使連結更容易分享和記憶。"
+  },
+  "zh-HK": {
+    "title": "什麼是 Slug？",
+    "description": "Slug 是字串的網址友善版本，通常用於建立人類可讀且對 SEO 友善的網址。它透過移除特殊字元、用連字符取代空格並轉換為小寫來轉換文字。",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"我的部落格文章標題\" → \"wo-de-bu-luo-ge-wen-zhang-biao-ti\"",
+    "example3": "\"產品：iPhone 15 Pro\" → \"chan-pin-iphone-15-pro\"",
+    "benefits": "Slug 提高了網址的可讀性，有助於 SEO，並使連結更容易分享和記憶。"
+  },
+  "es": {
+    "title": "¿Qué es un Slug?",
+    "description": "Un slug es una versión amigable para URLs de una cadena de texto, típicamente usada para crear URLs legibles y amigables para SEO. Convierte el texto eliminando caracteres especiales, reemplazando espacios con guiones y convirtiendo a minúsculas.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Mi Título de Blog\" → \"mi-titulo-de-blog\"",
+    "example3": "\"Producto: iPhone 15 Pro\" → \"producto-iphone-15-pro\"",
+    "benefits": "Los slugs mejoran la legibilidad de las URLs, ayudan con el SEO y hacen que los enlaces sean más fáciles de compartir y recordar."
+  },
+  "fr": {
+    "title": "Qu'est-ce qu'un Slug ?",
+    "description": "Un slug est une version compatible URL d'une chaîne de caractères, généralement utilisée pour créer des URLs lisibles et optimisées pour le SEO. Il convertit le texte en supprimant les caractères spéciaux, en remplaçant les espaces par des tirets et en convertissant en minuscules.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Mon Titre de Blog\" → \"mon-titre-de-blog\"",
+    "example3": "\"Produit : iPhone 15 Pro\" → \"produit-iphone-15-pro\"",
+    "benefits": "Les slugs améliorent la lisibilité des URLs, aident au SEO et rendent les liens plus faciles à partager et à mémoriser."
+  },
+  "de": {
+    "title": "Was ist ein Slug?",
+    "description": "Ein Slug ist eine URL-freundliche Version eines Strings, die typischerweise verwendet wird, um lesbare und SEO-freundliche URLs zu erstellen. Er konvertiert Text, indem Sonderzeichen entfernt, Leerzeichen durch Bindestriche ersetzt und in Kleinbuchstaben umgewandelt werden.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Mein Blog-Titel\" → \"mein-blog-titel\"",
+    "example3": "\"Produkt: iPhone 15 Pro\" → \"produkt-iphone-15-pro\"",
+    "benefits": "Slugs verbessern die URL-Lesbarkeit, helfen bei SEO und machen Links einfacher zu teilen und zu merken."
+  },
+  "it": {
+    "title": "Cos'è uno Slug?",
+    "description": "Uno slug è una versione di una stringa compatibile con gli URL, tipicamente usata per creare URL leggibili e ottimizzati per la SEO. Converte il testo rimuovendo i caratteri speciali, sostituendo gli spazi con trattini e convertendo in minuscolo.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Il Mio Titolo del Blog\" → \"il-mio-titolo-del-blog\"",
+    "example3": "\"Prodotto: iPhone 15 Pro\" → \"prodotto-iphone-15-pro\"",
+    "benefits": "Gli slug migliorano la leggibilità degli URL, aiutano con la SEO e rendono i link più facili da condividere e ricordare."
+  },
+  "ja": {
+    "title": "Slugとは？",
+    "description": "Slugは文字列のURL対応バージョンで、通常は人間が読みやすくSEOに優しいURLを作成するために使用されます。特殊文字を削除し、スペースをハイフンに置き換え、小文字に変換することでテキストを変換します。",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"私のブログタイトル\" → \"si-noburogutaitoru\"",
+    "example3": "\"製品：iPhone 15 Pro\" → \"zhi-pin-iphone-15-pro\"",
+    "benefits": "SlugはURLの可読性を向上させ、SEOに役立ち、リンクを共有しやすく覚えやすくします。"
+  },
+  "ko": {
+    "title": "Slug란 무엇인가요?",
+    "description": "Slug는 문자열의 URL 친화적인 버전으로, 일반적으로 사람이 읽을 수 있고 SEO에 친화적인 URL을 만드는 데 사용됩니다. 특수 문자를 제거하고, 공백을 하이픈으로 바꾸고, 소문자로 변환하여 텍스트를 변환합니다.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"내 블로그 제목\" → \"nae-beullogeu-jemok\"",
+    "example3": "\"제품: iPhone 15 Pro\" → \"jepum-iphone-15-pro\"",
+    "benefits": "Slug는 URL 가독성을 향상시키고, SEO에 도움이 되며, 링크를 공유하고 기억하기 쉽게 만듭니다."
+  },
+  "ru": {
+    "title": "Что такое Slug?",
+    "description": "Slug — это URL-совместимая версия строки, обычно используемая для создания читаемых и SEO-оптимизированных URL-адресов. Он преобразует текст, удаляя специальные символы, заменяя пробелы дефисами и переводя в нижний регистр.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Мой Заголовок Блога\" → \"moj-zagolovok-bloga\"",
+    "example3": "\"Продукт: iPhone 15 Pro\" → \"produkt-iphone-15-pro\"",
+    "benefits": "Slug улучшает читаемость URL, помогает с SEO и делает ссылки более удобными для распространения и запоминания."
+  },
+  "pt": {
+    "title": "O que é um Slug?",
+    "description": "Um slug é uma versão amigável para URL de uma string, tipicamente usada para criar URLs legíveis e otimizadas para SEO. Ele converte o texto removendo caracteres especiais, substituindo espaços por hífens e convertendo para minúsculas.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Meu Título de Blog\" → \"meu-titulo-de-blog\"",
+    "example3": "\"Produto: iPhone 15 Pro\" → \"produto-iphone-15-pro\"",
+    "benefits": "Slugs melhoram a legibilidade das URLs, ajudam com SEO e tornam os links mais fáceis de compartilhar e lembrar."
+  },
+  "ar": {
+    "title": "ما هو الـ Slug؟",
+    "description": "الـ Slug هو نسخة متوافقة مع عناوين URL من النص، تُستخدم عادةً لإنشاء عناوين URL قابلة للقراءة وصديقة لمحركات البحث. يقوم بتحويل النص عن طريق إزالة الأحرف الخاصة، واستبدال المسافات بشرطات، وتحويلها إلى أحرف صغيرة.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"عنوان مدونتي\" → \"anwan-mdwnty\"",
+    "example3": "\"منتج: iPhone 15 Pro\" → \"mntj-iphone-15-pro\"",
+    "benefits": "تحسن الـ Slugs قابلية قراءة عناوين URL، وتساعد في تحسين محركات البحث، وتجعل الروابط أسهل للمشاركة والتذكر."
+  },
+  "hi": {
+    "title": "Slug क्या है?",
+    "description": "Slug एक स्ट्रिंग का URL-अनुकूल संस्करण है, जो आमतौर पर मानव-पठनीय और SEO-अनुकूल URL बनाने के लिए उपयोग किया जाता है। यह विशेष वर्णों को हटाकर, स्पेस को हाइफ़न से बदलकर और लोअरकेस में बदलकर टेक्स्ट को परिवर्तित करता है।",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"मेरा ब्लॉग शीर्षक\" → \"mera-blog-shirshak\"",
+    "example3": "\"उत्पाद: iPhone 15 Pro\" → \"utpad-iphone-15-pro\"",
+    "benefits": "Slug URL की पठनीयता में सुधार करते हैं, SEO में मदद करते हैं, और लिंक को साझा करने और याद रखने में आसान बनाते हैं।"
+  },
+  "tr": {
+    "title": "Slug Nedir?",
+    "description": "Slug, bir dizenin URL dostu sürümüdür ve genellikle okunabilir ve SEO dostu URL'ler oluşturmak için kullanılır. Özel karakterleri kaldırarak, boşlukları tirelerle değiştirerek ve küçük harfe dönüştürerek metni dönüştürür.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Blog Başlığım\" → \"blog-basligim\"",
+    "example3": "\"Ürün: iPhone 15 Pro\" → \"urun-iphone-15-pro\"",
+    "benefits": "Slug'lar URL okunabilirliğini artırır, SEO'ya yardımcı olur ve bağlantıları paylaşmayı ve hatırlamayı kolaylaştırır."
+  },
+  "nl": {
+    "title": "Wat is een Slug?",
+    "description": "Een slug is een URL-vriendelijke versie van een string, meestal gebruikt om leesbare en SEO-vriendelijke URL's te maken. Het converteert tekst door speciale tekens te verwijderen, spaties te vervangen door koppeltekens en om te zetten naar kleine letters.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Mijn Blogtitel\" → \"mijn-blogtitel\"",
+    "example3": "\"Product: iPhone 15 Pro\" → \"product-iphone-15-pro\"",
+    "benefits": "Slugs verbeteren de leesbaarheid van URL's, helpen met SEO en maken links gemakkelijker te delen en te onthouden."
+  },
+  "sv": {
+    "title": "Vad är en Slug?",
+    "description": "En slug är en URL-vänlig version av en sträng, vanligtvis använd för att skapa läsbara och SEO-vänliga URL:er. Den konverterar text genom att ta bort specialtecken, ersätta mellanslag med bindestreck och konvertera till gemener.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Min Bloggtitel\" → \"min-bloggtitel\"",
+    "example3": "\"Produkt: iPhone 15 Pro\" → \"produkt-iphone-15-pro\"",
+    "benefits": "Slugs förbättrar URL-läsbarheten, hjälper med SEO och gör länkar enklare att dela och komma ihåg."
+  },
+  "pl": {
+    "title": "Czym jest Slug?",
+    "description": "Slug to przyjazna dla URL wersja ciągu znaków, zwykle używana do tworzenia czytelnych i przyjaznych dla SEO adresów URL. Konwertuje tekst, usuwając znaki specjalne, zamieniając spacje na myślniki i konwertując na małe litery.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Mój Tytuł Bloga\" → \"moj-tytul-bloga\"",
+    "example3": "\"Produkt: iPhone 15 Pro\" → \"produkt-iphone-15-pro\"",
+    "benefits": "Slugi poprawiają czytelność URL, pomagają w SEO i ułatwiają udostępnianie i zapamiętywanie linków."
+  },
+  "vi": {
+    "title": "Slug là gì?",
+    "description": "Slug là phiên bản thân thiện với URL của một chuỗi, thường được sử dụng để tạo các URL dễ đọc và thân thiện với SEO. Nó chuyển đổi văn bản bằng cách loại bỏ các ký tự đặc biệt, thay thế khoảng trắng bằng dấu gạch ngang và chuyển thành chữ thường.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Tiêu Đề Blog Của Tôi\" → \"tieu-de-blog-cua-toi\"",
+    "example3": "\"Sản phẩm: iPhone 15 Pro\" → \"san-pham-iphone-15-pro\"",
+    "benefits": "Slug cải thiện khả năng đọc URL, hỗ trợ SEO và giúp các liên kết dễ chia sẻ và ghi nhớ hơn."
+  },
+  "th": {
+    "title": "Slug คืออะไร?",
+    "description": "Slug คือเวอร์ชันที่เป็นมิตรกับ URL ของสตริง โดยทั่วไปใช้เพื่อสร้าง URL ที่อ่านง่ายและเป็นมิตรกับ SEO มันแปลงข้อความโดยการลบอักขระพิเศษ แทนที่ช่องว่างด้วยขีด และแปลงเป็นตัวพิมพ์เล็ก",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"หัวข้อบล็อกของฉัน\" → \"hawkhxbilxgkhxngchan\"",
+    "example3": "\"ผลิตภัณฑ์: iPhone 15 Pro\" → \"phlitphanth-iphone-15-pro\"",
+    "benefits": "Slug ช่วยปรับปรุงความสามารถในการอ่าน URL ช่วยในเรื่อง SEO และทำให้ลิงก์แชร์และจำได้ง่ายขึ้น"
+  },
+  "id": {
+    "title": "Apa itu Slug?",
+    "description": "Slug adalah versi ramah URL dari sebuah string, biasanya digunakan untuk membuat URL yang mudah dibaca dan ramah SEO. Ini mengonversi teks dengan menghapus karakter khusus, mengganti spasi dengan tanda hubung, dan mengubahnya menjadi huruf kecil.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Judul Blog Saya\" → \"judul-blog-saya\"",
+    "example3": "\"Produk: iPhone 15 Pro\" → \"produk-iphone-15-pro\"",
+    "benefits": "Slug meningkatkan keterbacaan URL, membantu SEO, dan membuat tautan lebih mudah dibagikan dan diingat."
+  },
+  "he": {
+    "title": "מה זה Slug?",
+    "description": "Slug הוא גרסה ידידותית ל-URL של מחרוזת, המשמשת בדרך כלל ליצירת כתובות URL קריאות וידידותיות ל-SEO. הוא ממיר טקסט על ידי הסרת תווים מיוחדים, החלפת רווחים במקפים והמרה לאותיות קטנות.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"כותרת הבלוג שלי\" → \"kotrת-hblwg-shly\"",
+    "example3": "\"מוצר: iPhone 15 Pro\" → \"mwzr-iphone-15-pro\"",
+    "benefits": "Slugs משפרים את קריאות ה-URL, עוזרים ל-SEO ומקלים על שיתוף וזכירת קישורים."
+  },
+  "ms": {
+    "title": "Apakah Slug?",
+    "description": "Slug ialah versi mesra URL bagi rentetan, biasanya digunakan untuk mencipta URL yang boleh dibaca dan mesra SEO. Ia menukar teks dengan membuang aksara khas, menggantikan ruang dengan sempang, dan menukar kepada huruf kecil.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Tajuk Blog Saya\" → \"tajuk-blog-saya\"",
+    "example3": "\"Produk: iPhone 15 Pro\" → \"produk-iphone-15-pro\"",
+    "benefits": "Slug meningkatkan kebolehbacaan URL, membantu SEO, dan menjadikan pautan lebih mudah dikongsi dan diingat."
+  },
+  "no": {
+    "title": "Hva er en Slug?",
+    "description": "En slug er en URL-vennlig versjon av en streng, vanligvis brukt for å lage lesbare og SEO-vennlige URL-er. Den konverterer tekst ved å fjerne spesialtegn, erstatte mellomrom med bindestreker og konvertere til små bokstaver.",
+    "example1": "\"Hello World!\" → \"hello-world\"",
+    "example2": "\"Min Bloggtittel\" → \"min-bloggtittel\"",
+    "example3": "\"Produkt: iPhone 15 Pro\" → \"produkt-iphone-15-pro\"",
+    "benefits": "Slugs forbedrer URL-lesbarheten, hjelper med SEO og gjør lenker enklere å dele og huske."
+  }
+}
+</i18n>

--- a/tools/web/slug-generator/src/index.ts
+++ b/tools/web/slug-generator/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/web/slug-generator/src/info.ts
+++ b/tools/web/slug-generator/src/info.ts
@@ -1,0 +1,113 @@
+export { Link16Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'slug-generator'
+export const path = '/tools/slug-generator'
+
+export const tags = ['slug', 'url', 'seo', 'permalink', 'text', 'converter']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Slug Generator',
+    description:
+      'Convert text into URL-friendly slugs. Supports Unicode transliteration for Chinese, Japanese, Korean, Cyrillic, and more.',
+  },
+  zh: {
+    name: 'Slug 生成器',
+    description:
+      '将文本转换为 URL 友好的 slug，支持中文、日文、韩文、西里尔文等多语言 Unicode 转写',
+  },
+  'zh-CN': {
+    name: 'Slug 生成器',
+    description:
+      '将文本转换为 URL 友好的 slug，支持中文、日文、韩文、西里尔文等多语言 Unicode 转写',
+  },
+  'zh-TW': {
+    name: 'Slug 產生器',
+    description: '將文字轉換為網址友善的 slug，支援中文、日文、韓文、西里爾文等多語言 Unicode 轉寫',
+  },
+  'zh-HK': {
+    name: 'Slug 產生器',
+    description: '將文字轉換為網址友善的 slug，支援中文、日文、韓文、西里爾文等多語言 Unicode 轉寫',
+  },
+  es: {
+    name: 'Generador de Slug',
+    description: 'Convierte texto en slugs amigables para URLs, SEO y enlaces permanentes',
+  },
+  fr: {
+    name: 'Générateur de Slug',
+    description: 'Convertit le texte en slugs compatibles URL pour le SEO et les permaliens',
+  },
+  de: {
+    name: 'Slug-Generator',
+    description: 'Konvertiert Text in URL-freundliche Slugs für SEO und Permalinks',
+  },
+  it: {
+    name: 'Generatore di Slug',
+    description: 'Converte il testo in slug compatibili con URL per SEO e permalink',
+  },
+  ja: {
+    name: 'Slug ジェネレーター',
+    description: 'テキストを SEO やパーマリンク用の URL フレンドリーな slug に変換',
+  },
+  ko: {
+    name: 'Slug 생성기',
+    description: '텍스트를 SEO 및 퍼머링크용 URL 친화적인 slug로 변환',
+  },
+  ru: {
+    name: 'Генератор Slug',
+    description: 'Преобразует текст в URL-совместимые slug для SEO и постоянных ссылок',
+  },
+  pt: {
+    name: 'Gerador de Slug',
+    description: 'Converte texto em slugs amigáveis para URL, SEO e links permanentes',
+  },
+  ar: {
+    name: 'مولد Slug',
+    description: 'تحويل النص إلى slug متوافق مع عناوين URL لتحسين محركات البحث والروابط الدائمة',
+  },
+  hi: {
+    name: 'Slug जेनरेटर',
+    description: 'टेक्स्ट को SEO और पर्मालिंक के लिए URL-अनुकूल slug में बदलें',
+  },
+  tr: {
+    name: 'Slug Oluşturucu',
+    description: "Metni SEO ve kalıcı bağlantılar için URL dostu slug'lara dönüştürün",
+  },
+  nl: {
+    name: 'Slug Generator',
+    description: 'Converteer tekst naar URL-vriendelijke slugs voor SEO en permalinks',
+  },
+  sv: {
+    name: 'Slug-generator',
+    description: 'Konvertera text till URL-vänliga slugs för SEO och permalänkar',
+  },
+  pl: {
+    name: 'Generator Slug',
+    description: 'Konwertuj tekst na przyjazne dla URL slugi do SEO i linków bezpośrednich',
+  },
+  vi: {
+    name: 'Tạo Slug',
+    description: 'Chuyển đổi văn bản thành slug thân thiện với URL cho SEO và liên kết cố định',
+  },
+  th: {
+    name: 'ตัวสร้าง Slug',
+    description: 'แปลงข้อความเป็น slug ที่เข้ากันได้กับ URL สำหรับ SEO และลิงก์ถาวร',
+  },
+  id: {
+    name: 'Generator Slug',
+    description: 'Konversi teks menjadi slug yang ramah URL untuk SEO dan tautan permanen',
+  },
+  he: {
+    name: 'מחולל Slug',
+    description: 'המרת טקסט ל-slug ידידותי לכתובות URL עבור SEO וקישורים קבועים',
+  },
+  ms: {
+    name: 'Penjana Slug',
+    description: 'Tukar teks kepada slug mesra URL untuk SEO dan pautan kekal',
+  },
+  no: {
+    name: 'Slug-generator',
+    description: 'Konverter tekst til URL-vennlige slugs for SEO og permalenker',
+  },
+}

--- a/tools/web/slug-generator/src/routes.ts
+++ b/tools/web/slug-generator/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'slug-generator',
+    path: '/tools/slug-generator',
+    component: () => import('./SlugGeneratorView.vue'),
+  },
+] as const


### PR DESCRIPTION
## Summary
- add slug generator tool with Unicode transliteration support
- register tool routes and metadata in registry
- include localized UI and explanatory section

## Test plan
- [x] pnpm lint
- [x] pnpm format-check
- [x] pnpm type-check
- [x] pnpm build

🤖 Generated with [Claude Code](https://claude.com/claude-code)