### PR TITLE
feat(tools): add QR Code Reader tool

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,6 +228,9 @@ catalogs:
     jsdom:
       specifier: ^27.4.0
       version: 27.4.0
+    jsqr:
+      specifier: ^1.4.0
+      version: 1.4.0
     lint-staged:
       specifier: ^16.2.7
       version: 16.2.7
@@ -708,6 +711,9 @@ importers:
       '@tools/qr-code-generator':
         specifier: workspace:*
         version: link:../../tools/image/qr-code-generator
+      '@tools/qr-code-reader':
+        specifier: workspace:*
+        version: link:../../tools/image/qr-code-reader
       '@tools/random-password-generator':
         specifier: workspace:*
         version: link:../../tools/random/random-password-generator
@@ -2283,6 +2289,33 @@ importers:
       '@types/qrcode':
         specifier: 'catalog:'
         version: 1.5.6
+
+  tools/image/qr-code-reader:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      jsqr:
+        specifier: 'catalog:'
+        version: 1.4.0
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
 
   tools/image/svg-optimizer:
     dependencies:
@@ -7480,6 +7513,9 @@ packages:
     resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
     engines: {node: '>=0.10.0'}
 
+  jsqr@1.4.0:
+    resolution: {integrity: sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==}
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -10785,7 +10821,7 @@ snapshots:
 
   '@types/sax@1.2.7':
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 24.10.4
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -12619,6 +12655,8 @@ snapshots:
   jsonparse@1.3.1: {}
 
   jsonpointer@5.0.1: {}
+
+  jsqr@1.4.0: {}
 
   keyv@4.5.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -83,6 +83,7 @@ catalog:
   js-yaml: ^4.1.1
   jsbarcode: ^3.12.1
   jsdom: ^27.4.0
+  jsqr: ^1.4.0
   lint-staged: ^16.2.7
   marked: ^17.0.1
   mime: ^4.1.0

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -73,6 +73,7 @@
     "@tools/png-optimizer": "workspace:*",
     "@tools/port-number-lookup": "workspace:*",
     "@tools/qr-code-generator": "workspace:*",
+    "@tools/qr-code-reader": "workspace:*",
     "@tools/random-password-generator": "workspace:*",
     "@tools/redirects": "workspace:*",
     "@tools/remove-pdf-owner-password": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -49,6 +49,7 @@ import { toolInfo as jwtSignerToolInfo } from '@tools/jwt-signer'
 import { toolInfo as jwtDecoderVerifierToolInfo } from '@tools/jwt-decoder-verifier'
 import { toolInfo as randomPasswordGeneratorToolInfo } from '@tools/random-password-generator'
 import { toolInfo as qrCodeGeneratorToolInfo } from '@tools/qr-code-generator'
+import { toolInfo as qrCodeReaderToolInfo } from '@tools/qr-code-reader'
 import { toolInfo as barcodeGeneratorToolInfo } from '@tools/barcode-generator'
 import { toolInfo as markdownToHtmlConverterToolInfo } from '@tools/markdown-to-html-converter'
 import { toolInfo as htmlToMarkdownConverterToolInfo } from '@tools/html-to-markdown-converter'
@@ -122,6 +123,7 @@ export const tools: ToolInfo[] = [
   svgOptimizerToolInfo,
   exifViewerToolInfo,
   qrCodeGeneratorToolInfo,
+  qrCodeReaderToolInfo,
   barcodeGeneratorToolInfo,
   markdownToHtmlConverterToolInfo,
   htmlToMarkdownConverterToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -47,6 +47,7 @@ import { routes as jwtSignerRoutes } from '@tools/jwt-signer/routes'
 import { routes as jwtDecoderVerifierRoutes } from '@tools/jwt-decoder-verifier/routes'
 import { routes as randomPasswordGeneratorRoutes } from '@tools/random-password-generator/routes'
 import { routes as qrCodeGeneratorRoutes } from '@tools/qr-code-generator/routes'
+import { routes as qrCodeReaderRoutes } from '@tools/qr-code-reader/routes'
 import { routes as barcodeGeneratorRoutes } from '@tools/barcode-generator/routes'
 import { routes as markdownToHtmlConverterRoutes } from '@tools/markdown-to-html-converter/routes'
 import { routes as htmlToMarkdownConverterRoutes } from '@tools/html-to-markdown-converter/routes'
@@ -141,6 +142,7 @@ export const routes: ToolRoute[] = [
   ...jwtDecoderVerifierRoutes,
   ...randomPasswordGeneratorRoutes,
   ...qrCodeGeneratorRoutes,
+  ...qrCodeReaderRoutes,
   ...barcodeGeneratorRoutes,
   ...markdownToHtmlConverterRoutes,
   ...htmlToMarkdownConverterRoutes,

--- a/tools/image/qr-code-reader/package.json
+++ b/tools/image/qr-code-reader/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@tools/qr-code-reader",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "jsqr": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/image/qr-code-reader/src/QRCodeReaderView.vue
+++ b/tools/image/qr-code-reader/src/QRCodeReaderView.vue
@@ -1,0 +1,155 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <ToolSection>
+      <NTabs v-model:value="mode" type="segment" animated>
+        <NTabPane name="upload" :tab="t('uploadImage')">
+          <ImageUpload v-model:file="file" @decoded="handleDecoded" @error="handleError" />
+        </NTabPane>
+        <NTabPane name="camera" :tab="t('useCamera')">
+          <CameraCapture @decoded="handleDecoded" @error="handleError" />
+        </NTabPane>
+      </NTabs>
+    </ToolSection>
+    <QRResult :result="result" :error="error" />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NTabs, NTabPane } from 'naive-ui'
+import { ToolDefaultPageLayout, ToolSection } from '@shared/ui/tool'
+import * as toolInfo from './info'
+import ImageUpload from './components/ImageUpload.vue'
+import CameraCapture from './components/CameraCapture.vue'
+import QRResult from './components/QRResult.vue'
+
+const { t } = useI18n()
+
+const mode = ref<'upload' | 'camera'>('upload')
+const file = ref<File | null>(null)
+const result = ref<string | null>(null)
+const error = ref<string | null>(null)
+
+function handleDecoded(data: string) {
+  result.value = data
+  error.value = null
+}
+
+function handleError(msg: string) {
+  error.value = msg
+  result.value = null
+}
+
+// Clear result and file when switching modes
+watch(mode, () => {
+  result.value = null
+  error.value = null
+  file.value = null
+})
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "uploadImage": "Upload Image",
+    "useCamera": "Use Camera"
+  },
+  "zh": {
+    "uploadImage": "上传图片",
+    "useCamera": "使用摄像头"
+  },
+  "zh-CN": {
+    "uploadImage": "上传图片",
+    "useCamera": "使用摄像头"
+  },
+  "zh-TW": {
+    "uploadImage": "上傳圖片",
+    "useCamera": "使用攝影機"
+  },
+  "zh-HK": {
+    "uploadImage": "上傳圖片",
+    "useCamera": "使用攝影機"
+  },
+  "es": {
+    "uploadImage": "Subir imagen",
+    "useCamera": "Usar camara"
+  },
+  "fr": {
+    "uploadImage": "Telecharger l'image",
+    "useCamera": "Utiliser la camera"
+  },
+  "de": {
+    "uploadImage": "Bild hochladen",
+    "useCamera": "Kamera verwenden"
+  },
+  "it": {
+    "uploadImage": "Carica immagine",
+    "useCamera": "Usa fotocamera"
+  },
+  "ja": {
+    "uploadImage": "画像をアップロード",
+    "useCamera": "カメラを使用"
+  },
+  "ko": {
+    "uploadImage": "이미지 업로드",
+    "useCamera": "카메라 사용"
+  },
+  "ru": {
+    "uploadImage": "Загрузить изображение",
+    "useCamera": "Использовать камеру"
+  },
+  "pt": {
+    "uploadImage": "Carregar imagem",
+    "useCamera": "Usar camera"
+  },
+  "ar": {
+    "uploadImage": "تحميل صورة",
+    "useCamera": "استخدام الكاميرا"
+  },
+  "hi": {
+    "uploadImage": "छवि अपलोड करें",
+    "useCamera": "कैमरा का उपयोग करें"
+  },
+  "tr": {
+    "uploadImage": "Gorsel yukle",
+    "useCamera": "Kamera kullan"
+  },
+  "nl": {
+    "uploadImage": "Afbeelding uploaden",
+    "useCamera": "Camera gebruiken"
+  },
+  "sv": {
+    "uploadImage": "Ladda upp bild",
+    "useCamera": "Anvand kamera"
+  },
+  "pl": {
+    "uploadImage": "Przeslij obraz",
+    "useCamera": "Uzyj kamery"
+  },
+  "vi": {
+    "uploadImage": "Tai anh len",
+    "useCamera": "Su dung camera"
+  },
+  "th": {
+    "uploadImage": "อัปโหลดรูปภาพ",
+    "useCamera": "ใช้กล้อง"
+  },
+  "id": {
+    "uploadImage": "Unggah gambar",
+    "useCamera": "Gunakan kamera"
+  },
+  "he": {
+    "uploadImage": "העלה תמונה",
+    "useCamera": "השתמש במצלמה"
+  },
+  "ms": {
+    "uploadImage": "Muat naik imej",
+    "useCamera": "Gunakan kamera"
+  },
+  "no": {
+    "uploadImage": "Last opp bilde",
+    "useCamera": "Bruk kamera"
+  }
+}
+</i18n>

