### PR TITLE
docs(agents): add tool-lister agent

### DIFF
--- a/.claude/agents/tool-lister.md
+++ b/.claude/agents/tool-lister.md
@@ -1,0 +1,48 @@
+---
+name: tool-lister
+description: "List all available tools in the registry. Use this to quickly see what tools exist in the project and their basic information."
+tools: Grep, Read
+model: haiku
+---
+
+List all available tools in the InBrowserApp registry.
+
+## Steps
+
+1. **Read the registry index**: Read `registry/tools/src/index.ts` to get the list of all registered tools.
+
+2. **Extract tool information**: For each tool import, identify:
+   - Tool package name (e.g., `@tools/cidr-parser`)
+   - Tool info variable name
+
+3. **Get tool details** (optional, if more detail is requested):
+   - Use Grep to search for `export const toolID` in `tools/` to find all tool IDs
+   - Read specific `info.ts` files if detailed information is needed
+
+## Output Format
+
+Present the tools in a structured format:
+
+```
+## Tools Registry Summary
+
+Total tools: [count]
+
+### By Category
+- **Network Tools**: [list]
+- **Hash Tools**: [list]
+- **Web Tools**: [list]
+- **Image Tools**: [list]
+- **PDF Tools**: [list]
+- **Time Tools**: [list]
+- **Document Tools**: [list]
+- **Misc Tools**: [list]
+...
+```
+
+If detailed info is requested for a specific tool, include:
+- Tool ID
+- Path
+- Tags
+- Features
+- Localized names (en, zh)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,8 @@ This project has Claude Code skills and agents configured in `.claude/`:
     ├── i18n-translator.md    # MUST BE USED - Translation expert for 25 languages
     ├── pr-checks-watcher.md  # PROACTIVELY - Wait for PR checks to complete
     ├── test-runner.md        # MUST BE USED - Run all checks before committing
-    └── test-writer.md        # PROACTIVELY - Create unit tests for new code
+    ├── test-writer.md        # PROACTIVELY - Create unit tests for new code
+    └── tool-lister.md        # List all tools in the registry
 ```
 
 ### Custom Slash Commands
@@ -32,6 +33,7 @@ This project has Claude Code skills and agents configured in `.claude/`:
 | `i18n-translator` | **MUST BE USED** for new tools/i18n | Complete all 25 languages in info.ts meta and Vue `<i18n>` blocks |
 | `test-writer` | **Use PROACTIVELY** after new code | Create unit tests following project patterns (vitest, *.dom.test.ts) |
 | `pr-checks-watcher` | **Use PROACTIVELY** after PR creation | Wait for GitHub checks, report status with error summaries |
+| `tool-lister` | On request | List all available tools in the registry |
 
 ## Build & Development Commands
 


### PR DESCRIPTION
Add a new agent for listing all available tools in the registry.

- Uses haiku model with Grep and Read tools only
- Reads registry/tools/src/index.ts to get tool list
- Outputs tools organized by category
- Can optionally provide detailed info for specific tools

Updated CLAUDE.md to document the new agent.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>