--- a/tools/image/qr-code-reader/src/components/CameraCapture.vue
+++ b/tools/image/qr-code-reader/src/components/CameraCapture.vue
@@ -1,0 +1,395 @@
+<template>
+  <NFlex vertical :size="16" align="center">
+    <template v-if="!isSupported">
+      <NAlert type="warning">{{ t('cameraNotSupported') }}</NAlert>
+    </template>
+    <template v-else-if="permissionDenied">
+      <NAlert type="error">{{ t('cameraPermissionDenied') }}</NAlert>
+      <NButton @click="requestCamera">{{ t('retryPermission') }}</NButton>
+    </template>
+    <template v-else>
+      <NFlex :size="12">
+        <NButton v-if="!isScanning" type="primary" @click="startCamera">
+          <template #icon>
+            <NIcon><Camera24Regular /></NIcon>
+          </template>
+          {{ t('startCamera') }}
+        </NButton>
+        <NButton v-else type="error" @click="stopCamera">
+          <template #icon>
+            <NIcon><Stop24Regular /></NIcon>
+          </template>
+          {{ t('stopCamera') }}
+        </NButton>
+      </NFlex>
+
+      <div v-show="isScanning" class="video-container">
+        <video ref="videoRef" autoplay playsinline muted />
+        <div class="scan-overlay">
+          <div class="scan-line" />
+        </div>
+      </div>
+
+      <NText v-if="isScanning" depth="3">{{ t('pointAtQRCode') }}</NText>
+    </template>
+  </NFlex>
+</template>
+
+<script setup lang="ts">
+import { ref, onUnmounted, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NFlex, NButton, NIcon, NAlert, NText } from 'naive-ui'
+import { Camera24Regular, Stop24Regular } from '@shared/icons/fluent'
+import { readQRFromVideo } from '../qr-reader'
+
+const { t } = useI18n()
+
+const emit = defineEmits<{
+  decoded: [data: string]
+  error: [message: string]
+}>()
+
+const videoRef = ref<HTMLVideoElement>()
+const isScanning = ref(false)
+const permissionDenied = ref(false)
+const canvas = document.createElement('canvas')
+let animationId: number | null = null
+
+const isSupported = computed(() => {
+  return typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia
+})
+
+async function requestCamera() {
+  permissionDenied.value = false
+  await startCamera()
+}
+
+async function startCamera() {
+  if (!videoRef.value) return
+
+  try {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      video: { facingMode: 'environment' },
+    })
+    videoRef.value.srcObject = stream
+    await videoRef.value.play()
+    isScanning.value = true
+    permissionDenied.value = false
+    scanLoop()
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError')
+    ) {
+      permissionDenied.value = true
+      emit('error', t('cameraPermissionDenied'))
+    } else {
+      emit('error', t('cameraError'))
+    }
+  }
+}
+
+function scanLoop() {
+  if (!videoRef.value || !isScanning.value) return
+
+  const result = readQRFromVideo(videoRef.value, canvas)
+  if (result) {
+    emit('decoded', result)
+    stopCamera()
+  } else {
+    animationId = requestAnimationFrame(scanLoop)
+  }
+}
+
+function stopCamera() {
+  isScanning.value = false
+
+  if (animationId !== null) {
+    cancelAnimationFrame(animationId)
+    animationId = null
+  }
+
+  if (videoRef.value?.srcObject) {
+    const stream = videoRef.value.srcObject as MediaStream
+    stream.getTracks().forEach((track) => track.stop())
+    videoRef.value.srcObject = null
+  }
+}
+
+onUnmounted(stopCamera)
+</script>
+
+<style scoped>
+.video-container {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+  aspect-ratio: 1;
+  overflow: hidden;
+  border-radius: 8px;
+  background: #000;
+}
+
+.video-container video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.scan-overlay {
+  position: absolute;
+  inset: 0;
+  border: 2px solid rgba(24, 160, 88, 0.5);
+  border-radius: 8px;
+  pointer-events: none;
+}
+
+.scan-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, #18a058, transparent);
+  animation: scan 2s ease-in-out infinite;
+}
+
+@keyframes scan {
+  0%,
+  100% {
+    top: 10%;
+  }
+  50% {
+    top: 90%;
+  }
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "startCamera": "Start Camera",
+    "stopCamera": "Stop Camera",
+    "pointAtQRCode": "Point camera at a QR code",
+    "cameraNotSupported": "Camera is not supported in this browser",
+    "cameraPermissionDenied": "Camera permission denied. Please allow camera access.",
+    "retryPermission": "Retry",
+    "cameraError": "Failed to access camera"
+  },
+  "zh": {
+    "startCamera": "启动摄像头",
+    "stopCamera": "停止摄像头",
+    "pointAtQRCode": "将摄像头对准二维码",
+    "cameraNotSupported": "此浏览器不支持摄像头",
+    "cameraPermissionDenied": "摄像头权限被拒绝，请允许摄像头访问",
+    "retryPermission": "重试",
+    "cameraError": "无法访问摄像头"
+  },
+  "zh-CN": {
+    "startCamera": "启动摄像头",
+    "stopCamera": "停止摄像头",
+    "pointAtQRCode": "将摄像头对准二维码",
+    "cameraNotSupported": "此浏览器不支持摄像头",
+    "cameraPermissionDenied": "摄像头权限被拒绝，请允许摄像头访问",
+    "retryPermission": "重试",
+    "cameraError": "无法访问摄像头"
+  },
+  "zh-TW": {
+    "startCamera": "啟動攝影機",
+    "stopCamera": "停止攝影機",
+    "pointAtQRCode": "將攝影機對準 QR Code",
+    "cameraNotSupported": "此瀏覽器不支援攝影機",
+    "cameraPermissionDenied": "攝影機權限被拒絕，請允許攝影機存取",
+    "retryPermission": "重試",
+    "cameraError": "無法存取攝影機"
+  },
+  "zh-HK": {
+    "startCamera": "啟動攝影機",
+    "stopCamera": "停止攝影機",
+    "pointAtQRCode": "將攝影機對準 QR Code",
+    "cameraNotSupported": "此瀏覽器不支援攝影機",
+    "cameraPermissionDenied": "攝影機權限被拒絕，請允許攝影機存取",
+    "retryPermission": "重試",
+    "cameraError": "無法存取攝影機"
+  },
+  "es": {
+    "startCamera": "Iniciar camara",
+    "stopCamera": "Detener camara",
+    "pointAtQRCode": "Apunta la camara a un codigo QR",
+    "cameraNotSupported": "La camara no es compatible con este navegador",
+    "cameraPermissionDenied": "Permiso de camara denegado. Por favor permita el acceso.",
+    "retryPermission": "Reintentar",
+    "cameraError": "Error al acceder a la camara"
+  },
+  "fr": {
+    "startCamera": "Demarrer la camera",
+    "stopCamera": "Arreter la camera",
+    "pointAtQRCode": "Pointez la camera vers un code QR",
+    "cameraNotSupported": "La camera n'est pas prise en charge dans ce navigateur",
+    "cameraPermissionDenied": "Permission de la camera refusee. Veuillez autoriser l'acces.",
+    "retryPermission": "Reessayer",
+    "cameraError": "Impossible d'acceder a la camera"
+  },
+  "de": {
+    "startCamera": "Kamera starten",
+    "stopCamera": "Kamera stoppen",
+    "pointAtQRCode": "Richten Sie die Kamera auf einen QR-Code",
+    "cameraNotSupported": "Kamera wird in diesem Browser nicht unterstutzt",
+    "cameraPermissionDenied": "Kameraberechtigung verweigert. Bitte erlauben Sie den Zugriff.",
+    "retryPermission": "Erneut versuchen",
+    "cameraError": "Kamerazugriff fehlgeschlagen"
+  },
+  "it": {
+    "startCamera": "Avvia fotocamera",
+    "stopCamera": "Ferma fotocamera",
+    "pointAtQRCode": "Punta la fotocamera verso un codice QR",
+    "cameraNotSupported": "La fotocamera non e supportata in questo browser",
+    "cameraPermissionDenied": "Permesso fotocamera negato. Si prega di consentire l'accesso.",
+    "retryPermission": "Riprova",
+    "cameraError": "Impossibile accedere alla fotocamera"
+  },
+  "ja": {
+    "startCamera": "カメラを起動",
+    "stopCamera": "カメラを停止",
+    "pointAtQRCode": "カメラをQRコードに向けてください",
+    "cameraNotSupported": "このブラウザではカメラがサポートされていません",
+    "cameraPermissionDenied": "カメラの許可が拒否されました。アクセスを許可してください。",
+    "retryPermission": "再試行",
+    "cameraError": "カメラにアクセスできませんでした"
+  },
+  "ko": {
+    "startCamera": "카메라 시작",
+    "stopCamera": "카메라 중지",
+    "pointAtQRCode": "카메라를 QR 코드에 맞추세요",
+    "cameraNotSupported": "이 브라우저에서는 카메라가 지원되지 않습니다",
+    "cameraPermissionDenied": "카메라 권한이 거부되었습니다. 접근을 허용해주세요.",
+    "retryPermission": "다시 시도",
+    "cameraError": "카메라에 접근할 수 없습니다"
+  },
+  "ru": {
+    "startCamera": "Запустить камеру",
+    "stopCamera": "Остановить камеру",
+    "pointAtQRCode": "Наведите камеру на QR-код",
+    "cameraNotSupported": "Камера не поддерживается в этом браузере",
+    "cameraPermissionDenied": "Доступ к камере запрещен. Пожалуйста, разрешите доступ.",
+    "retryPermission": "Повторить",
+    "cameraError": "Не удалось получить доступ к камере"
+  },
+  "pt": {
+    "startCamera": "Iniciar camera",
+    "stopCamera": "Parar camera",
+    "pointAtQRCode": "Aponte a camera para um codigo QR",
+    "cameraNotSupported": "A camera nao e suportada neste navegador",
+    "cameraPermissionDenied": "Permissao da camera negada. Por favor, permita o acesso.",
+    "retryPermission": "Tentar novamente",
+    "cameraError": "Falha ao acessar a camera"
+  },
+  "ar": {
+    "startCamera": "بدء الكاميرا",
+    "stopCamera": "إيقاف الكاميرا",
+    "pointAtQRCode": "وجه الكاميرا نحو رمز QR",
+    "cameraNotSupported": "الكاميرا غير مدعومة في هذا المتصفح",
+    "cameraPermissionDenied": "تم رفض إذن الكاميرا. يرجى السماح بالوصول.",
+    "retryPermission": "إعادة المحاولة",
+    "cameraError": "فشل في الوصول إلى الكاميرا"
+  },
+  "hi": {
+    "startCamera": "कैमरा शुरू करें",
+    "stopCamera": "कैमरा बंद करें",
+    "pointAtQRCode": "कैमरे को QR कोड की ओर इंगित करें",
+    "cameraNotSupported": "इस ब्राउज़र में कैमरा समर्थित नहीं है",
+    "cameraPermissionDenied": "कैमरा अनुमति अस्वीकृत। कृपया पहुंच की अनुमति दें।",
+    "retryPermission": "पुनः प्रयास करें",
+    "cameraError": "कैमरे तक पहुंचने में विफल"
+  },
+  "tr": {
+    "startCamera": "Kamerayi baslat",
+    "stopCamera": "Kamerayi durdur",
+    "pointAtQRCode": "Kamerayi bir QR koduna yoneltin",
+    "cameraNotSupported": "Bu tarayicide kamera desteklenmiyor",
+    "cameraPermissionDenied": "Kamera izni reddedildi. Lutfen erisime izin verin.",
+    "retryPermission": "Tekrar dene",
+    "cameraError": "Kameraya erisilemedi"
+  },
+  "nl": {
+    "startCamera": "Camera starten",
+    "stopCamera": "Camera stoppen",
+    "pointAtQRCode": "Richt de camera op een QR-code",
+    "cameraNotSupported": "Camera wordt niet ondersteund in deze browser",
+    "cameraPermissionDenied": "Camera toestemming geweigerd. Sta toegang toe.",
+    "retryPermission": "Opnieuw proberen",
+    "cameraError": "Kan geen toegang krijgen tot camera"
+  },
+  "sv": {
+    "startCamera": "Starta kamera",
+    "stopCamera": "Stoppa kamera",
+    "pointAtQRCode": "Rikta kameran mot en QR-kod",
+    "cameraNotSupported": "Kamera stods inte i denna webblasare",
+    "cameraPermissionDenied": "Kameratillstand nekades. Ge atkomst.",
+    "retryPermission": "Forsok igen",
+    "cameraError": "Kunde inte komma at kameran"
+  },
+  "pl": {
+    "startCamera": "Uruchom kamere",
+    "stopCamera": "Zatrzymaj kamere",
+    "pointAtQRCode": "Skieruj kamere na kod QR",
+    "cameraNotSupported": "Kamera nie jest obslugiwana w tej przegladarce",
+    "cameraPermissionDenied": "Odmowiono dostepu do kamery. Prosze zezwolic na dostep.",
+    "retryPermission": "Ponow probe",
+    "cameraError": "Nie udalo sie uzyskac dostepu do kamery"
+  },
+  "vi": {
+    "startCamera": "Bat camera",
+    "stopCamera": "Dung camera",
+    "pointAtQRCode": "Huong camera vao ma QR",
+    "cameraNotSupported": "Camera khong duoc ho tro tren trinh duyet nay",
+    "cameraPermissionDenied": "Quyen truy cap camera bi tu choi. Vui long cho phep truy cap.",
+    "retryPermission": "Thu lai",
+    "cameraError": "Khong the truy cap camera"
+  },
+  "th": {
+    "startCamera": "เริ่มกล้อง",
+    "stopCamera": "หยุดกล้อง",
+    "pointAtQRCode": "หันกล้องไปที่ QR Code",
+    "cameraNotSupported": "กล้องไม่รองรับในเบราว์เซอร์นี้",
+    "cameraPermissionDenied": "สิทธิ์กล้องถูกปฏิเสธ กรุณาอนุญาตการเข้าถึง",
+    "retryPermission": "ลองอีกครั้ง",
+    "cameraError": "ไม่สามารถเข้าถึงกล้องได้"
+  },
+  "id": {
+    "startCamera": "Mulai kamera",
+    "stopCamera": "Hentikan kamera",
+    "pointAtQRCode": "Arahkan kamera ke kode QR",
+    "cameraNotSupported": "Kamera tidak didukung di browser ini",
+    "cameraPermissionDenied": "Izin kamera ditolak. Harap izinkan akses.",
+    "retryPermission": "Coba lagi",
+    "cameraError": "Gagal mengakses kamera"
+  },
+  "he": {
+    "startCamera": "הפעל מצלמה",
+    "stopCamera": "עצור מצלמה",
+    "pointAtQRCode": "כוון את המצלמה לקוד QR",
+    "cameraNotSupported": "המצלמה אינה נתמכת בדפדפן זה",
+    "cameraPermissionDenied": "הרשאת מצלמה נדחתה. אנא אפשר גישה.",
+    "retryPermission": "נסה שוב",
+    "cameraError": "נכשל בגישה למצלמה"
+  },
+  "ms": {
+    "startCamera": "Mulakan kamera",
+    "stopCamera": "Hentikan kamera",
+    "pointAtQRCode": "Halakan kamera ke kod QR",
+    "cameraNotSupported": "Kamera tidak disokong dalam pelayar ini",
+    "cameraPermissionDenied": "Kebenaran kamera ditolak. Sila benarkan akses.",
+    "retryPermission": "Cuba lagi",
+    "cameraError": "Gagal mengakses kamera"
+  },
+  "no": {
+    "startCamera": "Start kamera",
+    "stopCamera": "Stopp kamera",
+    "pointAtQRCode": "Pek kameraet mot en QR-kode",
+    "cameraNotSupported": "Kamera stettes ikke i denne nettleseren",
+    "cameraPermissionDenied": "Kameratillatelse nektet. Vennligst tillat tilgang.",
+    "retryPermission": "Prov igjen",
+    "cameraError": "Kunne ikke fa tilgang til kamera"
+  }
+}
+</i18n>

--- a/tools/image/qr-code-reader/src/components/ImageUpload.vue
+++ b/tools/image/qr-code-reader/src/components/ImageUpload.vue
@@ -1,0 +1,275 @@
+<template>
+  <NFlex vertical :size="16">
+    <NUpload
+      v-if="!imagePreview"
+      :show-file-list="false"
+      accept="image/*"
+      :max="1"
+      @before-upload="handleBeforeUpload"
+    >
+      <NUploadDragger>
+        <NFlex vertical align="center" :size="12">
+          <NIcon :size="48" :depth="3">
+            <ImageAdd24Regular />
+          </NIcon>
+          <NText>{{ t('dragDropOrClick') }}</NText>
+          <NText depth="3" style="font-size: 12px">
+            {{ t('supportedFormats') }}
+          </NText>
+        </NFlex>
+      </NUploadDragger>
+    </NUpload>
+
+    <template v-else>
+      <NFlex justify="center">
+        <img :src="imagePreview" class="preview-image" />
+      </NFlex>
+      <NFlex justify="center">
+        <NButton @click="clearFile">
+          <template #icon>
+            <NIcon><ArrowUpload24Regular /></NIcon>
+          </template>
+          {{ t('uploadAnother') }}
+        </NButton>
+      </NFlex>
+    </template>
+  </NFlex>
+</template>
+
+<script setup lang="ts">
+import { computed, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useObjectUrl } from '@vueuse/core'
+import { NFlex, NUpload, NUploadDragger, NIcon, NText, NButton } from 'naive-ui'
+import type { UploadFileInfo } from 'naive-ui'
+import { ImageAdd24Regular, ArrowUpload24Regular } from '@shared/icons/fluent'
+import { readQRFromFile } from '../qr-reader'
+
+const { t } = useI18n()
+
+const file = defineModel<File | null>('file', { default: null })
+const emit = defineEmits<{
+  decoded: [data: string]
+  error: [message: string]
+}>()
+
+const imagePreview = useObjectUrl(computed(() => file.value))
+
+async function handleBeforeUpload(data: { file: UploadFileInfo; fileList: UploadFileInfo[] }) {
+  const uploadedFile = data.file.file
+  if (!uploadedFile) return false
+
+  file.value = uploadedFile
+
+  try {
+    const result = await readQRFromFile(uploadedFile)
+    if (result) {
+      emit('decoded', result)
+    } else {
+      emit('error', t('noQRCodeFound'))
+    }
+  } catch {
+    emit('error', t('failedToReadImage'))
+  }
+
+  return false
+}
+
+function clearFile() {
+  file.value = null
+}
+
+watch(file, (newFile) => {
+  if (!newFile) {
+    emit('error', '')
+  }
+})
+</script>
+
+<style scoped>
+.preview-image {
+  max-width: 300px;
+  max-height: 300px;
+  object-fit: contain;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "dragDropOrClick": "Click or drag image to upload",
+    "supportedFormats": "Supports PNG, JPG, WebP, GIF, BMP, SVG and other image files",
+    "uploadAnother": "Upload Another",
+    "noQRCodeFound": "No QR code found in the image",
+    "failedToReadImage": "Failed to read the image"
+  },
+  "zh": {
+    "dragDropOrClick": "点击或拖拽图片上传",
+    "supportedFormats": "支持 PNG、JPG、WebP、GIF、BMP、SVG 等图片文件",
+    "uploadAnother": "上传另一个",
+    "noQRCodeFound": "图片中未找到二维码",
+    "failedToReadImage": "读取图片失败"
+  },
+  "zh-CN": {
+    "dragDropOrClick": "点击或拖拽图片上传",
+    "supportedFormats": "支持 PNG、JPG、WebP、GIF、BMP、SVG 等图片文件",
+    "uploadAnother": "上传另一个",
+    "noQRCodeFound": "图片中未找到二维码",
+    "failedToReadImage": "读取图片失败"
+  },
+  "zh-TW": {
+    "dragDropOrClick": "點擊或拖曳圖片上傳",
+    "supportedFormats": "支援 PNG、JPG、WebP、GIF、BMP、SVG 等圖片檔案",
+    "uploadAnother": "上传另一个",
+    "noQRCodeFound": "圖片中未找到 QR Code",
+    "failedToReadImage": "讀取圖片失敗"
+  },
+  "zh-HK": {
+    "dragDropOrClick": "點擊或拖曳圖片上傳",
+    "supportedFormats": "支援 PNG、JPG、WebP、GIF、BMP、SVG 等圖片檔案",
+    "uploadAnother": "上传另一个",
+    "noQRCodeFound": "圖片中未找到 QR Code",
+    "failedToReadImage": "讀取圖片失敗"
+  },
+  "es": {
+    "dragDropOrClick": "Haga clic o arrastre la imagen para cargar",
+    "supportedFormats": "Soporta PNG, JPG, WebP, GIF, BMP, SVG y otros archivos de imagen",
+    "uploadAnother": "Subir otro",
+    "noQRCodeFound": "No se encontro codigo QR en la imagen",
+    "failedToReadImage": "Error al leer la imagen"
+  },
+  "fr": {
+    "dragDropOrClick": "Cliquez ou faites glisser l'image pour telecharger",
+    "supportedFormats": "Prend en charge PNG, JPG, WebP, GIF, BMP, SVG et autres fichiers image",
+    "uploadAnother": "Telecharger un autre",
+    "noQRCodeFound": "Aucun code QR trouve dans l'image",
+    "failedToReadImage": "Echec de la lecture de l'image"
+  },
+  "de": {
+    "dragDropOrClick": "Klicken oder Bild ziehen zum Hochladen",
+    "supportedFormats": "Unterstutzt PNG, JPG, WebP, GIF, BMP, SVG und andere Bilddateien",
+    "uploadAnother": "Anderes hochladen",
+    "noQRCodeFound": "Kein QR-Code im Bild gefunden",
+    "failedToReadImage": "Bild konnte nicht gelesen werden"
+  },
+  "it": {
+    "dragDropOrClick": "Clicca o trascina l'immagine per caricare",
+    "supportedFormats": "Supporta PNG, JPG, WebP, GIF, BMP, SVG e altri file immagine",
+    "uploadAnother": "Carica un altro",
+    "noQRCodeFound": "Nessun codice QR trovato nell'immagine",
+    "failedToReadImage": "Impossibile leggere l'immagine"
+  },
+  "ja": {
+    "dragDropOrClick": "クリックまたは画像をドラッグしてアップロード",
+    "supportedFormats": "PNG、JPG、WebP、GIF、BMP、SVG などの画像ファイルをサポート",
+    "uploadAnother": "別の画像をアップロード",
+    "noQRCodeFound": "画像にQRコードが見つかりません",
+    "failedToReadImage": "画像の読み取りに失敗しました"
+  },
+  "ko": {
+    "dragDropOrClick": "클릭하거나 이미지를 드래그하여 업로드",
+    "supportedFormats": "PNG, JPG, WebP, GIF, BMP, SVG 등 이미지 파일 지원",
+    "uploadAnother": "다른 이미지 업로드",
+    "noQRCodeFound": "이미지에서 QR 코드를 찾을 수 없습니다",
+    "failedToReadImage": "이미지를 읽을 수 없습니다"
+  },
+  "ru": {
+    "dragDropOrClick": "Нажмите или перетащите изображение для загрузки",
+    "supportedFormats": "Поддерживает PNG, JPG, WebP, GIF, BMP, SVG и другие изображения",
+    "uploadAnother": "Загрузить другое",
+    "noQRCodeFound": "QR-код не найден на изображении",
+    "failedToReadImage": "Не удалось прочитать изображение"
+  },
+  "pt": {
+    "dragDropOrClick": "Clique ou arraste a imagem para carregar",
+    "supportedFormats": "Suporta PNG, JPG, WebP, GIF, BMP, SVG e outros arquivos de imagem",
+    "uploadAnother": "Carregar outro",
+    "noQRCodeFound": "Nenhum codigo QR encontrado na imagem",
+    "failedToReadImage": "Falha ao ler a imagem"
+  },
+  "ar": {
+    "dragDropOrClick": "انقر أو اسحب الصورة للتحميل",
+    "supportedFormats": "يدعم PNG، JPG، WebP، GIF، BMP، SVG وملفات الصور الأخرى",
+    "uploadAnother": "تحميل آخر",
+    "noQRCodeFound": "لم يتم العثور على رمز QR في الصورة",
+    "failedToReadImage": "فشل في قراءة الصورة"
+  },
+  "hi": {
+    "dragDropOrClick": "अपलोड करने के लिए क्लिक करें या छवि खींचें",
+    "supportedFormats": "PNG, JPG, WebP, GIF, BMP, SVG और अन्य छवि फ़ाइलें समर्थित",
+    "uploadAnother": "एक और अपलोड करें",
+    "noQRCodeFound": "छवि में कोई QR कोड नहीं मिला",
+    "failedToReadImage": "छवि पढ़ने में विफल"
+  },
+  "tr": {
+    "dragDropOrClick": "Yuklemek icin tiklayin veya gorsel suruklein",
+    "supportedFormats": "PNG, JPG, WebP, GIF, BMP, SVG ve diger gorsel dosyalari desteklenir",
+    "uploadAnother": "Baskasini yukle",
+    "noQRCodeFound": "Gorselde QR kodu bulunamadi",
+    "failedToReadImage": "Gorsel okunamadi"
+  },
+  "nl": {
+    "dragDropOrClick": "Klik of sleep afbeelding om te uploaden",
+    "supportedFormats": "Ondersteunt PNG, JPG, WebP, GIF, BMP, SVG en andere afbeeldingsbestanden",
+    "uploadAnother": "Andere uploaden",
+    "noQRCodeFound": "Geen QR-code gevonden in de afbeelding",
+    "failedToReadImage": "Kan afbeelding niet lezen"
+  },
+  "sv": {
+    "dragDropOrClick": "Klicka eller dra bild for att ladda upp",
+    "supportedFormats": "Stoder PNG, JPG, WebP, GIF, BMP, SVG och andra bildfiler",
+    "uploadAnother": "Ladda upp en annan",
+    "noQRCodeFound": "Ingen QR-kod hittades i bilden",
+    "failedToReadImage": "Kunde inte lasa bilden"
+  },
+  "pl": {
+    "dragDropOrClick": "Kliknij lub przeciagnij obraz, aby przeslac",
+    "supportedFormats": "Obsluguje PNG, JPG, WebP, GIF, BMP, SVG i inne pliki graficzne",
+    "uploadAnother": "Przeslij inny",
+    "noQRCodeFound": "Nie znaleziono kodu QR na obrazie",
+    "failedToReadImage": "Nie udalo sie odczytac obrazu"
+  },
+  "vi": {
+    "dragDropOrClick": "Nhan hoac keo anh de tai len",
+    "supportedFormats": "Ho tro PNG, JPG, WebP, GIF, BMP, SVG va cac file anh khac",
+    "uploadAnother": "Tai len anh khac",
+    "noQRCodeFound": "Khong tim thay ma QR trong anh",
+    "failedToReadImage": "Khong the doc anh"
+  },
+  "th": {
+    "dragDropOrClick": "คลิกหรือลากรูปภาพเพื่ออัปโหลด",
+    "supportedFormats": "รองรับ PNG, JPG, WebP, GIF, BMP, SVG และไฟล์รูปภาพอื่นๆ",
+    "uploadAnother": "อัปโหลดรูปอื่น",
+    "noQRCodeFound": "ไม่พบ QR Code ในรูปภาพ",
+    "failedToReadImage": "ไม่สามารถอ่านรูปภาพได้"
+  },
+  "id": {
+    "dragDropOrClick": "Klik atau seret gambar untuk mengunggah",
+    "supportedFormats": "Mendukung PNG, JPG, WebP, GIF, BMP, SVG dan file gambar lainnya",
+    "uploadAnother": "Unggah lainnya",
+    "noQRCodeFound": "Tidak ada kode QR ditemukan di gambar",
+    "failedToReadImage": "Gagal membaca gambar"
+  },
+  "he": {
+    "dragDropOrClick": "לחץ או גרור תמונה להעלאה",
+    "supportedFormats": "תומך ב-PNG, JPG, WebP, GIF, BMP, SVG וקבצי תמונה אחרים",
+    "uploadAnother": "העלה אחר",
+    "noQRCodeFound": "לא נמצא קוד QR בתמונה",
+    "failedToReadImage": "נכשל בקריאת התמונה"
+  },
+  "ms": {
+    "dragDropOrClick": "Klik atau seret imej untuk memuat naik",
+    "supportedFormats": "Menyokong PNG, JPG, WebP, GIF, BMP, SVG dan fail imej lain",
+    "uploadAnother": "Muat naik yang lain",
+    "noQRCodeFound": "Tiada kod QR ditemui dalam imej",
+    "failedToReadImage": "Gagal membaca imej"
+  },
+  "no": {
+    "dragDropOrClick": "Klikk eller dra bilde for a laste opp",
+    "supportedFormats": "Stotter PNG, JPG, WebP, GIF, BMP, SVG og andre bildefiler",
+    "uploadAnother": "Last opp en annen",
+    "noQRCodeFound": "Ingen QR-kode funnet i bildet",
+    "failedToReadImage": "Kunne ikke lese bildet"
+  }
+}
+</i18n>

--- a/tools/image/qr-code-reader/src/components/QRResult.vue
+++ b/tools/image/qr-code-reader/src/components/QRResult.vue
@@ -1,0 +1,362 @@
+<template>
+  <ToolSection v-if="result || error">
+    <ToolSectionHeader>{{ t('result') }}</ToolSectionHeader>
+
+    <NAlert v-if="error && !result" type="warning" :title="t('noResult')">
+      {{ error }}
+    </NAlert>
+
+    <template v-if="result">
+      <NFlex vertical :size="12">
+        <NCard>
+          <NFlex justify="space-between" align="start">
+            <NText class="result-text" style="word-break: break-all">
+              {{ result }}
+            </NText>
+            <CopyToClipboardButton :content="result" />
+          </NFlex>
+        </NCard>
+
+        <NFlex :size="8" align="center">
+          <NTag :type="contentType.type">{{ contentType.label }}</NTag>
+          <NButton
+            v-if="contentType.isUrl"
+            text
+            tag="a"
+            :href="result"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {{ t('openLink') }}
+          </NButton>
+        </NFlex>
+      </NFlex>
+    </template>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { NFlex, NAlert, NCard, NText, NTag, NButton } from 'naive-ui'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { CopyToClipboardButton } from '@shared/ui/base'
+
+const { t } = useI18n()
+
+const props = defineProps<{
+  result: string | null
+  error: string | null
+}>()
+
+const contentType = computed(() => {
+  if (!props.result) return { label: '', type: 'default' as const, isUrl: false }
+
+  const text = props.result
+
+  // URL
+  if (/^https?:\/\//i.test(text)) {
+    return { label: 'URL', type: 'info' as const, isUrl: true }
+  }
+
+  // Email
+  if (/^mailto:/i.test(text)) {
+    return { label: 'Email', type: 'success' as const, isUrl: true }
+  }
+
+  // Phone
+  if (/^tel:/i.test(text)) {
+    return { label: t('phone'), type: 'success' as const, isUrl: true }
+  }
+
+  // SMS
+  if (/^sms:/i.test(text)) {
+    return { label: 'SMS', type: 'success' as const, isUrl: true }
+  }
+
+  // WiFi
+  if (/^WIFI:/i.test(text)) {
+    return { label: 'WiFi', type: 'warning' as const, isUrl: false }
+  }
+
+  // vCard
+  if (/^BEGIN:VCARD/i.test(text)) {
+    return { label: 'vCard', type: 'success' as const, isUrl: false }
+  }
+
+  // Calendar event
+  if (/^BEGIN:VCALENDAR/i.test(text)) {
+    return { label: t('calendar'), type: 'success' as const, isUrl: false }
+  }
+
+  // Geo location
+  if (/^geo:/i.test(text)) {
+    return { label: t('location'), type: 'info' as const, isUrl: true }
+  }
+
+  // Plain text
+  return { label: t('text'), type: 'default' as const, isUrl: false }
+})
+</script>
+
+<style scoped>
+.result-text {
+  font-family: monospace;
+  white-space: pre-wrap;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "result": "Result",
+    "noResult": "No QR Code Found",
+    "openLink": "Open Link",
+    "scanAnother": "Scan Another",
+    "text": "Text",
+    "phone": "Phone",
+    "calendar": "Calendar",
+    "location": "Location"
+  },
+  "zh": {
+    "result": "结果",
+    "noResult": "未找到二维码",
+    "openLink": "打开链接",
+    "scanAnother": "扫描另一个",
+    "text": "文本",
+    "phone": "电话",
+    "calendar": "日历",
+    "location": "位置"
+  },
+  "zh-CN": {
+    "result": "结果",
+    "noResult": "未找到二维码",
+    "openLink": "打开链接",
+    "scanAnother": "扫描另一个",
+    "text": "文本",
+    "phone": "电话",
+    "calendar": "日历",
+    "location": "位置"
+  },
+  "zh-TW": {
+    "result": "結果",
+    "noResult": "未找到 QR Code",
+    "openLink": "開啟連結",
+    "scanAnother": "掃描另一個",
+    "text": "文字",
+    "phone": "電話",
+    "calendar": "日曆",
+    "location": "位置"
+  },
+  "zh-HK": {
+    "result": "結果",
+    "noResult": "未找到 QR Code",
+    "openLink": "開啟連結",
+    "scanAnother": "掃描另一個",
+    "text": "文字",
+    "phone": "電話",
+    "calendar": "日曆",
+    "location": "位置"
+  },
+  "es": {
+    "result": "Resultado",
+    "noResult": "No se encontro codigo QR",
+    "openLink": "Abrir enlace",
+    "scanAnother": "Escanear otro",
+    "text": "Texto",
+    "phone": "Telefono",
+    "calendar": "Calendario",
+    "location": "Ubicacion"
+  },
+  "fr": {
+    "result": "Resultat",
+    "noResult": "Aucun code QR trouve",
+    "openLink": "Ouvrir le lien",
+    "scanAnother": "Scanner un autre",
+    "text": "Texte",
+    "phone": "Telephone",
+    "calendar": "Calendrier",
+    "location": "Emplacement"
+  },
+  "de": {
+    "result": "Ergebnis",
+    "noResult": "Kein QR-Code gefunden",
+    "openLink": "Link offnen",
+    "scanAnother": "Weiteren scannen",
+    "text": "Text",
+    "phone": "Telefon",
+    "calendar": "Kalender",
+    "location": "Standort"
+  },
+  "it": {
+    "result": "Risultato",
+    "noResult": "Nessun codice QR trovato",
+    "openLink": "Apri link",
+    "scanAnother": "Scansiona un altro",
+    "text": "Testo",
+    "phone": "Telefono",
+    "calendar": "Calendario",
+    "location": "Posizione"
+  },
+  "ja": {
+    "result": "結果",
+    "noResult": "QRコードが見つかりません",
+    "openLink": "リンクを開く",
+    "scanAnother": "別のものをスキャン",
+    "text": "テキスト",
+    "phone": "電話",
+    "calendar": "カレンダー",
+    "location": "位置"
+  },
+  "ko": {
+    "result": "결과",
+    "noResult": "QR 코드를 찾을 수 없음",
+    "openLink": "링크 열기",
+    "scanAnother": "다른 것 스캔",
+    "text": "텍스트",
+    "phone": "전화",
+    "calendar": "캘린더",
+    "location": "위치"
+  },
+  "ru": {
+    "result": "Результат",
+    "noResult": "QR-код не найден",
+    "openLink": "Открыть ссылку",
+    "scanAnother": "Сканировать другой",
+    "text": "Текст",
+    "phone": "Телефон",
+    "calendar": "Календарь",
+    "location": "Местоположение"
+  },
+  "pt": {
+    "result": "Resultado",
+    "noResult": "Nenhum codigo QR encontrado",
+    "openLink": "Abrir link",
+    "scanAnother": "Escanear outro",
+    "text": "Texto",
+    "phone": "Telefone",
+    "calendar": "Calendario",
+    "location": "Localizacao"
+  },
+  "ar": {
+    "result": "النتيجة",
+    "noResult": "لم يتم العثور على رمز QR",
+    "openLink": "فتح الرابط",
+    "scanAnother": "مسح آخر",
+    "text": "نص",
+    "phone": "هاتف",
+    "calendar": "تقويم",
+    "location": "موقع"
+  },
+  "hi": {
+    "result": "परिणाम",
+    "noResult": "कोई QR कोड नहीं मिला",
+    "openLink": "लिंक खोलें",
+    "scanAnother": "एक और स्कैन करें",
+    "text": "पाठ",
+    "phone": "फ़ोन",
+    "calendar": "कैलेंडर",
+    "location": "स्थान"
+  },
+  "tr": {
+    "result": "Sonuc",
+    "noResult": "QR kodu bulunamadi",
+    "openLink": "Baglanti ac",
+    "scanAnother": "Baska tara",
+    "text": "Metin",
+    "phone": "Telefon",
+    "calendar": "Takvim",
+    "location": "Konum"
+  },
+  "nl": {
+    "result": "Resultaat",
+    "noResult": "Geen QR-code gevonden",
+    "openLink": "Link openen",
+    "scanAnother": "Scan nog een",
+    "text": "Tekst",
+    "phone": "Telefoon",
+    "calendar": "Kalender",
+    "location": "Locatie"
+  },
+  "sv": {
+    "result": "Resultat",
+    "noResult": "Ingen QR-kod hittades",
+    "openLink": "Oppna lank",
+    "scanAnother": "Skanna en annan",
+    "text": "Text",
+    "phone": "Telefon",
+    "calendar": "Kalender",
+    "location": "Plats"
+  },
+  "pl": {
+    "result": "Wynik",
+    "noResult": "Nie znaleziono kodu QR",
+    "openLink": "Otworz link",
+    "scanAnother": "Skanuj kolejny",
+    "text": "Tekst",
+    "phone": "Telefon",
+    "calendar": "Kalendarz",
+    "location": "Lokalizacja"
+  },
+  "vi": {
+    "result": "Ket qua",
+    "noResult": "Khong tim thay ma QR",
+    "openLink": "Mo lien ket",
+    "scanAnother": "Quet cai khac",
+    "text": "Van ban",
+    "phone": "Dien thoai",
+    "calendar": "Lich",
+    "location": "Vi tri"
+  },
+  "th": {
+    "result": "ผลลัพธ์",
+    "noResult": "ไม่พบ QR Code",
+    "openLink": "เปิดลิงก์",
+    "scanAnother": "สแกนอันอื่น",
+    "text": "ข้อความ",
+    "phone": "โทรศัพท์",
+    "calendar": "ปฏิทิน",
+    "location": "ตำแหน่ง"
+  },
+  "id": {
+    "result": "Hasil",
+    "noResult": "Kode QR tidak ditemukan",
+    "openLink": "Buka tautan",
+    "scanAnother": "Pindai lainnya",
+    "text": "Teks",
+    "phone": "Telepon",
+    "calendar": "Kalender",
+    "location": "Lokasi"
+  },
+  "he": {
+    "result": "תוצאה",
+    "noResult": "לא נמצא קוד QR",
+    "openLink": "פתח קישור",
+    "scanAnother": "סרוק אחר",
+    "text": "טקסט",
+    "phone": "טלפון",
+    "calendar": "לוח שנה",
+    "location": "מיקום"
+  },
+  "ms": {
+    "result": "Keputusan",
+    "noResult": "Kod QR tidak ditemui",
+    "openLink": "Buka pautan",
+    "scanAnother": "Imbas yang lain",
+    "text": "Teks",
+    "phone": "Telefon",
+    "calendar": "Kalendar",
+    "location": "Lokasi"
+  },
+  "no": {
+    "result": "Resultat",
+    "noResult": "Ingen QR-kode funnet",
+    "openLink": "Apne lenke",
+    "scanAnother": "Skann en annen",
+    "text": "Tekst",
+    "phone": "Telefon",
+    "calendar": "Kalender",
+    "location": "Plassering"
+  }
+}
+</i18n>

--- a/tools/image/qr-code-reader/src/index.ts
+++ b/tools/image/qr-code-reader/src/index.ts
@@ -1,0 +1,1 @@
+export * as toolInfo from './info'

--- a/tools/image/qr-code-reader/src/info.ts
+++ b/tools/image/qr-code-reader/src/info.ts
@@ -1,0 +1,109 @@
+export { QrCode24Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'qr-code-reader'
+export const path = '/tools/qr-code-reader'
+export const tags = ['qr', 'qrcode', 'barcode', 'scanner', 'reader', 'decoder', 'image', 'camera']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'QR Code Reader',
+    description: 'Scan and decode QR codes from images or camera',
+  },
+  zh: {
+    name: '二维码识别',
+    description: '从图片或摄像头扫描和解码二维码',
+  },
+  'zh-CN': {
+    name: '二维码识别',
+    description: '从图片或摄像头扫描和解码二维码',
+  },
+  'zh-TW': {
+    name: 'QR Code 識別',
+    description: '從圖片或攝影機掃描和解碼 QR Code',
+  },
+  'zh-HK': {
+    name: 'QR Code 識別',
+    description: '從圖片或攝影機掃描和解碼 QR Code',
+  },
+  es: {
+    name: 'Lector de Codigo QR',
+    description: 'Escanea y decodifica codigos QR desde imagenes o camara',
+  },
+  fr: {
+    name: 'Lecteur de QR Code',
+    description: 'Scannez et decodez les QR codes depuis des images ou camera',
+  },
+  de: {
+    name: 'QR-Code-Leser',
+    description: 'QR-Codes aus Bildern oder Kamera scannen und dekodieren',
+  },
+  it: {
+    name: 'Lettore di Codici QR',
+    description: 'Scansiona e decodifica codici QR da immagini o fotocamera',
+  },
+  ja: {
+    name: 'QRコードリーダー',
+    description: '画像またはカメラからQRコードをスキャンしてデコード',
+  },
+  ko: {
+    name: 'QR 코드 리더',
+    description: '이미지 또는 카메라에서 QR 코드를 스캔하고 디코딩',
+  },
+  ru: {
+    name: 'Сканер QR-кода',
+    description: 'Сканирование и декодирование QR-кодов из изображений или камеры',
+  },
+  pt: {
+    name: 'Leitor de Codigo QR',
+    description: 'Digitalize e decodifique codigos QR de imagens ou camera',
+  },
+  ar: {
+    name: 'قارئ رمز QR',
+    description: 'مسح وفك رموز QR من الصور أو الكاميرا',
+  },
+  hi: {
+    name: 'QR कोड रीडर',
+    description: 'छवियों या कैमरे से QR कोड स्कैन और डिकोड करें',
+  },
+  tr: {
+    name: 'QR Kod Okuyucu',
+    description: 'Gorsellerden veya kameradan QR kodlarini tarayin ve cozumleyin',
+  },
+  nl: {
+    name: 'QR-codelezer',
+    description: 'Scan en decodeer QR-codes van afbeeldingen of camera',
+  },
+  sv: {
+    name: 'QR-kodlasare',
+    description: 'Skanna och avkoda QR-koder fran bilder eller kamera',
+  },
+  pl: {
+    name: 'Czytnik Kodow QR',
+    description: 'Skanuj i dekoduj kody QR z obrazow lub kamery',
+  },
+  vi: {
+    name: 'Doc Ma QR',
+    description: 'Quet va giai ma ma QR tu anh hoac camera',
+  },
+  th: {
+    name: 'เครื่องอ่าน QR Code',
+    description: 'สแกนและถอดรหัส QR Code จากรูปภาพหรือกล้อง',
+  },
+  id: {
+    name: 'Pembaca Kode QR',
+    description: 'Pindai dan dekode kode QR dari gambar atau kamera',
+  },
+  he: {
+    name: 'קורא קוד QR',
+    description: 'סרוק ופענח קודי QR מתמונות או מצלמה',
+  },
+  ms: {
+    name: 'Pembaca Kod QR',
+    description: 'Imbas dan nyahkod kod QR dari imej atau kamera',
+  },
+  no: {
+    name: 'QR-kodeleser',
+    description: 'Skann og dekod QR-koder fra bilder eller kamera',
+  },
+}

--- a/tools/image/qr-code-reader/src/qr-reader.ts
+++ b/tools/image/qr-code-reader/src/qr-reader.ts
@@ -1,0 +1,50 @@
+import jsQR from 'jsqr'
+
+/**
+ * Read QR code from a File (image)
+ */
+export async function readQRFromFile(file: File): Promise<string | null> {
+  const img = new Image()
+  const url = URL.createObjectURL(file)
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      img.onload = () => resolve()
+      img.onerror = () => reject(new Error('Failed to load image'))
+      img.src = url
+    })
+
+    const canvas = document.createElement('canvas')
+    canvas.width = img.width
+    canvas.height = img.height
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return null
+
+    ctx.drawImage(img, 0, 0)
+    const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    const code = jsQR(imageData.data, imageData.width, imageData.height)
+
+    return code?.data ?? null
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+/**
+ * Read QR code from a video frame (for camera scanning)
+ */
+export function readQRFromVideo(video: HTMLVideoElement, canvas: HTMLCanvasElement): string | null {
+  if (video.videoWidth === 0 || video.videoHeight === 0) return null
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return null
+
+  canvas.width = video.videoWidth
+  canvas.height = video.videoHeight
+  ctx.drawImage(video, 0, 0)
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+  const code = jsQR(imageData.data, imageData.width, imageData.height)
+
+  return code?.data ?? null
+}

--- a/tools/image/qr-code-reader/src/routes.ts
+++ b/tools/image/qr-code-reader/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'qr-code-reader',
+    path: '/tools/qr-code-reader',
+    component: () => import('./QRCodeReaderView.vue'),
+  },
+] as const


### PR DESCRIPTION
## Summary
- Add a new QR Code Reader tool that decodes QR codes from images and camera
- Support image upload with drag & drop
- Support real-time camera scanning with getUserMedia API
- Auto-detect content type (URL, Email, Phone, WiFi, vCard, Calendar, Location, etc.)
- Full i18n support for all 25 languages

## Features
- **Image Upload Mode**: Drag & drop or click to upload images containing QR codes
- **Camera Mode**: Real-time scanning using device camera (prefers back camera on mobile)
- **Content Type Detection**: Automatically identifies and displays the type of QR code content
- **Copy to Clipboard**: Easy one-click copy of decoded content
- **Open Link**: Direct link to open URLs, emails, phone numbers, etc.

## Test plan
- [ ] Upload a QR code image → Should decode and show result
- [ ] Test with various QR code types (URL, text, WiFi, vCard)
- [ ] Test camera mode on desktop and mobile
- [ ] Test camera permission denied scenario
- [ ] Verify tab switching clears previous state
- [ ] Test copy button functionality
- [ ] Test on mobile devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)