### PR TITLE
feat(tools): add password strength checker

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,6 +729,9 @@ importers:
       '@tools/openapi-to-typescript':
         specifier: workspace:*
         version: link:../../tools/code/openapi-to-typescript
+      '@tools/password-strength-checker':
+        specifier: workspace:*
+        version: link:../../tools/validator/password-strength-checker
       '@tools/pdf-tools':
         specifier: workspace:*
         version: link:../../tools/pdf/pdf-tools
@@ -3723,6 +3726,30 @@ importers:
       '@utils/json-schema':
         specifier: workspace:*
         version: link:../../../utils/json-schema
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
+      naive-ui:
+        specifier: 'catalog:'
+        version: 2.43.2(vue@3.5.26(typescript@5.9.3))
+      vue:
+        specifier: 'catalog:'
+        version: 3.5.26(typescript@5.9.3)
+      vue-i18n:
+        specifier: 'catalog:'
+        version: 11.2.8(vue@3.5.26(typescript@5.9.3))
+
+  tools/validator/password-strength-checker:
+    dependencies:
+      '@shared/icons':
+        specifier: workspace:*
+        version: link:../../../shared/icons
+      '@shared/tools':
+        specifier: workspace:*
+        version: link:../../../shared/tools
+      '@shared/ui':
+        specifier: workspace:*
+        version: link:../../../shared/ui
       '@vueuse/core':
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.26(typescript@5.9.3))

--- a/registry/tools/package.json
+++ b/registry/tools/package.json
@@ -75,6 +75,7 @@
     "@tools/my-ip-address": "workspace:*",
     "@tools/network-tools": "workspace:*",
     "@tools/number-base-converter": "workspace:*",
+    "@tools/password-strength-checker": "workspace:*",
     "@tools/pdf-tools": "workspace:*",
     "@tools/placeholder-image-generator": "workspace:*",
     "@tools/png-optimizer": "workspace:*",

--- a/registry/tools/src/index.ts
+++ b/registry/tools/src/index.ts
@@ -69,6 +69,7 @@ import { toolInfo as jsonFormatterToolInfo } from '@tools/json-formatter'
 import { toolInfo as openApiToTypescriptToolInfo } from '@tools/openapi-to-typescript'
 import { toolInfo as prettierCodeFormatterToolInfo } from '@tools/prettier-code-formatter'
 import { toolInfo as jsonSchemaValidatorToolInfo } from '@tools/json-schema-validator'
+import { toolInfo as passwordStrengthCheckerToolInfo } from '@tools/password-strength-checker'
 import { toolInfo as deviceInformationToolInfo } from '@tools/device-information'
 import { toolInfo as romanNumeralConverterToolInfo } from '@tools/roman-numeral-converter'
 import { toolInfo as unixTimestampConverterToolInfo } from '@tools/unix-timestamp-converter'
@@ -239,6 +240,7 @@ export const tools: ToolInfo[] = [
 
   // Validator Tools
   jsonSchemaValidatorToolInfo,
+  passwordStrengthCheckerToolInfo,
   creditCardValidatorToolInfo,
   isbnValidatorToolInfo,
   ibanValidatorToolInfo,

--- a/registry/tools/src/routes.ts
+++ b/registry/tools/src/routes.ts
@@ -66,6 +66,7 @@ import { routes as jsonToCsvConverterRoutes } from '@tools/json-to-csv-converter
 import { routes as jsonFormatterRoutes } from '@tools/json-formatter/routes'
 import { routes as jsonSchemaValidatorRoutes } from '@tools/json-schema-validator/routes'
 import { routes as openApiToTypescriptRoutes } from '@tools/openapi-to-typescript/routes'
+import { routes as passwordStrengthCheckerRoutes } from '@tools/password-strength-checker/routes'
 import { routes as prettierCodeFormatterRoutes } from '@tools/prettier-code-formatter/routes'
 import { routes as deviceInformationRoutes } from '@tools/device-information/routes'
 import { routes as romanNumeralConverterRoutes } from '@tools/roman-numeral-converter/routes'
@@ -172,9 +173,10 @@ export const routes: ToolRoute[] = [
   ...csvToJsonConverterRoutes,
   ...jsonToCsvConverterRoutes,
   ...jsonFormatterRoutes,
+  ...jsonSchemaValidatorRoutes,
   ...openApiToTypescriptRoutes,
   ...prettierCodeFormatterRoutes,
-  ...jsonSchemaValidatorRoutes,
+  ...passwordStrengthCheckerRoutes,
   ...deviceInformationRoutes,
   ...romanNumeralConverterRoutes,
   ...unixTimestampConverterRoutes,

--- a/tools/validator/password-strength-checker/package.json
+++ b/tools/validator/password-strength-checker/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@tools/password-strength-checker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./routes": "./src/routes.ts"
+  },
+  "dependencies": {
+    "@shared/icons": "workspace:*",
+    "@shared/tools": "workspace:*",
+    "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
+    "naive-ui": "catalog:",
+    "vue": "catalog:",
+    "vue-i18n": "catalog:"
+  }
+}

--- a/tools/validator/password-strength-checker/src/PasswordStrengthCheckerView.dom.test.ts
+++ b/tools/validator/password-strength-checker/src/PasswordStrengthCheckerView.dom.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PasswordStrengthCheckerView from './PasswordStrengthCheckerView.vue'
+import PasswordStrengthChecker from './components/PasswordStrengthChecker.vue'
+import WhatIsPasswordStrength from './components/WhatIsPasswordStrength.vue'
+
+describe('PasswordStrengthCheckerView', () => {
+  it('renders the checker and explanation components', () => {
+    const wrapper = mount(PasswordStrengthCheckerView, {
+      global: {
+        stubs: {
+          ToolDefaultPageLayout: {
+            props: ['info'],
+            template: '<div><slot /></div>',
+          },
+        },
+      },
+    })
+
+    expect(wrapper.findComponent(PasswordStrengthChecker).exists()).toBe(true)
+    expect(wrapper.findComponent(WhatIsPasswordStrength).exists()).toBe(true)
+  })
+})

--- a/tools/validator/password-strength-checker/src/PasswordStrengthCheckerView.vue
+++ b/tools/validator/password-strength-checker/src/PasswordStrengthCheckerView.vue
@@ -1,0 +1,13 @@
+<template>
+  <ToolDefaultPageLayout :info="toolInfo">
+    <PasswordStrengthChecker />
+    <WhatIsPasswordStrength />
+  </ToolDefaultPageLayout>
+</template>
+
+<script setup lang="ts">
+import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import * as toolInfo from './info'
+import PasswordStrengthChecker from './components/PasswordStrengthChecker.vue'
+import WhatIsPasswordStrength from './components/WhatIsPasswordStrength.vue'
+</script>

--- a/tools/validator/password-strength-checker/src/components/PasswordStrengthChecker.dom.test.ts
+++ b/tools/validator/password-strength-checker/src/components/PasswordStrengthChecker.dom.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PasswordStrengthChecker from './PasswordStrengthChecker.vue'
+
+describe('PasswordStrengthChecker', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('shows empty state by default', () => {
+    const wrapper = mount(PasswordStrengthChecker)
+    const vm = wrapper.vm as unknown as {
+      strengthLabel: string
+      scorePercent: number
+      scoreTagType: string
+      entropyBits: string
+      log10Guesses: string
+      characterTags: string[]
+      warningMessages: string[]
+      suggestionMessages: string[]
+      offlineTimeLabel: string
+      onlineTimeLabel: string
+    }
+
+    expect(wrapper.text()).toContain('Enter a password to check its strength.')
+    expect(vm.strengthLabel).toBe('')
+    expect(vm.scorePercent).toBe(0)
+    expect(vm.scoreTagType).toBe('default')
+    expect(vm.entropyBits).toBe('0')
+    expect(vm.log10Guesses).toBe('0')
+    expect(vm.characterTags).toEqual([])
+    expect(vm.warningMessages).toEqual([])
+    expect(vm.suggestionMessages).toEqual([])
+    expect(vm.offlineTimeLabel).toBe('')
+    expect(vm.onlineTimeLabel).toBe('')
+  })
+
+  it('toggles password visibility', async () => {
+    const wrapper = mount(PasswordStrengthChecker)
+    const input = wrapper.find('input')
+    expect(input.element.type).toBe('password')
+    expect(wrapper.text()).toContain('Show')
+
+    const toggle = wrapper.find('button')
+    await toggle.trigger('click')
+
+    expect(wrapper.find('input').element.type).toBe('text')
+    expect(wrapper.text()).toContain('Hide')
+  })
+
+  it('renders warnings and fast crack time for weak passwords', async () => {
+    const wrapper = mount(PasswordStrengthChecker)
+    await wrapper.find('input').setValue('123456')
+
+    const text = wrapper.text()
+    expect(text).toContain('Very weak')
+    expect(text).toContain('This is a very common password')
+    expect(text).toContain('Use a longer password or passphrase')
+    expect(text).toContain('Less than 1 second')
+    const alerts = wrapper.findAll('.n-alert')
+    expect(alerts).toHaveLength(2)
+    expect(alerts.every((alert) => (alert.element as HTMLElement).style.display !== 'none')).toBe(
+      true,
+    )
+  })
+
+  it('renders strong results for complex passwords', async () => {
+    const wrapper = mount(PasswordStrengthChecker)
+    await wrapper.find('input').setValue('Str0ng!Passw0rd-Example')
+
+    const text = wrapper.text()
+    expect(text).toContain('Very strong')
+    expect(text).toContain('Entropy')
+    expect(text).toContain('Character sets')
+    expect(wrapper.findAll('li')).toHaveLength(0)
+  })
+
+  it('hides digit tags when no numbers are present', async () => {
+    const wrapper = mount(PasswordStrengthChecker)
+    await wrapper.find('input').setValue('Abc!defg')
+
+    const text = wrapper.text()
+    expect(text).toContain('a-z')
+    expect(text).toContain('A-Z')
+    expect(text).toContain('#@$')
+    expect(text).not.toContain('0-9')
+  })
+})

--- a/tools/validator/password-strength-checker/src/components/PasswordStrengthChecker.vue
+++ b/tools/validator/password-strength-checker/src/components/PasswordStrengthChecker.vue
@@ -1,0 +1,1447 @@
+<template>
+  <ToolSectionHeader>{{ t('input-title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-form-item :label="t('password-label')">
+      <n-input
+        v-model:value="password"
+        :type="showPassword ? 'text' : 'password'"
+        :placeholder="t('password-placeholder')"
+      >
+        <template #suffix>
+          <n-button text size="small" @click="toggleVisibility">
+            {{ showPassword ? t('hide') : t('show') }}
+          </n-button>
+        </template>
+      </n-input>
+    </n-form-item>
+    <n-text depth="3" class="hint">{{ t('privacy-hint') }}</n-text>
+  </ToolSection>
+
+  <ToolSectionHeader>{{ t('results-title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-text v-if="!analysis" depth="3">{{ t('empty') }}</n-text>
+    <div v-else class="results">
+      <n-flex align="center" :size="12" wrap>
+        <n-tag :type="scoreTagType" size="small">
+          {{ strengthLabel }}
+        </n-tag>
+        <n-text depth="3">{{ t('entropy-bits', { bits: entropyBits }) }}</n-text>
+        <n-text depth="3">{{ t('log10-guesses', { value: log10Guesses }) }}</n-text>
+      </n-flex>
+
+      <div class="strength-meter" role="presentation">
+        <div
+          class="strength-meter-fill"
+          :class="`score-${analysis.score}`"
+          :style="{ width: `${scorePercent}%` }"
+        />
+      </div>
+
+      <n-descriptions :column="1" bordered label-placement="left">
+        <n-descriptions-item :label="t('length')">
+          <n-text depth="3">{{ analysis.length }}</n-text>
+        </n-descriptions-item>
+        <n-descriptions-item :label="t('unique')">
+          <n-text depth="3">{{ analysis.uniqueCount }}</n-text>
+        </n-descriptions-item>
+        <n-descriptions-item :label="t('character-sets')">
+          <n-flex align="center" :size="6" wrap>
+            <n-tag v-for="tag in characterTags" :key="tag" size="small">{{ tag }}</n-tag>
+          </n-flex>
+        </n-descriptions-item>
+        <n-descriptions-item :label="t('crack-offline')">
+          <n-text depth="3">{{ offlineTimeLabel }}</n-text>
+        </n-descriptions-item>
+        <n-descriptions-item :label="t('crack-online')">
+          <n-text depth="3">{{ onlineTimeLabel }}</n-text>
+        </n-descriptions-item>
+      </n-descriptions>
+
+      <n-alert v-show="warningMessages.length" type="warning" :show-icon="true" class="alert">
+        <n-ul>
+          <n-li v-for="message in warningMessages" :key="message">{{ message }}</n-li>
+        </n-ul>
+      </n-alert>
+
+      <n-alert v-show="suggestionMessages.length" type="info" :show-icon="true" class="alert">
+        <n-ul>
+          <n-li v-for="message in suggestionMessages" :key="message">{{ message }}</n-li>
+        </n-ul>
+      </n-alert>
+    </div>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  NAlert,
+  NButton,
+  NDescriptions,
+  NDescriptionsItem,
+  NFlex,
+  NFormItem,
+  NInput,
+  NTag,
+  NText,
+  NUl,
+  NLi,
+} from 'naive-ui'
+import { useI18n } from 'vue-i18n'
+import { useStorage } from '@vueuse/core'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { analyzePassword, type DurationDisplay } from '../utils'
+
+const { t } = useI18n()
+
+const password = useStorage('tools:password-strength-checker:password', '')
+const showPassword = ref(false)
+
+const analysis = computed(() => analyzePassword(password.value))
+
+const strengthLabel = computed(() => {
+  if (!analysis.value) return ''
+  return t(`strength-${analysis.value.score}`)
+})
+
+const scorePercent = computed(() => {
+  if (!analysis.value) return 0
+  return (analysis.value.score + 1) * 20
+})
+
+const scoreTagType = computed(() => {
+  if (!analysis.value) return 'default'
+  const scoreMap = ['error', 'warning', 'info', 'success', 'success'] as const
+  return scoreMap[analysis.value.score]
+})
+
+const entropyBits = computed(() => {
+  if (!analysis.value) return '0'
+  return analysis.value.entropyBits.toFixed(1)
+})
+
+const log10Guesses = computed(() => {
+  if (!analysis.value) return '0'
+  return analysis.value.log10Guesses.toFixed(1)
+})
+
+const characterTags = computed(() => {
+  if (!analysis.value) return []
+  const entries = [
+    { label: 'a-z', enabled: analysis.value.composition.lower },
+    { label: 'A-Z', enabled: analysis.value.composition.upper },
+    { label: '0-9', enabled: analysis.value.composition.digit },
+    { label: '#@$', enabled: analysis.value.composition.symbol },
+  ]
+  return entries.filter((entry) => entry.enabled).map((entry) => entry.label)
+})
+
+const warningMessages = computed(() =>
+  analysis.value ? analysis.value.warnings.map((key) => t(`warning.${key}`)) : [],
+)
+
+const suggestionMessages = computed(() =>
+  analysis.value ? analysis.value.suggestions.map((key) => t(`suggestion.${key}`)) : [],
+)
+
+const offlineTimeLabel = computed(() => {
+  if (!analysis.value) return ''
+  return formatDurationLabel(analysis.value.crackTimes.offlineFast)
+})
+
+const onlineTimeLabel = computed(() => {
+  if (!analysis.value) return ''
+  return formatDurationLabel(analysis.value.crackTimes.onlineThrottled)
+})
+
+function formatDurationLabel(duration: DurationDisplay): string {
+  if (duration.isUnderSecond) return t('duration-under-second')
+  return t('duration-format', {
+    value: duration.value,
+    unit: t(`unit.${duration.unit}`),
+  })
+}
+
+function toggleVisibility() {
+  showPassword.value = !showPassword.value
+}
+</script>
+
+<style scoped>
+.hint {
+  display: block;
+  margin-top: 8px;
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.strength-meter {
+  height: 10px;
+  background-color: var(--n-border-color);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.strength-meter-fill {
+  height: 100%;
+  transition: width 0.2s ease;
+}
+
+.strength-meter-fill.score-0 {
+  background-color: #d92d20;
+}
+
+.strength-meter-fill.score-1 {
+  background-color: #f79009;
+}
+
+.strength-meter-fill.score-2 {
+  background-color: #fdb022;
+}
+
+.strength-meter-fill.score-3 {
+  background-color: #32d583;
+}
+
+.strength-meter-fill.score-4 {
+  background-color: #12b76a;
+}
+
+.alert :deep(.n-alert-body) {
+  width: 100%;
+}
+</style>
+
+<i18n lang="json">
+{
+  "en": {
+    "input-title": "Password",
+    "password-label": "Password",
+    "password-placeholder": "Type a password to evaluate",
+    "show": "Show",
+    "hide": "Hide",
+    "privacy-hint": "Strength checks run locally in your browser.",
+    "results-title": "Strength Summary",
+    "empty": "Enter a password to check its strength.",
+    "strength-0": "Very weak",
+    "strength-1": "Weak",
+    "strength-2": "Fair",
+    "strength-3": "Strong",
+    "strength-4": "Very strong",
+    "entropy-bits": "Entropy: {bits} bits",
+    "log10-guesses": "Guesses (log10): {value}",
+    "length": "Length",
+    "unique": "Unique characters",
+    "character-sets": "Character sets",
+    "crack-offline": "Crack time (offline, 1e10/s)",
+    "crack-online": "Crack time (online, 100/s)",
+    "duration-format": "About {value} {unit}",
+    "duration-under-second": "Less than 1 second",
+    "unit": {
+      "seconds": "seconds",
+      "minutes": "minutes",
+      "hours": "hours",
+      "days": "days",
+      "months": "months",
+      "years": "years"
+    },
+    "warning": {
+      "common": "This is a very common password.",
+      "short": "The password is too short.",
+      "sequence": "Sequential patterns are easy to guess.",
+      "repeat": "Repeated patterns reduce strength.",
+      "singleClass": "Using only one character type lowers strength."
+    },
+    "suggestion": {
+      "use-longer": "Use a longer password or passphrase.",
+      "add-uppercase": "Add uppercase letters.",
+      "add-lowercase": "Add lowercase letters.",
+      "add-numbers": "Add numbers.",
+      "add-symbols": "Add symbols.",
+      "avoid-common": "Avoid common passwords and leaked phrases.",
+      "avoid-sequences": "Avoid sequences like 123 or abc.",
+      "avoid-repetition": "Avoid repeated patterns."
+    }
+  },
+  "zh": {
+    "input-title": "密码",
+    "password-label": "密码",
+    "password-placeholder": "输入要评估的密码",
+    "show": "显示",
+    "hide": "隐藏",
+    "privacy-hint": "强度检测在本地浏览器中完成。",
+    "results-title": "强度摘要",
+    "empty": "请输入密码以检查强度。",
+    "strength-0": "非常弱",
+    "strength-1": "较弱",
+    "strength-2": "一般",
+    "strength-3": "强",
+    "strength-4": "非常强",
+    "entropy-bits": "熵值：{bits} 位",
+    "log10-guesses": "猜测次数（log10）：{value}",
+    "length": "长度",
+    "unique": "唯一字符数",
+    "character-sets": "字符集",
+    "crack-offline": "破解时间（离线 1e10/秒）",
+    "crack-online": "破解时间（在线 100/秒）",
+    "duration-format": "约 {value} {unit}",
+    "duration-under-second": "少于 1 秒",
+    "unit": {
+      "seconds": "秒",
+      "minutes": "分钟",
+      "hours": "小时",
+      "days": "天",
+      "months": "个月",
+      "years": "年"
+    },
+    "warning": {
+      "common": "这是非常常见的密码。",
+      "short": "密码过短。",
+      "sequence": "连续模式容易被猜中。",
+      "repeat": "重复模式会降低强度。",
+      "singleClass": "仅使用一种字符类型会降低强度。"
+    },
+    "suggestion": {
+      "use-longer": "使用更长的密码或口令短语。",
+      "add-uppercase": "添加大写字母。",
+      "add-lowercase": "添加小写字母。",
+      "add-numbers": "添加数字。",
+      "add-symbols": "添加符号。",
+      "avoid-common": "避免常见密码和已泄露的短语。",
+      "avoid-sequences": "避免 123 或 abc 之类的序列。",
+      "avoid-repetition": "避免重复模式。"
+    }
+  },
+  "zh-CN": {
+    "input-title": "密码",
+    "password-label": "密码",
+    "password-placeholder": "输入要评估的密码",
+    "show": "显示",
+    "hide": "隐藏",
+    "privacy-hint": "强度检测在本地浏览器中完成。",
+    "results-title": "强度摘要",
+    "empty": "请输入密码以检查强度。",
+    "strength-0": "非常弱",
+    "strength-1": "较弱",
+    "strength-2": "一般",
+    "strength-3": "强",
+    "strength-4": "非常强",
+    "entropy-bits": "熵值：{bits} 位",
+    "log10-guesses": "猜测次数（log10）：{value}",
+    "length": "长度",
+    "unique": "唯一字符数",
+    "character-sets": "字符集",
+    "crack-offline": "破解时间（离线 1e10/秒）",
+    "crack-online": "破解时间（在线 100/秒）",
+    "duration-format": "约 {value} {unit}",
+    "duration-under-second": "少于 1 秒",
+    "unit": {
+      "seconds": "秒",
+      "minutes": "分钟",
+      "hours": "小时",
+      "days": "天",
+      "months": "个月",
+      "years": "年"
+    },
+    "warning": {
+      "common": "这是非常常见的密码。",
+      "short": "密码过短。",
+      "sequence": "连续模式容易被猜中。",
+      "repeat": "重复模式会降低强度。",
+      "singleClass": "仅使用一种字符类型会降低强度。"
+    },
+    "suggestion": {
+      "use-longer": "使用更长的密码或口令短语。",
+      "add-uppercase": "添加大写字母。",
+      "add-lowercase": "添加小写字母。",
+      "add-numbers": "添加数字。",
+      "add-symbols": "添加符号。",
+      "avoid-common": "避免常见密码和已泄露的短语。",
+      "avoid-sequences": "避免 123 或 abc 之类的序列。",
+      "avoid-repetition": "避免重复模式。"
+    }
+  },
+  "zh-TW": {
+    "input-title": "密碼",
+    "password-label": "密碼",
+    "password-placeholder": "輸入要評估的密碼",
+    "show": "顯示",
+    "hide": "隱藏",
+    "privacy-hint": "強度檢測在本地瀏覽器中完成。",
+    "results-title": "強度摘要",
+    "empty": "請輸入密碼以檢查強度。",
+    "strength-0": "非常弱",
+    "strength-1": "較弱",
+    "strength-2": "一般",
+    "strength-3": "強",
+    "strength-4": "非常強",
+    "entropy-bits": "熵值：{bits} 位",
+    "log10-guesses": "猜測次數（log10）：{value}",
+    "length": "長度",
+    "unique": "唯一字元數",
+    "character-sets": "字元集",
+    "crack-offline": "破解時間（離線 1e10/秒）",
+    "crack-online": "破解時間（線上 100/秒）",
+    "duration-format": "約 {value} {unit}",
+    "duration-under-second": "少於 1 秒",
+    "unit": {
+      "seconds": "秒",
+      "minutes": "分鐘",
+      "hours": "小時",
+      "days": "天",
+      "months": "個月",
+      "years": "年"
+    },
+    "warning": {
+      "common": "這是非常常見的密碼。",
+      "short": "密碼過短。",
+      "sequence": "連續模式容易被猜中。",
+      "repeat": "重複模式會降低強度。",
+      "singleClass": "僅使用一種字元類型會降低強度。"
+    },
+    "suggestion": {
+      "use-longer": "使用更長的密碼或口令短語。",
+      "add-uppercase": "加入大寫字母。",
+      "add-lowercase": "加入小寫字母。",
+      "add-numbers": "加入數字。",
+      "add-symbols": "加入符號。",
+      "avoid-common": "避免常見密碼和已洩露的短語。",
+      "avoid-sequences": "避免 123 或 abc 等序列。",
+      "avoid-repetition": "避免重複模式。"
+    }
+  },
+  "zh-HK": {
+    "input-title": "密碼",
+    "password-label": "密碼",
+    "password-placeholder": "輸入要評估嘅密碼",
+    "show": "顯示",
+    "hide": "隱藏",
+    "privacy-hint": "強度檢測喺本地瀏覽器完成。",
+    "results-title": "強度摘要",
+    "empty": "請輸入密碼以檢查強度。",
+    "strength-0": "非常弱",
+    "strength-1": "較弱",
+    "strength-2": "一般",
+    "strength-3": "強",
+    "strength-4": "非常強",
+    "entropy-bits": "熵值：{bits} 位",
+    "log10-guesses": "猜測次數（log10）：{value}",
+    "length": "長度",
+    "unique": "唯一字元數",
+    "character-sets": "字元集",
+    "crack-offline": "破解時間（離線 1e10/秒）",
+    "crack-online": "破解時間（線上 100/秒）",
+    "duration-format": "約 {value} {unit}",
+    "duration-under-second": "少於 1 秒",
+    "unit": {
+      "seconds": "秒",
+      "minutes": "分鐘",
+      "hours": "小時",
+      "days": "天",
+      "months": "個月",
+      "years": "年"
+    },
+    "warning": {
+      "common": "呢個係非常常見嘅密碼。",
+      "short": "密碼太短。",
+      "sequence": "連續模式容易被估中。",
+      "repeat": "重複模式會降低強度。",
+      "singleClass": "只用一種字元類型會降低強度。"
+    },
+    "suggestion": {
+      "use-longer": "使用更長嘅密碼或口令短語。",
+      "add-uppercase": "加入大寫字母。",
+      "add-lowercase": "加入小寫字母。",
+      "add-numbers": "加入數字。",
+      "add-symbols": "加入符號。",
+      "avoid-common": "避免常見密碼同已洩露嘅短語。",
+      "avoid-sequences": "避免 123 或 abc 等序列。",
+      "avoid-repetition": "避免重複模式。"
+    }
+  },
+  "es": {
+    "input-title": "Contraseña",
+    "password-label": "Contraseña",
+    "password-placeholder": "Escribe una contraseña para evaluar",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "privacy-hint": "Las comprobaciones se realizan localmente en tu navegador.",
+    "results-title": "Resumen de fuerza",
+    "empty": "Introduce una contraseña para comprobar su fuerza.",
+    "strength-0": "Muy débil",
+    "strength-1": "Débil",
+    "strength-2": "Aceptable",
+    "strength-3": "Fuerte",
+    "strength-4": "Muy fuerte",
+    "entropy-bits": "Entropía: {bits} bits",
+    "log10-guesses": "Intentos (log10): {value}",
+    "length": "Longitud",
+    "unique": "Caracteres únicos",
+    "character-sets": "Conjuntos de caracteres",
+    "crack-offline": "Tiempo de ruptura (offline, 1e10/s)",
+    "crack-online": "Tiempo de ruptura (online, 100/s)",
+    "duration-format": "Aproximadamente {value} {unit}",
+    "duration-under-second": "Menos de 1 segundo",
+    "unit": {
+      "seconds": "segundos",
+      "minutes": "minutos",
+      "hours": "horas",
+      "days": "días",
+      "months": "meses",
+      "years": "años"
+    },
+    "warning": {
+      "common": "Esta es una contraseña muy común.",
+      "short": "La contraseña es demasiado corta.",
+      "sequence": "Las secuencias son fáciles de adivinar.",
+      "repeat": "Los patrones repetidos reducen la fuerza.",
+      "singleClass": "Usar solo un tipo de carácter reduce la fuerza."
+    },
+    "suggestion": {
+      "use-longer": "Usa una contraseña o frase más larga.",
+      "add-uppercase": "Añade letras mayúsculas.",
+      "add-lowercase": "Añade letras minúsculas.",
+      "add-numbers": "Añade números.",
+      "add-symbols": "Añade símbolos.",
+      "avoid-common": "Evita contraseñas comunes y filtradas.",
+      "avoid-sequences": "Evita secuencias como 123 o abc.",
+      "avoid-repetition": "Evita patrones repetidos."
+    }
+  },
+  "fr": {
+    "input-title": "Mot de passe",
+    "password-label": "Mot de passe",
+    "password-placeholder": "Saisissez un mot de passe à évaluer",
+    "show": "Afficher",
+    "hide": "Masquer",
+    "privacy-hint": "Les vérifications sont effectuées localement dans votre navigateur.",
+    "results-title": "Résumé de robustesse",
+    "empty": "Saisissez un mot de passe pour vérifier sa robustesse.",
+    "strength-0": "Très faible",
+    "strength-1": "Faible",
+    "strength-2": "Moyenne",
+    "strength-3": "Forte",
+    "strength-4": "Très forte",
+    "entropy-bits": "Entropie : {bits} bits",
+    "log10-guesses": "Essais (log10) : {value}",
+    "length": "Longueur",
+    "unique": "Caractères uniques",
+    "character-sets": "Jeux de caractères",
+    "crack-offline": "Temps de cassage (offline, 1e10/s)",
+    "crack-online": "Temps de cassage (en ligne, 100/s)",
+    "duration-format": "Environ {value} {unit}",
+    "duration-under-second": "Moins d'une seconde",
+    "unit": {
+      "seconds": "secondes",
+      "minutes": "minutes",
+      "hours": "heures",
+      "days": "jours",
+      "months": "mois",
+      "years": "années"
+    },
+    "warning": {
+      "common": "C'est un mot de passe très courant.",
+      "short": "Le mot de passe est trop court.",
+      "sequence": "Les séquences sont faciles à deviner.",
+      "repeat": "Les motifs répétés réduisent la robustesse.",
+      "singleClass": "Utiliser un seul type de caractère réduit la robustesse."
+    },
+    "suggestion": {
+      "use-longer": "Utilisez un mot de passe ou une phrase plus long.",
+      "add-uppercase": "Ajoutez des lettres majuscules.",
+      "add-lowercase": "Ajoutez des lettres minuscules.",
+      "add-numbers": "Ajoutez des chiffres.",
+      "add-symbols": "Ajoutez des symboles.",
+      "avoid-common": "Évitez les mots de passe courants et divulgués.",
+      "avoid-sequences": "Évitez les séquences comme 123 ou abc.",
+      "avoid-repetition": "Évitez les motifs répétitifs."
+    }
+  },
+  "de": {
+    "input-title": "Passwort",
+    "password-label": "Passwort",
+    "password-placeholder": "Geben Sie ein Passwort zur Bewertung ein",
+    "show": "Anzeigen",
+    "hide": "Verbergen",
+    "privacy-hint": "Die Prüfung erfolgt lokal in Ihrem Browser.",
+    "results-title": "Stärkeübersicht",
+    "empty": "Geben Sie ein Passwort ein, um die Stärke zu prüfen.",
+    "strength-0": "Sehr schwach",
+    "strength-1": "Schwach",
+    "strength-2": "Mittel",
+    "strength-3": "Stark",
+    "strength-4": "Sehr stark",
+    "entropy-bits": "Entropie: {bits} Bits",
+    "log10-guesses": "Versuche (log10): {value}",
+    "length": "Länge",
+    "unique": "Eindeutige Zeichen",
+    "character-sets": "Zeichensätze",
+    "crack-offline": "Knackzeit (offline, 1e10/s)",
+    "crack-online": "Knackzeit (online, 100/s)",
+    "duration-format": "Etwa {value} {unit}",
+    "duration-under-second": "Weniger als 1 Sekunde",
+    "unit": {
+      "seconds": "Sekunden",
+      "minutes": "Minuten",
+      "hours": "Stunden",
+      "days": "Tage",
+      "months": "Monate",
+      "years": "Jahre"
+    },
+    "warning": {
+      "common": "Dies ist ein sehr häufiges Passwort.",
+      "short": "Das Passwort ist zu kurz.",
+      "sequence": "Sequenzen sind leicht zu erraten.",
+      "repeat": "Wiederholte Muster verringern die Stärke.",
+      "singleClass": "Nur eine Zeichenart zu verwenden verringert die Stärke."
+    },
+    "suggestion": {
+      "use-longer": "Verwenden Sie ein längeres Passwort oder eine Passphrase.",
+      "add-uppercase": "Fügen Sie Großbuchstaben hinzu.",
+      "add-lowercase": "Fügen Sie Kleinbuchstaben hinzu.",
+      "add-numbers": "Fügen Sie Zahlen hinzu.",
+      "add-symbols": "Fügen Sie Symbole hinzu.",
+      "avoid-common": "Vermeiden Sie häufige und geleakte Passwörter.",
+      "avoid-sequences": "Vermeiden Sie Sequenzen wie 123 oder abc.",
+      "avoid-repetition": "Vermeiden Sie wiederholte Muster."
+    }
+  },
+  "it": {
+    "input-title": "Password",
+    "password-label": "Password",
+    "password-placeholder": "Inserisci una password da valutare",
+    "show": "Mostra",
+    "hide": "Nascondi",
+    "privacy-hint": "Le verifiche vengono eseguite localmente nel browser.",
+    "results-title": "Riepilogo forza",
+    "empty": "Inserisci una password per verificarne la forza.",
+    "strength-0": "Molto debole",
+    "strength-1": "Debole",
+    "strength-2": "Discreta",
+    "strength-3": "Forte",
+    "strength-4": "Molto forte",
+    "entropy-bits": "Entropia: {bits} bit",
+    "log10-guesses": "Tentativi (log10): {value}",
+    "length": "Lunghezza",
+    "unique": "Caratteri unici",
+    "character-sets": "Set di caratteri",
+    "crack-offline": "Tempo di crack (offline, 1e10/s)",
+    "crack-online": "Tempo di crack (online, 100/s)",
+    "duration-format": "Circa {value} {unit}",
+    "duration-under-second": "Meno di 1 secondo",
+    "unit": {
+      "seconds": "secondi",
+      "minutes": "minuti",
+      "hours": "ore",
+      "days": "giorni",
+      "months": "mesi",
+      "years": "anni"
+    },
+    "warning": {
+      "common": "Questa è una password molto comune.",
+      "short": "La password è troppo corta.",
+      "sequence": "Le sequenze sono facili da indovinare.",
+      "repeat": "I pattern ripetuti riducono la forza.",
+      "singleClass": "Usare un solo tipo di carattere riduce la forza."
+    },
+    "suggestion": {
+      "use-longer": "Usa una password o una passphrase più lunga.",
+      "add-uppercase": "Aggiungi lettere maiuscole.",
+      "add-lowercase": "Aggiungi lettere minuscole.",
+      "add-numbers": "Aggiungi numeri.",
+      "add-symbols": "Aggiungi simboli.",
+      "avoid-common": "Evita password comuni o compromesse.",
+      "avoid-sequences": "Evita sequenze come 123 o abc.",
+      "avoid-repetition": "Evita pattern ripetuti."
+    }
+  },
+  "ja": {
+    "input-title": "パスワード",
+    "password-label": "パスワード",
+    "password-placeholder": "評価するパスワードを入力",
+    "show": "表示",
+    "hide": "非表示",
+    "privacy-hint": "強度チェックはブラウザ内でローカルに実行されます。",
+    "results-title": "強度サマリー",
+    "empty": "パスワードを入力して強度を確認してください。",
+    "strength-0": "非常に弱い",
+    "strength-1": "弱い",
+    "strength-2": "普通",
+    "strength-3": "強い",
+    "strength-4": "非常に強い",
+    "entropy-bits": "エントロピー: {bits} ビット",
+    "log10-guesses": "推測回数（log10）: {value}",
+    "length": "長さ",
+    "unique": "ユニーク文字数",
+    "character-sets": "文字種",
+    "crack-offline": "解析時間（オフライン 1e10/秒）",
+    "crack-online": "解析時間（オンライン 100/秒）",
+    "duration-format": "約 {value} {unit}",
+    "duration-under-second": "1 秒未満",
+    "unit": {
+      "seconds": "秒",
+      "minutes": "分",
+      "hours": "時間",
+      "days": "日",
+      "months": "か月",
+      "years": "年"
+    },
+    "warning": {
+      "common": "非常に一般的なパスワードです。",
+      "short": "パスワードが短すぎます。",
+      "sequence": "連続パターンは推測されやすいです。",
+      "repeat": "繰り返しパターンは強度を下げます。",
+      "singleClass": "1種類の文字だけだと強度が下がります。"
+    },
+    "suggestion": {
+      "use-longer": "より長いパスワードやパスフレーズを使用してください。",
+      "add-uppercase": "大文字を追加してください。",
+      "add-lowercase": "小文字を追加してください。",
+      "add-numbers": "数字を追加してください。",
+      "add-symbols": "記号を追加してください。",
+      "avoid-common": "一般的または流出したパスワードを避けてください。",
+      "avoid-sequences": "123 や abc のような連続を避けてください。",
+      "avoid-repetition": "繰り返しパターンを避けてください。"
+    }
+  },
+  "ko": {
+    "input-title": "비밀번호",
+    "password-label": "비밀번호",
+    "password-placeholder": "평가할 비밀번호를 입력하세요",
+    "show": "표시",
+    "hide": "숨기기",
+    "privacy-hint": "강도 검사는 브라우저에서 로컬로 실행됩니다.",
+    "results-title": "강도 요약",
+    "empty": "비밀번호를 입력해 강도를 확인하세요.",
+    "strength-0": "매우 약함",
+    "strength-1": "약함",
+    "strength-2": "보통",
+    "strength-3": "강함",
+    "strength-4": "매우 강함",
+    "entropy-bits": "엔트로피: {bits}비트",
+    "log10-guesses": "추측 횟수(log10): {value}",
+    "length": "길이",
+    "unique": "고유 문자 수",
+    "character-sets": "문자 집합",
+    "crack-offline": "해독 시간(오프라인 1e10/초)",
+    "crack-online": "해독 시간(온라인 100/초)",
+    "duration-format": "약 {value} {unit}",
+    "duration-under-second": "1초 미만",
+    "unit": {
+      "seconds": "초",
+      "minutes": "분",
+      "hours": "시간",
+      "days": "일",
+      "months": "개월",
+      "years": "년"
+    },
+    "warning": {
+      "common": "매우 흔한 비밀번호입니다.",
+      "short": "비밀번호가 너무 짧습니다.",
+      "sequence": "연속 패턴은 쉽게 추측됩니다.",
+      "repeat": "반복 패턴은 강도를 낮춥니다.",
+      "singleClass": "한 가지 문자 유형만 사용하면 강도가 낮아집니다."
+    },
+    "suggestion": {
+      "use-longer": "더 긴 비밀번호 또는 구문을 사용하세요.",
+      "add-uppercase": "대문자를 추가하세요.",
+      "add-lowercase": "소문자를 추가하세요.",
+      "add-numbers": "숫자를 추가하세요.",
+      "add-symbols": "기호를 추가하세요.",
+      "avoid-common": "흔하거나 유출된 비밀번호를 피하세요.",
+      "avoid-sequences": "123 또는 abc 같은 연속을 피하세요.",
+      "avoid-repetition": "반복 패턴을 피하세요."
+    }
+  },
+  "ru": {
+    "input-title": "Пароль",
+    "password-label": "Пароль",
+    "password-placeholder": "Введите пароль для оценки",
+    "show": "Показать",
+    "hide": "Скрыть",
+    "privacy-hint": "Проверка выполняется локально в браузере.",
+    "results-title": "Сводка прочности",
+    "empty": "Введите пароль, чтобы проверить его прочность.",
+    "strength-0": "Очень слабый",
+    "strength-1": "Слабый",
+    "strength-2": "Средний",
+    "strength-3": "Сильный",
+    "strength-4": "Очень сильный",
+    "entropy-bits": "Энтропия: {bits} бит",
+    "log10-guesses": "Попытки (log10): {value}",
+    "length": "Длина",
+    "unique": "Уникальные символы",
+    "character-sets": "Наборы символов",
+    "crack-offline": "Время взлома (оффлайн, 1e10/с)",
+    "crack-online": "Время взлома (онлайн, 100/с)",
+    "duration-format": "Около {value} {unit}",
+    "duration-under-second": "Меньше 1 секунды",
+    "unit": {
+      "seconds": "секунд",
+      "minutes": "минут",
+      "hours": "часов",
+      "days": "дней",
+      "months": "месяцев",
+      "years": "лет"
+    },
+    "warning": {
+      "common": "Это очень распространенный пароль.",
+      "short": "Пароль слишком короткий.",
+      "sequence": "Последовательности легко угадываются.",
+      "repeat": "Повторяющиеся шаблоны снижают прочность.",
+      "singleClass": "Использование только одного типа символов снижает прочность."
+    },
+    "suggestion": {
+      "use-longer": "Используйте более длинный пароль или фразу.",
+      "add-uppercase": "Добавьте заглавные буквы.",
+      "add-lowercase": "Добавьте строчные буквы.",
+      "add-numbers": "Добавьте цифры.",
+      "add-symbols": "Добавьте символы.",
+      "avoid-common": "Избегайте распространенных и утекших паролей.",
+      "avoid-sequences": "Избегайте последовательностей вроде 123 или abc.",
+      "avoid-repetition": "Избегайте повторяющихся шаблонов."
+    }
+  },
+  "pt": {
+    "input-title": "Senha",
+    "password-label": "Senha",
+    "password-placeholder": "Digite uma senha para avaliar",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "privacy-hint": "As verificações são feitas localmente no navegador.",
+    "results-title": "Resumo de força",
+    "empty": "Digite uma senha para verificar a força.",
+    "strength-0": "Muito fraca",
+    "strength-1": "Fraca",
+    "strength-2": "Regular",
+    "strength-3": "Forte",
+    "strength-4": "Muito forte",
+    "entropy-bits": "Entropia: {bits} bits",
+    "log10-guesses": "Tentativas (log10): {value}",
+    "length": "Comprimento",
+    "unique": "Caracteres únicos",
+    "character-sets": "Conjuntos de caracteres",
+    "crack-offline": "Tempo de quebra (offline, 1e10/s)",
+    "crack-online": "Tempo de quebra (online, 100/s)",
+    "duration-format": "Cerca de {value} {unit}",
+    "duration-under-second": "Menos de 1 segundo",
+    "unit": {
+      "seconds": "segundos",
+      "minutes": "minutos",
+      "hours": "horas",
+      "days": "dias",
+      "months": "meses",
+      "years": "anos"
+    },
+    "warning": {
+      "common": "Esta é uma senha muito comum.",
+      "short": "A senha é muito curta.",
+      "sequence": "Sequências são fáceis de adivinhar.",
+      "repeat": "Padrões repetidos reduzem a força.",
+      "singleClass": "Usar apenas um tipo de caractere reduz a força."
+    },
+    "suggestion": {
+      "use-longer": "Use uma senha ou frase mais longa.",
+      "add-uppercase": "Adicione letras maiúsculas.",
+      "add-lowercase": "Adicione letras minúsculas.",
+      "add-numbers": "Adicione números.",
+      "add-symbols": "Adicione símbolos.",
+      "avoid-common": "Evite senhas comuns e vazadas.",
+      "avoid-sequences": "Evite sequências como 123 ou abc.",
+      "avoid-repetition": "Evite padrões repetidos."
+    }
+  },
+  "ar": {
+    "input-title": "كلمة المرور",
+    "password-label": "كلمة المرور",
+    "password-placeholder": "أدخل كلمة مرور لتقييمها",
+    "show": "إظهار",
+    "hide": "إخفاء",
+    "privacy-hint": "الفحص يتم محليًا في المتصفح.",
+    "results-title": "ملخص القوة",
+    "empty": "أدخل كلمة مرور لفحص القوة.",
+    "strength-0": "ضعيفة جدًا",
+    "strength-1": "ضعيفة",
+    "strength-2": "متوسطة",
+    "strength-3": "قوية",
+    "strength-4": "قوية جدًا",
+    "entropy-bits": "الإنتروبيا: {bits} بت",
+    "log10-guesses": "محاولات (log10): {value}",
+    "length": "الطول",
+    "unique": "حروف فريدة",
+    "character-sets": "مجموعات الأحرف",
+    "crack-offline": "زمن الكسر (غير متصل 1e10/ث)",
+    "crack-online": "زمن الكسر (متصل 100/ث)",
+    "duration-format": "حوالي {value} {unit}",
+    "duration-under-second": "أقل من ثانية واحدة",
+    "unit": {
+      "seconds": "ثوانٍ",
+      "minutes": "دقائق",
+      "hours": "ساعات",
+      "days": "أيام",
+      "months": "أشهر",
+      "years": "سنوات"
+    },
+    "warning": {
+      "common": "هذه كلمة مرور شائعة جدًا.",
+      "short": "كلمة المرور قصيرة جدًا.",
+      "sequence": "التسلسلات سهلة التخمين.",
+      "repeat": "الأنماط المتكررة تقلل القوة.",
+      "singleClass": "استخدام نوع واحد من الأحرف يقلل القوة."
+    },
+    "suggestion": {
+      "use-longer": "استخدم كلمة مرور أو عبارة أطول.",
+      "add-uppercase": "أضف أحرفًا كبيرة.",
+      "add-lowercase": "أضف أحرفًا صغيرة.",
+      "add-numbers": "أضف أرقامًا.",
+      "add-symbols": "أضف رموزًا.",
+      "avoid-common": "تجنب كلمات المرور الشائعة أو المسرّبة.",
+      "avoid-sequences": "تجنب تسلسلات مثل 123 أو abc.",
+      "avoid-repetition": "تجنب الأنماط المتكررة."
+    }
+  },
+  "hi": {
+    "input-title": "पासवर्ड",
+    "password-label": "पासवर्ड",
+    "password-placeholder": "मूल्यांकन के लिए पासवर्ड दर्ज करें",
+    "show": "दिखाएँ",
+    "hide": "छिपाएँ",
+    "privacy-hint": "जांच आपके ब्राउज़र में स्थानीय रूप से होती है।",
+    "results-title": "मजबूती सारांश",
+    "empty": "मजबूती जाँचने के लिए पासवर्ड दर्ज करें।",
+    "strength-0": "बहुत कमजोर",
+    "strength-1": "कमजोर",
+    "strength-2": "ठीक-ठाक",
+    "strength-3": "मजबूत",
+    "strength-4": "बहुत मजबूत",
+    "entropy-bits": "एंट्रॉपी: {bits} बिट",
+    "log10-guesses": "अनुमान (log10): {value}",
+    "length": "लंबाई",
+    "unique": "अद्वितीय अक्षर",
+    "character-sets": "करेक्टर सेट",
+    "crack-offline": "क्रैक समय (ऑफलाइन 1e10/से)",
+    "crack-online": "क्रैक समय (ऑनलाइन 100/से)",
+    "duration-format": "लगभग {value} {unit}",
+    "duration-under-second": "1 सेकंड से कम",
+    "unit": {
+      "seconds": "सेकंड",
+      "minutes": "मिनट",
+      "hours": "घंटे",
+      "days": "दिन",
+      "months": "महीने",
+      "years": "वर्ष"
+    },
+    "warning": {
+      "common": "यह बहुत आम पासवर्ड है।",
+      "short": "पासवर्ड बहुत छोटा है।",
+      "sequence": "क्रम आसान होते हैं।",
+      "repeat": "दोहराव पैटर्न मजबूती घटाते हैं।",
+      "singleClass": "केवल एक प्रकार के अक्षर इस्तेमाल करने से मजबूती घटती है।"
+    },
+    "suggestion": {
+      "use-longer": "लंबा पासवर्ड या पासफ्रेज़ इस्तेमाल करें।",
+      "add-uppercase": "बड़े अक्षर जोड़ें।",
+      "add-lowercase": "छोटे अक्षर जोड़ें।",
+      "add-numbers": "संख्याएँ जोड़ें।",
+      "add-symbols": "चिह्न जोड़ें।",
+      "avoid-common": "आम या लीक हुए पासवर्ड से बचें।",
+      "avoid-sequences": "123 या abc जैसे क्रम से बचें।",
+      "avoid-repetition": "दोहराव पैटर्न से बचें।"
+    }
+  },
+  "tr": {
+    "input-title": "Parola",
+    "password-label": "Parola",
+    "password-placeholder": "Değerlendirmek için parola girin",
+    "show": "Göster",
+    "hide": "Gizle",
+    "privacy-hint": "Kontroller tarayıcınızda yerel olarak yapılır.",
+    "results-title": "Güç özeti",
+    "empty": "Gücü kontrol etmek için bir parola girin.",
+    "strength-0": "Çok zayıf",
+    "strength-1": "Zayıf",
+    "strength-2": "Orta",
+    "strength-3": "Güçlü",
+    "strength-4": "Çok güçlü",
+    "entropy-bits": "Entropi: {bits} bit",
+    "log10-guesses": "Tahmin (log10): {value}",
+    "length": "Uzunluk",
+    "unique": "Benzersiz karakterler",
+    "character-sets": "Karakter kümeleri",
+    "crack-offline": "Kırma süresi (offline, 1e10/sn)",
+    "crack-online": "Kırma süresi (online, 100/sn)",
+    "duration-format": "Yaklaşık {value} {unit}",
+    "duration-under-second": "1 saniyeden kısa",
+    "unit": {
+      "seconds": "saniye",
+      "minutes": "dakika",
+      "hours": "saat",
+      "days": "gün",
+      "months": "ay",
+      "years": "yıl"
+    },
+    "warning": {
+      "common": "Bu çok yaygın bir paroladır.",
+      "short": "Parola çok kısa.",
+      "sequence": "Ardışık diziler kolayca tahmin edilir.",
+      "repeat": "Tekrarlayan desenler gücü düşürür.",
+      "singleClass": "Tek bir karakter türü kullanmak gücü düşürür."
+    },
+    "suggestion": {
+      "use-longer": "Daha uzun bir parola veya ifade kullanın.",
+      "add-uppercase": "Büyük harf ekleyin.",
+      "add-lowercase": "Küçük harf ekleyin.",
+      "add-numbers": "Rakam ekleyin.",
+      "add-symbols": "Sembol ekleyin.",
+      "avoid-common": "Yaygın ve sızmış parolalardan kaçının.",
+      "avoid-sequences": "123 veya abc gibi dizilerden kaçının.",
+      "avoid-repetition": "Tekrarlayan desenlerden kaçının."
+    }
+  },
+  "nl": {
+    "input-title": "Wachtwoord",
+    "password-label": "Wachtwoord",
+    "password-placeholder": "Typ een wachtwoord om te beoordelen",
+    "show": "Tonen",
+    "hide": "Verbergen",
+    "privacy-hint": "De controle gebeurt lokaal in je browser.",
+    "results-title": "Sterkteoverzicht",
+    "empty": "Voer een wachtwoord in om de sterkte te controleren.",
+    "strength-0": "Zeer zwak",
+    "strength-1": "Zwak",
+    "strength-2": "Redelijk",
+    "strength-3": "Sterk",
+    "strength-4": "Zeer sterk",
+    "entropy-bits": "Entropie: {bits} bits",
+    "log10-guesses": "Gissingen (log10): {value}",
+    "length": "Lengte",
+    "unique": "Unieke tekens",
+    "character-sets": "Tekensets",
+    "crack-offline": "Kraaktijd (offline, 1e10/s)",
+    "crack-online": "Kraaktijd (online, 100/s)",
+    "duration-format": "Ongeveer {value} {unit}",
+    "duration-under-second": "Minder dan 1 seconde",
+    "unit": {
+      "seconds": "seconden",
+      "minutes": "minuten",
+      "hours": "uur",
+      "days": "dagen",
+      "months": "maanden",
+      "years": "jaar"
+    },
+    "warning": {
+      "common": "Dit is een zeer veelvoorkomend wachtwoord.",
+      "short": "Het wachtwoord is te kort.",
+      "sequence": "Reeksen zijn makkelijk te raden.",
+      "repeat": "Herhaalde patronen verlagen de sterkte.",
+      "singleClass": "Slechts één tekentype gebruiken verlaagt de sterkte."
+    },
+    "suggestion": {
+      "use-longer": "Gebruik een langer wachtwoord of wachtzin.",
+      "add-uppercase": "Voeg hoofdletters toe.",
+      "add-lowercase": "Voeg kleine letters toe.",
+      "add-numbers": "Voeg cijfers toe.",
+      "add-symbols": "Voeg symbolen toe.",
+      "avoid-common": "Vermijd veelvoorkomende of gelekte wachtwoorden.",
+      "avoid-sequences": "Vermijd reeksen zoals 123 of abc.",
+      "avoid-repetition": "Vermijd herhaalde patronen."
+    }
+  },
+  "sv": {
+    "input-title": "Lösenord",
+    "password-label": "Lösenord",
+    "password-placeholder": "Skriv ett lösenord att bedöma",
+    "show": "Visa",
+    "hide": "Dölj",
+    "privacy-hint": "Kontrollen sker lokalt i webbläsaren.",
+    "results-title": "Styrkesammanfattning",
+    "empty": "Ange ett lösenord för att kontrollera styrkan.",
+    "strength-0": "Mycket svagt",
+    "strength-1": "Svagt",
+    "strength-2": "Okej",
+    "strength-3": "Starkt",
+    "strength-4": "Mycket starkt",
+    "entropy-bits": "Entropi: {bits} bit",
+    "log10-guesses": "Gissningar (log10): {value}",
+    "length": "Längd",
+    "unique": "Unika tecken",
+    "character-sets": "Teckenuppsättningar",
+    "crack-offline": "Knäckningstid (offline, 1e10/s)",
+    "crack-online": "Knäckningstid (online, 100/s)",
+    "duration-format": "Cirka {value} {unit}",
+    "duration-under-second": "Mindre än 1 sekund",
+    "unit": {
+      "seconds": "sekunder",
+      "minutes": "minuter",
+      "hours": "timmar",
+      "days": "dagar",
+      "months": "månader",
+      "years": "år"
+    },
+    "warning": {
+      "common": "Det här är ett mycket vanligt lösenord.",
+      "short": "Lösenordet är för kort.",
+      "sequence": "Sekvenser är lätta att gissa.",
+      "repeat": "Upprepade mönster minskar styrkan.",
+      "singleClass": "Att bara använda en teckentyp minskar styrkan."
+    },
+    "suggestion": {
+      "use-longer": "Använd ett längre lösenord eller lösenfras.",
+      "add-uppercase": "Lägg till versaler.",
+      "add-lowercase": "Lägg till gemener.",
+      "add-numbers": "Lägg till siffror.",
+      "add-symbols": "Lägg till symboler.",
+      "avoid-common": "Undvik vanliga eller läckta lösenord.",
+      "avoid-sequences": "Undvik sekvenser som 123 eller abc.",
+      "avoid-repetition": "Undvik upprepade mönster."
+    }
+  },
+  "pl": {
+    "input-title": "Hasło",
+    "password-label": "Hasło",
+    "password-placeholder": "Wpisz hasło do oceny",
+    "show": "Pokaż",
+    "hide": "Ukryj",
+    "privacy-hint": "Sprawdzanie odbywa się lokalnie w przeglądarce.",
+    "results-title": "Podsumowanie siły",
+    "empty": "Wpisz hasło, aby sprawdzić siłę.",
+    "strength-0": "Bardzo słabe",
+    "strength-1": "Słabe",
+    "strength-2": "Przeciętne",
+    "strength-3": "Silne",
+    "strength-4": "Bardzo silne",
+    "entropy-bits": "Entropia: {bits} bitów",
+    "log10-guesses": "Próby (log10): {value}",
+    "length": "Długość",
+    "unique": "Unikalne znaki",
+    "character-sets": "Zestawy znaków",
+    "crack-offline": "Czas złamania (offline, 1e10/s)",
+    "crack-online": "Czas złamania (online, 100/s)",
+    "duration-format": "Około {value} {unit}",
+    "duration-under-second": "Mniej niż 1 sekunda",
+    "unit": {
+      "seconds": "sekund",
+      "minutes": "minut",
+      "hours": "godzin",
+      "days": "dni",
+      "months": "miesięcy",
+      "years": "lat"
+    },
+    "warning": {
+      "common": "To bardzo popularne hasło.",
+      "short": "Hasło jest zbyt krótkie.",
+      "sequence": "Sekwencje są łatwe do odgadnięcia.",
+      "repeat": "Powtarzające się wzorce obniżają siłę.",
+      "singleClass": "Użycie tylko jednego typu znaków obniża siłę."
+    },
+    "suggestion": {
+      "use-longer": "Użyj dłuższego hasła lub frazy.",
+      "add-uppercase": "Dodaj wielkie litery.",
+      "add-lowercase": "Dodaj małe litery.",
+      "add-numbers": "Dodaj cyfry.",
+      "add-symbols": "Dodaj symbole.",
+      "avoid-common": "Unikaj popularnych lub wyciekłych haseł.",
+      "avoid-sequences": "Unikaj sekwencji jak 123 lub abc.",
+      "avoid-repetition": "Unikaj powtarzających się wzorców."
+    }
+  },
+  "vi": {
+    "input-title": "Mật khẩu",
+    "password-label": "Mật khẩu",
+    "password-placeholder": "Nhập mật khẩu để đánh giá",
+    "show": "Hiện",
+    "hide": "Ẩn",
+    "privacy-hint": "Việc kiểm tra được thực hiện cục bộ trong trình duyệt.",
+    "results-title": "Tóm tắt độ mạnh",
+    "empty": "Nhập mật khẩu để kiểm tra độ mạnh.",
+    "strength-0": "Rất yếu",
+    "strength-1": "Yếu",
+    "strength-2": "Trung bình",
+    "strength-3": "Mạnh",
+    "strength-4": "Rất mạnh",
+    "entropy-bits": "Entropy: {bits} bit",
+    "log10-guesses": "Số lần đoán (log10): {value}",
+    "length": "Độ dài",
+    "unique": "Ký tự duy nhất",
+    "character-sets": "Tập ký tự",
+    "crack-offline": "Thời gian bẻ (offline, 1e10/s)",
+    "crack-online": "Thời gian bẻ (online, 100/s)",
+    "duration-format": "Khoảng {value} {unit}",
+    "duration-under-second": "Nhỏ hơn 1 giây",
+    "unit": {
+      "seconds": "giây",
+      "minutes": "phút",
+      "hours": "giờ",
+      "days": "ngày",
+      "months": "tháng",
+      "years": "năm"
+    },
+    "warning": {
+      "common": "Đây là mật khẩu rất phổ biến.",
+      "short": "Mật khẩu quá ngắn.",
+      "sequence": "Chuỗi liên tiếp dễ đoán.",
+      "repeat": "Mẫu lặp lại làm giảm độ mạnh.",
+      "singleClass": "Chỉ dùng một loại ký tự làm giảm độ mạnh."
+    },
+    "suggestion": {
+      "use-longer": "Dùng mật khẩu hoặc cụm từ dài hơn.",
+      "add-uppercase": "Thêm chữ in hoa.",
+      "add-lowercase": "Thêm chữ thường.",
+      "add-numbers": "Thêm số.",
+      "add-symbols": "Thêm ký hiệu.",
+      "avoid-common": "Tránh mật khẩu phổ biến hoặc đã lộ.",
+      "avoid-sequences": "Tránh chuỗi như 123 hoặc abc.",
+      "avoid-repetition": "Tránh mẫu lặp lại."
+    }
+  },
+  "th": {
+    "input-title": "รหัสผ่าน",
+    "password-label": "รหัสผ่าน",
+    "password-placeholder": "พิมพ์รหัสผ่านเพื่อประเมิน",
+    "show": "แสดง",
+    "hide": "ซ่อน",
+    "privacy-hint": "การตรวจสอบทำงานในเบราว์เซอร์ของคุณแบบออฟไลน์",
+    "results-title": "สรุปความแข็งแรง",
+    "empty": "กรอกรหัสผ่านเพื่อประเมินความแข็งแรง",
+    "strength-0": "อ่อนมาก",
+    "strength-1": "อ่อน",
+    "strength-2": "ปานกลาง",
+    "strength-3": "แข็งแรง",
+    "strength-4": "แข็งแรงมาก",
+    "entropy-bits": "เอนโทรปี: {bits} บิต",
+    "log10-guesses": "จำนวนเดา (log10): {value}",
+    "length": "ความยาว",
+    "unique": "อักขระไม่ซ้ำ",
+    "character-sets": "ชุดอักขระ",
+    "crack-offline": "เวลาแคร็ก (ออฟไลน์ 1e10/วินาที)",
+    "crack-online": "เวลาแคร็ก (ออนไลน์ 100/วินาที)",
+    "duration-format": "ประมาณ {value} {unit}",
+    "duration-under-second": "น้อยกว่า 1 วินาที",
+    "unit": {
+      "seconds": "วินาที",
+      "minutes": "นาที",
+      "hours": "ชั่วโมง",
+      "days": "วัน",
+      "months": "เดือน",
+      "years": "ปี"
+    },
+    "warning": {
+      "common": "นี่เป็นรหัสผ่านที่พบบ่อยมาก",
+      "short": "รหัสผ่านสั้นเกินไป",
+      "sequence": "ลำดับต่อเนื่องเดาง่าย",
+      "repeat": "รูปแบบซ้ำทำให้ความแข็งแรงลดลง",
+      "singleClass": "ใช้ประเภทอักขระเพียงแบบเดียวทำให้ความแข็งแรงลดลง"
+    },
+    "suggestion": {
+      "use-longer": "ใช้รหัสผ่านหรือวลีที่ยาวขึ้น",
+      "add-uppercase": "เพิ่มตัวอักษรพิมพ์ใหญ่",
+      "add-lowercase": "เพิ่มตัวอักษรพิมพ์เล็ก",
+      "add-numbers": "เพิ่มตัวเลข",
+      "add-symbols": "เพิ่มสัญลักษณ์",
+      "avoid-common": "หลีกเลี่ยงรหัสผ่านยอดนิยมและที่รั่วไหล",
+      "avoid-sequences": "หลีกเลี่ยงลำดับอย่าง 123 หรือ abc",
+      "avoid-repetition": "หลีกเลี่ยงรูปแบบซ้ำ"
+    }
+  },
+  "id": {
+    "input-title": "Kata sandi",
+    "password-label": "Kata sandi",
+    "password-placeholder": "Masukkan kata sandi untuk menilai",
+    "show": "Tampilkan",
+    "hide": "Sembunyikan",
+    "privacy-hint": "Pemeriksaan berjalan lokal di browser Anda.",
+    "results-title": "Ringkasan kekuatan",
+    "empty": "Masukkan kata sandi untuk mengecek kekuatannya.",
+    "strength-0": "Sangat lemah",
+    "strength-1": "Lemah",
+    "strength-2": "Cukup",
+    "strength-3": "Kuat",
+    "strength-4": "Sangat kuat",
+    "entropy-bits": "Entropi: {bits} bit",
+    "log10-guesses": "Perkiraan (log10): {value}",
+    "length": "Panjang",
+    "unique": "Karakter unik",
+    "character-sets": "Set karakter",
+    "crack-offline": "Waktu pecah (offline, 1e10/detik)",
+    "crack-online": "Waktu pecah (online, 100/detik)",
+    "duration-format": "Sekitar {value} {unit}",
+    "duration-under-second": "Kurang dari 1 detik",
+    "unit": {
+      "seconds": "detik",
+      "minutes": "menit",
+      "hours": "jam",
+      "days": "hari",
+      "months": "bulan",
+      "years": "tahun"
+    },
+    "warning": {
+      "common": "Ini adalah kata sandi yang sangat umum.",
+      "short": "Kata sandi terlalu pendek.",
+      "sequence": "Urutan mudah ditebak.",
+      "repeat": "Pola berulang mengurangi kekuatan.",
+      "singleClass": "Hanya satu jenis karakter menurunkan kekuatan."
+    },
+    "suggestion": {
+      "use-longer": "Gunakan kata sandi atau frasa yang lebih panjang.",
+      "add-uppercase": "Tambahkan huruf kapital.",
+      "add-lowercase": "Tambahkan huruf kecil.",
+      "add-numbers": "Tambahkan angka.",
+      "add-symbols": "Tambahkan simbol.",
+      "avoid-common": "Hindari kata sandi umum atau yang bocor.",
+      "avoid-sequences": "Hindari urutan seperti 123 atau abc.",
+      "avoid-repetition": "Hindari pola berulang."
+    }
+  },
+  "he": {
+    "input-title": "סיסמה",
+    "password-label": "סיסמה",
+    "password-placeholder": "הקלד סיסמה להערכה",
+    "show": "הצג",
+    "hide": "הסתר",
+    "privacy-hint": "הבדיקה מתבצעת מקומית בדפדפן שלך.",
+    "results-title": "סיכום חוזק",
+    "empty": "הזן סיסמה כדי לבדוק את החוזק.",
+    "strength-0": "חלשה מאוד",
+    "strength-1": "חלשה",
+    "strength-2": "בינונית",
+    "strength-3": "חזקה",
+    "strength-4": "חזקה מאוד",
+    "entropy-bits": "אנטרופיה: {bits} ביט",
+    "log10-guesses": "ניסיונות (log10): {value}",
+    "length": "אורך",
+    "unique": "תווים ייחודיים",
+    "character-sets": "קבוצות תווים",
+    "crack-offline": "זמן פיצוח (אופליין, 1e10/שניה)",
+    "crack-online": "זמן פיצוח (אונליין, 100/שניה)",
+    "duration-format": "בערך {value} {unit}",
+    "duration-under-second": "פחות משנייה אחת",
+    "unit": {
+      "seconds": "שניות",
+      "minutes": "דקות",
+      "hours": "שעות",
+      "days": "ימים",
+      "months": "חודשים",
+      "years": "שנים"
+    },
+    "warning": {
+      "common": "זו סיסמה נפוצה מאוד.",
+      "short": "הסיסמה קצרה מדי.",
+      "sequence": "רצפים קלים לניחוש.",
+      "repeat": "דפוסים חוזרים מפחיתים את החוזק.",
+      "singleClass": "שימוש בסוג תווים אחד מפחית את החוזק."
+    },
+    "suggestion": {
+      "use-longer": "השתמש בסיסמה או ביטוי ארוכים יותר.",
+      "add-uppercase": "הוסף אותיות גדולות.",
+      "add-lowercase": "הוסף אותיות קטנות.",
+      "add-numbers": "הוסף מספרים.",
+      "add-symbols": "הוסף סמלים.",
+      "avoid-common": "הימנע מסיסמאות נפוצות או דלופות.",
+      "avoid-sequences": "הימנע מרצפים כמו 123 או abc.",
+      "avoid-repetition": "הימנע מדפוסים חוזרים."
+    }
+  },
+  "ms": {
+    "input-title": "Kata laluan",
+    "password-label": "Kata laluan",
+    "password-placeholder": "Masukkan kata laluan untuk dinilai",
+    "show": "Tunjuk",
+    "hide": "Sembunyi",
+    "privacy-hint": "Pemeriksaan dijalankan secara tempatan dalam pelayar.",
+    "results-title": "Ringkasan kekuatan",
+    "empty": "Masukkan kata laluan untuk semak kekuatan.",
+    "strength-0": "Sangat lemah",
+    "strength-1": "Lemah",
+    "strength-2": "Sederhana",
+    "strength-3": "Kuat",
+    "strength-4": "Sangat kuat",
+    "entropy-bits": "Entropi: {bits} bit",
+    "log10-guesses": "Tebakan (log10): {value}",
+    "length": "Panjang",
+    "unique": "Aksara unik",
+    "character-sets": "Set aksara",
+    "crack-offline": "Masa pecah (offline, 1e10/s)",
+    "crack-online": "Masa pecah (online, 100/s)",
+    "duration-format": "Kira-kira {value} {unit}",
+    "duration-under-second": "Kurang daripada 1 saat",
+    "unit": {
+      "seconds": "saat",
+      "minutes": "minit",
+      "hours": "jam",
+      "days": "hari",
+      "months": "bulan",
+      "years": "tahun"
+    },
+    "warning": {
+      "common": "Ini kata laluan yang sangat biasa.",
+      "short": "Kata laluan terlalu pendek.",
+      "sequence": "Jujukan mudah diteka.",
+      "repeat": "Corak berulang mengurangkan kekuatan.",
+      "singleClass": "Hanya satu jenis aksara menurunkan kekuatan."
+    },
+    "suggestion": {
+      "use-longer": "Gunakan kata laluan atau frasa yang lebih panjang.",
+      "add-uppercase": "Tambah huruf besar.",
+      "add-lowercase": "Tambah huruf kecil.",
+      "add-numbers": "Tambah nombor.",
+      "add-symbols": "Tambah simbol.",
+      "avoid-common": "Elakkan kata laluan biasa atau yang bocor.",
+      "avoid-sequences": "Elakkan jujukan seperti 123 atau abc.",
+      "avoid-repetition": "Elakkan corak berulang."
+    }
+  },
+  "no": {
+    "input-title": "Passord",
+    "password-label": "Passord",
+    "password-placeholder": "Skriv inn et passord for vurdering",
+    "show": "Vis",
+    "hide": "Skjul",
+    "privacy-hint": "Sjekken kjøres lokalt i nettleseren.",
+    "results-title": "Styrkesammendrag",
+    "empty": "Skriv inn et passord for å sjekke styrken.",
+    "strength-0": "Svært svakt",
+    "strength-1": "Svakt",
+    "strength-2": "Greit",
+    "strength-3": "Sterkt",
+    "strength-4": "Svært sterkt",
+    "entropy-bits": "Entropi: {bits} bit",
+    "log10-guesses": "Gjetninger (log10): {value}",
+    "length": "Lengde",
+    "unique": "Unike tegn",
+    "character-sets": "Tegnsett",
+    "crack-offline": "Knekktid (offline, 1e10/s)",
+    "crack-online": "Knekktid (online, 100/s)",
+    "duration-format": "Omtrent {value} {unit}",
+    "duration-under-second": "Mindre enn 1 sekund",
+    "unit": {
+      "seconds": "sekunder",
+      "minutes": "minutter",
+      "hours": "timer",
+      "days": "dager",
+      "months": "måneder",
+      "years": "år"
+    },
+    "warning": {
+      "common": "Dette er et svært vanlig passord.",
+      "short": "Passordet er for kort.",
+      "sequence": "Sekvenser er lette å gjette.",
+      "repeat": "Gjentatte mønstre reduserer styrken.",
+      "singleClass": "Kun én tegnkategori reduserer styrken."
+    },
+    "suggestion": {
+      "use-longer": "Bruk et lengre passord eller en passfrase.",
+      "add-uppercase": "Legg til store bokstaver.",
+      "add-lowercase": "Legg til små bokstaver.",
+      "add-numbers": "Legg til tall.",
+      "add-symbols": "Legg til symboler.",
+      "avoid-common": "Unngå vanlige eller lekkede passord.",
+      "avoid-sequences": "Unngå sekvenser som 123 eller abc.",
+      "avoid-repetition": "Unngå gjentatte mønstre."
+    }
+  }
+}
+</i18n>

--- a/tools/validator/password-strength-checker/src/components/WhatIsPasswordStrength.dom.test.ts
+++ b/tools/validator/password-strength-checker/src/components/WhatIsPasswordStrength.dom.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import WhatIsPasswordStrength from './WhatIsPasswordStrength.vue'
+
+describe('WhatIsPasswordStrength', () => {
+  it('renders explanation content', () => {
+    const wrapper = mount(WhatIsPasswordStrength)
+    const text = wrapper.text()
+
+    expect(text).toContain('What is Password Strength')
+    expect(text).toContain('Longer passphrases')
+    expect(text).toContain('password manager')
+  })
+})

--- a/tools/validator/password-strength-checker/src/components/WhatIsPasswordStrength.vue
+++ b/tools/validator/password-strength-checker/src/components/WhatIsPasswordStrength.vue
@@ -1,0 +1,225 @@
+<template>
+  <ToolSectionHeader>{{ t('title') }}</ToolSectionHeader>
+  <ToolSection>
+    <n-text>{{ t('description') }}</n-text>
+    <n-ul style="margin-top: 12px">
+      <n-li>{{ t('point-1') }}</n-li>
+      <n-li>{{ t('point-2') }}</n-li>
+      <n-li>{{ t('point-3') }}</n-li>
+    </n-ul>
+    <n-text style="margin-top: 12px; display: block">{{ t('tip') }}</n-text>
+  </ToolSection>
+</template>
+
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n'
+import { NText, NUl, NLi } from 'naive-ui'
+import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+
+const { t } = useI18n()
+</script>
+
+<i18n lang="json">
+{
+  "en": {
+    "title": "What is Password Strength?",
+    "description": "Password strength describes how resistant a password is to guessing and cracking attacks.",
+    "point-1": "Longer passphrases increase entropy and are easier to remember.",
+    "point-2": "Mixing uppercase, lowercase, numbers, and symbols improves variety.",
+    "point-3": "Avoid reused, common, or leaked passwords.",
+    "tip": "Use a password manager to generate and store unique passwords."
+  },
+  "zh": {
+    "title": "什么是密码强度？",
+    "description": "密码强度描述密码抵抗猜测和破解攻击的能力。",
+    "point-1": "更长的口令短语熵更高，也更容易记住。",
+    "point-2": "混合大小写、数字和符号可以增加多样性。",
+    "point-3": "避免重复使用、常见或已泄露的密码。",
+    "tip": "使用密码管理器生成并保存唯一密码。"
+  },
+  "zh-CN": {
+    "title": "什么是密码强度？",
+    "description": "密码强度描述密码抵抗猜测和破解攻击的能力。",
+    "point-1": "更长的口令短语熵更高，也更容易记住。",
+    "point-2": "混合大小写、数字和符号可以增加多样性。",
+    "point-3": "避免重复使用、常见或已泄露的密码。",
+    "tip": "使用密码管理器生成并保存唯一密码。"
+  },
+  "zh-TW": {
+    "title": "什麼是密碼強度？",
+    "description": "密碼強度描述密碼抵抗猜測與破解攻擊的能力。",
+    "point-1": "更長的口令短語熵更高，也更容易記住。",
+    "point-2": "混合大小寫、數字與符號可增加多樣性。",
+    "point-3": "避免重複使用、常見或已洩露的密碼。",
+    "tip": "使用密碼管理器產生並保存唯一密碼。"
+  },
+  "zh-HK": {
+    "title": "乜嘢係密碼強度？",
+    "description": "密碼強度描述密碼抵抗猜測同破解攻擊嘅能力。",
+    "point-1": "更長嘅口令短語熵更高，亦更容易記住。",
+    "point-2": "混合大小寫、數字同符號可增加多樣性。",
+    "point-3": "避免重複使用、常見或已洩露嘅密碼。",
+    "tip": "使用密碼管理器生成並保存唯一密碼。"
+  },
+  "es": {
+    "title": "¿Qué es la fuerza de una contraseña?",
+    "description": "La fuerza de la contraseña describe qué tan resistente es ante intentos de adivinación o cracking.",
+    "point-1": "Las frases más largas aumentan la entropía y son más fáciles de recordar.",
+    "point-2": "Mezclar mayúsculas, minúsculas, números y símbolos mejora la variedad.",
+    "point-3": "Evita contraseñas reutilizadas, comunes o filtradas.",
+    "tip": "Usa un gestor de contraseñas para generar y guardar contraseñas únicas."
+  },
+  "fr": {
+    "title": "Qu'est-ce que la robustesse d'un mot de passe ?",
+    "description": "La robustesse décrit la résistance d'un mot de passe aux tentatives de devinette ou de cassage.",
+    "point-1": "Les phrases longues augmentent l'entropie et sont plus faciles à retenir.",
+    "point-2": "Mélanger majuscules, minuscules, chiffres et symboles améliore la variété.",
+    "point-3": "Évitez les mots de passe réutilisés, courants ou divulgués.",
+    "tip": "Utilisez un gestionnaire pour générer et stocker des mots de passe uniques."
+  },
+  "de": {
+    "title": "Was ist Passwortstärke?",
+    "description": "Die Passwortstärke beschreibt, wie widerstandsfähig ein Passwort gegen Raten und Knacken ist.",
+    "point-1": "Längere Passphrasen erhöhen die Entropie und sind leichter zu merken.",
+    "point-2": "Eine Mischung aus Großbuchstaben, Kleinbuchstaben, Zahlen und Symbolen erhöht die Vielfalt.",
+    "point-3": "Vermeiden Sie wiederverwendete, häufige oder geleakte Passwörter.",
+    "tip": "Nutzen Sie einen Passwortmanager, um einzigartige Passwörter zu erstellen und zu speichern."
+  },
+  "it": {
+    "title": "Che cos'è la forza di una password?",
+    "description": "La forza della password descrive quanto resiste ai tentativi di indovinare o di cracking.",
+    "point-1": "Frasi più lunghe aumentano l'entropia e sono più facili da ricordare.",
+    "point-2": "Mescolare maiuscole, minuscole, numeri e simboli aumenta la varietà.",
+    "point-3": "Evita password riutilizzate, comuni o compromesse.",
+    "tip": "Usa un password manager per generare e salvare password uniche."
+  },
+  "ja": {
+    "title": "パスワード強度とは？",
+    "description": "パスワード強度は、推測や解析攻撃にどれだけ耐えられるかを示します。",
+    "point-1": "長いパスフレーズはエントロピーが高く、覚えやすいです。",
+    "point-2": "大文字・小文字・数字・記号の混在で多様性が増えます。",
+    "point-3": "使い回しや一般的、流出したパスワードは避けましょう。",
+    "tip": "パスワードマネージャーで一意のパスワードを生成・保管しましょう。"
+  },
+  "ko": {
+    "title": "비밀번호 강도란?",
+    "description": "비밀번호 강도는 추측이나 크래킹 공격에 얼마나 잘 견디는지를 나타냅니다.",
+    "point-1": "더 긴 문구는 엔트로피를 높이고 기억하기 쉽습니다.",
+    "point-2": "대문자, 소문자, 숫자, 기호를 섞으면 다양성이 향상됩니다.",
+    "point-3": "재사용되었거나 흔한, 유출된 비밀번호는 피하세요.",
+    "tip": "비밀번호 관리자 사용으로 고유한 비밀번호를 생성하고 저장하세요."
+  },
+  "ru": {
+    "title": "Что такое стойкость пароля?",
+    "description": "Стойкость пароля показывает, насколько он устойчив к угадыванию и взлому.",
+    "point-1": "Длинные фразы повышают энтропию и проще запоминаются.",
+    "point-2": "Смешивание букв разного регистра, цифр и символов повышает разнообразие.",
+    "point-3": "Избегайте повторного использования, распространенных или утекших паролей.",
+    "tip": "Используйте менеджер паролей для создания и хранения уникальных паролей."
+  },
+  "pt": {
+    "title": "O que é força de senha?",
+    "description": "A força da senha indica o quanto ela resiste a tentativas de adivinhação ou quebra.",
+    "point-1": "Frases mais longas aumentam a entropia e são mais fáceis de lembrar.",
+    "point-2": "Misturar maiúsculas, minúsculas, números e símbolos aumenta a variedade.",
+    "point-3": "Evite senhas reutilizadas, comuns ou vazadas.",
+    "tip": "Use um gerenciador para gerar e armazenar senhas únicas."
+  },
+  "ar": {
+    "title": "ما هي قوة كلمة المرور؟",
+    "description": "قوة كلمة المرور تصف مدى مقاومتها للتخمين والكسر.",
+    "point-1": "العبارات الأطول تزيد الإنتروبيا وأسهل في التذكر.",
+    "point-2": "مزج الأحرف الكبيرة والصغيرة والأرقام والرموز يزيد التنوع.",
+    "point-3": "تجنب كلمات المرور المعاد استخدامها أو الشائعة أو المسرّبة.",
+    "tip": "استخدم مدير كلمات مرور لإنشاء كلمات مرور فريدة وحفظها."
+  },
+  "hi": {
+    "title": "पासवर्ड की मजबूती क्या है?",
+    "description": "पासवर्ड की मजबूती बताती है कि वह अनुमान और क्रैकिंग हमलों के खिलाफ कितना मजबूत है।",
+    "point-1": "लंबी पासफ्रेज़ एंट्रॉपी बढ़ाती है और याद रखना आसान बनाती है।",
+    "point-2": "बड़े अक्षर, छोटे अक्षर, संख्याएं और प्रतीक मिलाने से विविधता बढ़ती है।",
+    "point-3": "पुनः उपयोग किए गए, आम या लीक हुए पासवर्ड से बचें।",
+    "tip": "एक पासवर्ड मैनेजर से अद्वितीय पासवर्ड बनाएं और सहेजें।"
+  },
+  "tr": {
+    "title": "Parola gücü nedir?",
+    "description": "Parola gücü, tahmin ve kırma saldırılarına karşı dayanıklılığı ifade eder.",
+    "point-1": "Daha uzun parolalar entropiyi artırır ve hatırlaması daha kolaydır.",
+    "point-2": "Büyük/küçük harf, sayı ve sembol karışımı çeşitliliği artırır.",
+    "point-3": "Yeniden kullanılan, yaygın ya da sızmış parolalardan kaçının.",
+    "tip": "Benzersiz parolalar için parola yöneticisi kullanın."
+  },
+  "nl": {
+    "title": "Wat is wachtwoordsterkte?",
+    "description": "Wachtwoordsterkte geeft aan hoe goed een wachtwoord bestand is tegen raden en kraken.",
+    "point-1": "Langere wachtzinnen verhogen de entropie en zijn makkelijker te onthouden.",
+    "point-2": "Een mix van hoofdletters, kleine letters, cijfers en symbolen vergroot de variatie.",
+    "point-3": "Vermijd hergebruikte, veelvoorkomende of gelekte wachtwoorden.",
+    "tip": "Gebruik een wachtwoordmanager om unieke wachtwoorden te maken en bewaren."
+  },
+  "sv": {
+    "title": "Vad är lösenordsstyrka?",
+    "description": "Lösenordsstyrka beskriver hur motståndskraftigt ett lösenord är mot gissning och knäckning.",
+    "point-1": "Längre lösenfraser ökar entropin och är lättare att komma ihåg.",
+    "point-2": "Blanda stora/små bokstäver, siffror och symboler för bättre variation.",
+    "point-3": "Undvik återanvända, vanliga eller läckta lösenord.",
+    "tip": "Använd en lösenordshanterare för unika lösenord."
+  },
+  "pl": {
+    "title": "Czym jest siła hasła?",
+    "description": "Siła hasła opisuje odporność na zgadywanie i łamanie.",
+    "point-1": "Dłuższe frazy zwiększają entropię i są łatwiejsze do zapamiętania.",
+    "point-2": "Mieszanie wielkich liter, małych liter, cyfr i symboli zwiększa różnorodność.",
+    "point-3": "Unikaj haseł używanych ponownie, popularnych lub ujawnionych.",
+    "tip": "Korzystaj z menedżera haseł do tworzenia i przechowywania unikalnych haseł."
+  },
+  "vi": {
+    "title": "Độ mạnh mật khẩu là gì?",
+    "description": "Độ mạnh mật khẩu thể hiện mức độ chống lại đoán và bẻ khóa.",
+    "point-1": "Cụm từ dài hơn tăng entropy và dễ nhớ hơn.",
+    "point-2": "Trộn chữ hoa, chữ thường, số và ký hiệu giúp tăng đa dạng.",
+    "point-3": "Tránh mật khẩu tái sử dụng, phổ biến hoặc bị lộ.",
+    "tip": "Dùng trình quản lý mật khẩu để tạo và lưu mật khẩu duy nhất."
+  },
+  "th": {
+    "title": "ความแข็งแรงของรหัสผ่านคืออะไร?",
+    "description": "ความแข็งแรงของรหัสผ่านบอกถึงการต้านทานต่อการเดาและการแคร็ก.",
+    "point-1": "วลีที่ยาวขึ้นเพิ่มเอนโทรปีและจำง่ายกว่า.",
+    "point-2": "ผสมตัวพิมพ์ใหญ่ ตัวพิมพ์เล็ก ตัวเลข และสัญลักษณ์ช่วยเพิ่มความหลากหลาย.",
+    "point-3": "หลีกเลี่ยงรหัสผ่านที่ใช้ซ้ำ เป็นที่นิยม หรือรั่วไหล.",
+    "tip": "ใช้โปรแกรมจัดการรหัสผ่านเพื่อสร้างและเก็บรหัสผ่านที่ไม่ซ้ำ."
+  },
+  "id": {
+    "title": "Apa itu kekuatan kata sandi?",
+    "description": "Kekuatan kata sandi menunjukkan ketahanannya terhadap tebakan dan cracking.",
+    "point-1": "Frasa yang lebih panjang meningkatkan entropi dan lebih mudah diingat.",
+    "point-2": "Menggabungkan huruf besar, kecil, angka, dan simbol meningkatkan variasi.",
+    "point-3": "Hindari kata sandi yang digunakan ulang, umum, atau bocor.",
+    "tip": "Gunakan pengelola kata sandi untuk membuat dan menyimpan kata sandi unik."
+  },
+  "he": {
+    "title": "מהו חוזק סיסמה?",
+    "description": "חוזק סיסמה מתאר עד כמה היא עמידה לניחוש ולפריצה.",
+    "point-1": "ביטויים ארוכים יותר מעלים את האנטרופיה וקלים יותר לזכור.",
+    "point-2": "שילוב אותיות גדולות, קטנות, מספרים וסמלים מגביר את הגיוון.",
+    "point-3": "הימנעו מסיסמאות חוזרות, נפוצות או דלופות.",
+    "tip": "השתמשו במנהל סיסמאות ליצירה ושמירה של סיסמאות ייחודיות."
+  },
+  "ms": {
+    "title": "Apakah kekuatan kata laluan?",
+    "description": "Kekuatan kata laluan menunjukkan ketahanan terhadap tekaan dan pemecahan.",
+    "point-1": "Frasa lebih panjang meningkatkan entropi dan lebih mudah diingati.",
+    "point-2": "Gabungan huruf besar, huruf kecil, nombor dan simbol menambah variasi.",
+    "point-3": "Elakkan kata laluan yang digunakan semula, biasa atau bocor.",
+    "tip": "Gunakan pengurus kata laluan untuk menjana dan menyimpan kata laluan unik."
+  },
+  "no": {
+    "title": "Hva er passordstyrke?",
+    "description": "Passordstyrke beskriver hvor motstandsdyktig et passord er mot gjetting og knekking.",
+    "point-1": "Lengre passfraser gir høyere entropi og er lettere å huske.",
+    "point-2": "Blanding av store/små bokstaver, tall og symboler øker variasjonen.",
+    "point-3": "Unngå gjenbrukte, vanlige eller lekkede passord.",
+    "tip": "Bruk en passordbehandler til å lage og lagre unike passord."
+  }
+}
+</i18n>

--- a/tools/validator/password-strength-checker/src/exports.dom.test.ts
+++ b/tools/validator/password-strength-checker/src/exports.dom.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import * as toolInfo from './info'
+import { routes } from './routes'
+import * as tool from './index'
+
+describe('password-strength-checker exports', () => {
+  it('exposes tool metadata and routes', () => {
+    expect(toolInfo.toolID).toBe('password-strength-checker')
+    expect(toolInfo.path).toBe('/tools/password-strength-checker')
+    expect(routes[0]?.path).toBe(toolInfo.path)
+    expect(tool.toolInfo).toBeDefined()
+  })
+
+  it('resolves the route component loader', async () => {
+    const loader = routes[0]?.component as (() => Promise<{ default: unknown }>) | undefined
+    expect(loader).toBeDefined()
+    if (loader) {
+      const module = await loader()
+      expect(module.default).toBeDefined()
+    }
+  })
+})

--- a/tools/validator/password-strength-checker/src/index.ts
+++ b/tools/validator/password-strength-checker/src/index.ts
@@ -1,0 +1,5 @@
+import * as toolInfo from './info'
+
+const toolInfoExport = toolInfo
+
+export { toolInfoExport as toolInfo }

--- a/tools/validator/password-strength-checker/src/info.ts
+++ b/tools/validator/password-strength-checker/src/info.ts
@@ -1,0 +1,126 @@
+export { ShieldCheckmark24Regular as icon } from '@shared/icons/fluent'
+
+export const toolID = 'password-strength-checker'
+export const path = '/tools/password-strength-checker'
+export const tags = ['password', 'security', 'strength', 'validator']
+export const features = ['offline']
+
+export const meta = {
+  en: {
+    name: 'Password Strength Checker',
+    description:
+      'Assess password strength with entropy, composition, and pattern checks plus tips to improve security.',
+  },
+  zh: {
+    name: '密码强度检测',
+    description: '通过熵值、字符组成和模式检测评估密码强度，并提供提升安全性的建议。',
+  },
+  'zh-CN': {
+    name: '密码强度检测',
+    description: '通过熵值、字符组成和模式检测评估密码强度，并提供提升安全性的建议。',
+  },
+  'zh-TW': {
+    name: '密碼強度檢測',
+    description: '透過熵值、字元組成與模式檢查評估密碼強度，並提供提升安全性的建議。',
+  },
+  'zh-HK': {
+    name: '密碼強度檢測',
+    description: '透過熵值、字元組成同模式檢查評估密碼強度，並提供提升安全性的建議。',
+  },
+  es: {
+    name: 'Comprobador de Fuerza de Contraseña',
+    description:
+      'Evalúa la fortaleza con entropía, composición y patrones, y ofrece sugerencias para mejorar la seguridad.',
+  },
+  fr: {
+    name: 'Vérificateur de Robustesse de Mot de Passe',
+    description:
+      'Évalue la robustesse via entropie, composition et motifs, avec des conseils pour améliorer la sécurité.',
+  },
+  de: {
+    name: 'Passwortstärke-Checker',
+    description:
+      'Bewertet die Passwortstärke anhand von Entropie, Zusammensetzung und Mustern und gibt Tipps zur Sicherheit.',
+  },
+  it: {
+    name: 'Verificatore di Forza Password',
+    description:
+      'Valuta la forza con entropia, composizione e pattern, con suggerimenti per migliorare la sicurezza.',
+  },
+  ja: {
+    name: 'パスワード強度チェッカー',
+    description: 'エントロピーや構成、パターン検査で強度を評価し、安全性向上のヒントを提供します。',
+  },
+  ko: {
+    name: '비밀번호 강도 검사기',
+    description: '엔트로피, 구성, 패턴 검사를 통해 강도를 평가하고 보안을 높이는 팁을 제공합니다.',
+  },
+  ru: {
+    name: 'Проверка Стойкости Пароля',
+    description:
+      'Оценивает стойкость по энтропии, составу и шаблонам и дает советы по повышению безопасности.',
+  },
+  pt: {
+    name: 'Verificador de Força de Senha',
+    description:
+      'Avalia a força com entropia, composição e padrões, além de dicas para melhorar a segurança.',
+  },
+  ar: {
+    name: 'مدقق قوة كلمة المرور',
+    description: 'قيّم القوة عبر الإنتروبيا والتركيب وفحص الأنماط مع نصائح لتحسين الأمان.',
+  },
+  hi: {
+    name: 'पासवर्ड मजबूती जांचकर्ता',
+    description:
+      'एंट्रॉपी, संरचना और पैटर्न जांच के साथ मजबूती का आकलन करें और सुरक्षा सुझाव पाएं।',
+  },
+  tr: {
+    name: 'Parola Gücü Denetleyici',
+    description:
+      'Entropi, bileşim ve desen kontrolleriyle gücü değerlendirir ve güvenliği artırmak için öneriler sunar.',
+  },
+  nl: {
+    name: 'Wachtwoordsterkte Checker',
+    description:
+      'Beoordeelt sterkte met entropie-, samenstellings- en patroonchecks, plus tips voor betere veiligheid.',
+  },
+  sv: {
+    name: 'Lösenordsstyrke-kontroll',
+    description:
+      'Bedömer lösenordsstyrka med entropi-, sammansättnings- och mönsterkontroller samt tips för säkerhet.',
+  },
+  pl: {
+    name: 'Sprawdzanie Siły Hasła',
+    description:
+      'Ocenia siłę hasła na podstawie entropii, składu i wzorców oraz podaje wskazówki bezpieczeństwa.',
+  },
+  vi: {
+    name: 'Kiểm tra độ mạnh mật khẩu',
+    description:
+      'Đánh giá độ mạnh bằng entropy, thành phần ký tự và mẫu, kèm gợi ý cải thiện bảo mật.',
+  },
+  th: {
+    name: 'ตัวตรวจสอบความแข็งแรงของรหัสผ่าน',
+    description:
+      'ประเมินความแข็งแรงด้วยเอนโทรปี องค์ประกอบ และรูปแบบ พร้อมคำแนะนำเพื่อเพิ่มความปลอดภัย.',
+  },
+  id: {
+    name: 'Pemeriksa Kekuatan Kata Sandi',
+    description:
+      'Menilai kekuatan dengan entropi, komposisi, dan pola, serta memberi saran untuk meningkatkan keamanan.',
+  },
+  he: {
+    name: 'בודק חוזק סיסמה',
+    description: 'מעריך חוזק באמצעות אנטרופיה, הרכב ובדיקות דפוסים ומספק טיפים לשיפור האבטחה.',
+  },
+  ms: {
+    name: 'Pemeriksa Kekuatan Kata Laluan',
+    description:
+      'Menilai kekuatan dengan entropi, komposisi dan corak, serta memberi cadangan untuk meningkatkan keselamatan.',
+  },
+  no: {
+    name: 'Passordstyrke-sjekk',
+    description:
+      'Vurderer passordstyrke med entropi, sammensetning og mønstre, og gir tips for bedre sikkerhet.',
+  },
+}

--- a/tools/validator/password-strength-checker/src/routes.ts
+++ b/tools/validator/password-strength-checker/src/routes.ts
@@ -1,0 +1,9 @@
+import type { ToolRoute } from '@shared/tools'
+
+export const routes: ToolRoute[] = [
+  {
+    name: 'password-strength-checker',
+    path: '/tools/password-strength-checker',
+    component: () => import('./PasswordStrengthCheckerView.vue'),
+  },
+] as const

--- a/tools/validator/password-strength-checker/src/utils.dom.test.ts
+++ b/tools/validator/password-strength-checker/src/utils.dom.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import { analyzePassword, formatDuration, scoreFromEntropy } from './utils'
+
+describe('scoreFromEntropy', () => {
+  it('maps entropy ranges to scores', () => {
+    expect(scoreFromEntropy(0)).toBe(0)
+    expect(scoreFromEntropy(27.9)).toBe(0)
+    expect(scoreFromEntropy(28)).toBe(1)
+    expect(scoreFromEntropy(35)).toBe(1)
+    expect(scoreFromEntropy(36)).toBe(2)
+    expect(scoreFromEntropy(59)).toBe(2)
+    expect(scoreFromEntropy(60)).toBe(3)
+    expect(scoreFromEntropy(89)).toBe(3)
+    expect(scoreFromEntropy(90)).toBe(4)
+  })
+})
+
+describe('formatDuration', () => {
+  it('handles non-finite and under-second durations', () => {
+    const infinite = formatDuration(Number.POSITIVE_INFINITY)
+    expect(infinite.unit).toBe('years')
+    expect(infinite.isUnderSecond).toBe(false)
+
+    const zero = formatDuration(0)
+    expect(zero.isUnderSecond).toBe(true)
+    expect(zero.unit).toBe('seconds')
+
+    const under = formatDuration(0.5)
+    expect(under.isUnderSecond).toBe(true)
+    expect(under.unit).toBe('seconds')
+  })
+
+  it('rounds values based on magnitude', () => {
+    const seconds = formatDuration(5)
+    expect(seconds.unit).toBe('seconds')
+    expect(seconds.value).toBe(5)
+
+    const minutes = formatDuration(60 * 12)
+    expect(minutes.unit).toBe('minutes')
+    expect(minutes.value).toBe(12)
+
+    const years = formatDuration(31557600 * 120)
+    expect(years.unit).toBe('years')
+    expect(years.value).toBe(120)
+  })
+})
+
+describe('analyzePassword', () => {
+  it('returns null for empty input', () => {
+    expect(analyzePassword('')).toBeNull()
+  })
+
+  it('flags common, short, and sequential passwords', () => {
+    const result = analyzePassword('123456')
+    expect(result).not.toBeNull()
+    expect(result!.warnings).toEqual(
+      expect.arrayContaining(['common', 'short', 'singleClass', 'sequence']),
+    )
+    expect(result!.suggestions).toEqual(
+      expect.arrayContaining(['avoid-common', 'use-longer', 'avoid-sequences']),
+    )
+  })
+
+  it('adds length suggestions without short warnings for medium length', () => {
+    const result = analyzePassword('Password!')
+    expect(result).not.toBeNull()
+    expect(result!.warnings).not.toContain('short')
+    expect(result!.suggestions).toContain('use-longer')
+    expect(result!.suggestions).toContain('add-numbers')
+  })
+
+  it('detects repeated patterns and avoids false sequences', () => {
+    const result = analyzePassword('a1a1a1')
+    expect(result).not.toBeNull()
+    expect(result!.warnings).toContain('repeat')
+    expect(result!.warnings).not.toContain('sequence')
+    expect(result!.suggestions).toContain('avoid-repetition')
+  })
+
+  it('detects sequential letters', () => {
+    const result = analyzePassword('abcd')
+    expect(result).not.toBeNull()
+    expect(result!.warnings).toContain('sequence')
+  })
+
+  it('detects repeating characters', () => {
+    const result = analyzePassword('aaabbb')
+    expect(result).not.toBeNull()
+    expect(result!.warnings).toContain('repeat')
+  })
+
+  it('returns a strong score for varied long passwords', () => {
+    const result = analyzePassword('Str0ng!Passw0rd-Example')
+    expect(result).not.toBeNull()
+    expect(result!.score).toBe(4)
+    expect(result!.composition.symbol).toBeGreaterThan(0)
+  })
+
+  it('handles very long passwords with huge crack times', () => {
+    const result = analyzePassword(`${'A'.repeat(400)}a1!`)
+    expect(result).not.toBeNull()
+    expect(result!.log10Guesses).toBeGreaterThan(318)
+    expect(result!.crackTimes.offlineFast.unit).toBe('years')
+  })
+})

--- a/tools/validator/password-strength-checker/src/utils.ts
+++ b/tools/validator/password-strength-checker/src/utils.ts
@@ -1,0 +1,289 @@
+const COMMON_PASSWORDS = new Set([
+  'password',
+  '123456',
+  '123456789',
+  '12345678',
+  '12345',
+  '1234',
+  '111111',
+  '000000',
+  'qwerty',
+  'qwerty123',
+  'abc123',
+  'letmein',
+  'welcome',
+  'admin',
+  'iloveyou',
+  'monkey',
+  'dragon',
+  'sunshine',
+  'princess',
+  'football',
+])
+
+const CHARSET_SIZES = {
+  lower: 26,
+  upper: 26,
+  digit: 10,
+  symbol: 33,
+}
+
+const LOG10_2 = Math.log10(2)
+const OFFLINE_GUESS_RATE = 1e10
+const ONLINE_GUESS_RATE = 100
+
+export type StrengthScore = 0 | 1 | 2 | 3 | 4
+
+export type StrengthWarningKey = 'common' | 'short' | 'sequence' | 'repeat' | 'singleClass'
+export type StrengthSuggestionKey =
+  | 'use-longer'
+  | 'add-uppercase'
+  | 'add-lowercase'
+  | 'add-numbers'
+  | 'add-symbols'
+  | 'avoid-common'
+  | 'avoid-sequences'
+  | 'avoid-repetition'
+
+export type DurationUnit = 'seconds' | 'minutes' | 'hours' | 'days' | 'months' | 'years'
+
+export type DurationDisplay = {
+  value: number
+  unit: DurationUnit
+  isUnderSecond: boolean
+}
+
+export type StrengthReport = {
+  length: number
+  uniqueCount: number
+  poolSize: number
+  entropyBits: number
+  log10Guesses: number
+  score: StrengthScore
+  composition: {
+    lower: number
+    upper: number
+    digit: number
+    symbol: number
+  }
+  warnings: StrengthWarningKey[]
+  suggestions: StrengthSuggestionKey[]
+  crackTimes: {
+    offlineFast: DurationDisplay
+    onlineThrottled: DurationDisplay
+  }
+}
+
+export function scoreFromEntropy(entropyBits: number): StrengthScore {
+  if (entropyBits < 28) return 0
+  if (entropyBits < 36) return 1
+  if (entropyBits < 60) return 2
+  if (entropyBits < 90) return 3
+  return 4
+}
+
+export function formatDuration(seconds: number): DurationDisplay {
+  if (!Number.isFinite(seconds)) {
+    return { value: Number.MAX_VALUE, unit: 'years', isUnderSecond: false }
+  }
+
+  if (seconds <= 0) {
+    return { value: 0, unit: 'seconds', isUnderSecond: true }
+  }
+
+  if (seconds < 1) {
+    return { value: 1, unit: 'seconds', isUnderSecond: true }
+  }
+
+  const units: Array<{ unit: DurationUnit; seconds: number }> = [
+    { unit: 'years', seconds: 31557600 },
+    { unit: 'months', seconds: 2629800 },
+    { unit: 'days', seconds: 86400 },
+    { unit: 'hours', seconds: 3600 },
+    { unit: 'minutes', seconds: 60 },
+    { unit: 'seconds', seconds: 1 },
+  ]
+
+  let selected = units[units.length - 1]!
+  for (const entry of units) {
+    if (seconds >= entry.seconds) {
+      selected = entry
+      break
+    }
+  }
+  const rawValue = seconds / selected.seconds
+  const value = roundDurationValue(rawValue)
+
+  return { value, unit: selected.unit, isUnderSecond: false }
+}
+
+export function analyzePassword(password: string): StrengthReport | null {
+  if (!password) return null
+
+  const composition = {
+    lower: countMatches(password, /[a-z]/g),
+    upper: countMatches(password, /[A-Z]/g),
+    digit: countMatches(password, /\d/g),
+    symbol: countMatches(password, /[^a-zA-Z0-9]/g),
+  }
+
+  const length = password.length
+  const uniqueCount = new Set(password).size
+  const poolSize =
+    (composition.lower ? CHARSET_SIZES.lower : 0) +
+    (composition.upper ? CHARSET_SIZES.upper : 0) +
+    (composition.digit ? CHARSET_SIZES.digit : 0) +
+    (composition.symbol ? CHARSET_SIZES.symbol : 0)
+
+  const typesUsed = [
+    composition.lower,
+    composition.upper,
+    composition.digit,
+    composition.symbol,
+  ].filter(Boolean).length
+
+  const warnings = new Set<StrengthWarningKey>()
+  const suggestions = new Set<StrengthSuggestionKey>()
+  const normalized = password.trim().toLowerCase()
+  const isCommon = COMMON_PASSWORDS.has(normalized)
+
+  if (isCommon) {
+    warnings.add('common')
+    suggestions.add('avoid-common')
+  }
+
+  if (length < 8) {
+    warnings.add('short')
+    suggestions.add('use-longer')
+  } else if (length < 12) {
+    suggestions.add('use-longer')
+  }
+
+  if (typesUsed <= 1) {
+    warnings.add('singleClass')
+  }
+
+  if (!composition.lower) suggestions.add('add-lowercase')
+  if (!composition.upper) suggestions.add('add-uppercase')
+  if (!composition.digit) suggestions.add('add-numbers')
+  if (!composition.symbol) suggestions.add('add-symbols')
+
+  const hasSequence = hasSequentialPattern(password)
+  if (hasSequence) {
+    warnings.add('sequence')
+    suggestions.add('avoid-sequences')
+  }
+
+  const hasRepeat = hasRepeatingCharacters(password) || hasRepeatedPattern(password)
+  if (hasRepeat) {
+    warnings.add('repeat')
+    suggestions.add('avoid-repetition')
+  }
+
+  const safePoolSize = Math.max(poolSize, 1)
+  const baseEntropy = length * Math.log2(safePoolSize)
+  let entropyBits = baseEntropy
+
+  if (isCommon) {
+    entropyBits = 0
+  } else {
+    entropyBits -= length < 8 ? 10 : 0
+    entropyBits -= typesUsed <= 1 ? 10 : 0
+    entropyBits -= hasSequence ? 10 : 0
+    entropyBits -= hasRepeat ? 12 : 0
+    entropyBits = Math.max(0, entropyBits)
+  }
+
+  const score = scoreFromEntropy(entropyBits)
+  const log10Guesses = entropyBits * LOG10_2
+  const offlineSeconds = toCrackSeconds(log10Guesses, OFFLINE_GUESS_RATE)
+  const onlineSeconds = toCrackSeconds(log10Guesses, ONLINE_GUESS_RATE)
+
+  return {
+    length,
+    uniqueCount,
+    poolSize,
+    entropyBits,
+    log10Guesses,
+    score,
+    composition,
+    warnings: Array.from(warnings),
+    suggestions: Array.from(suggestions),
+    crackTimes: {
+      offlineFast: formatDuration(offlineSeconds),
+      onlineThrottled: formatDuration(onlineSeconds),
+    },
+  }
+}
+
+function countMatches(value: string, regex: RegExp): number {
+  const matches = value.match(regex)
+  return matches ? matches.length : 0
+}
+
+function hasRepeatingCharacters(value: string): boolean {
+  return /(.)\1{2,}/.test(value)
+}
+
+function hasSequentialPattern(value: string): boolean {
+  const normalized = value.toLowerCase()
+  let run = 1
+
+  for (let index = 1; index < normalized.length; index += 1) {
+    const prev = normalized.charAt(index - 1)
+    const current = normalized.charAt(index)
+
+    if (isSequentialPair(prev, current)) {
+      run += 1
+      if (run >= 3) return true
+    } else {
+      run = 1
+    }
+  }
+
+  return false
+}
+
+function isSequentialPair(prev: string, current: string): boolean {
+  if (isDigit(prev) && isDigit(current)) {
+    return Math.abs(current.charCodeAt(0) - prev.charCodeAt(0)) === 1
+  }
+
+  if (isLowercaseLetter(prev) && isLowercaseLetter(current)) {
+    return Math.abs(current.charCodeAt(0) - prev.charCodeAt(0)) === 1
+  }
+
+  return false
+}
+
+function isDigit(value: string): boolean {
+  return value >= '0' && value <= '9'
+}
+
+function isLowercaseLetter(value: string): boolean {
+  return value >= 'a' && value <= 'z'
+}
+
+function hasRepeatedPattern(value: string): boolean {
+  const length = value.length
+
+  for (let size = 1; size <= Math.floor(length / 2); size += 1) {
+    if (length % size !== 0) continue
+    const chunk = value.slice(0, size)
+    if (chunk.repeat(length / size) === value) return true
+  }
+
+  return false
+}
+
+function roundDurationValue(value: number): number {
+  if (value >= 100) return Math.round(value)
+  if (value >= 10) return Math.round(value * 10) / 10
+  return Math.round(value * 100) / 100
+}
+
+function toCrackSeconds(log10Guesses: number, rate: number): number {
+  const log10Seconds = log10Guesses - Math.log10(rate)
+  if (log10Seconds > 308) return Number.MAX_VALUE
+  return Math.pow(10, log10Seconds)
+}


### PR DESCRIPTION
## Summary
- add a password strength checker tool with entropy, pattern checks, and crack time estimates
- provide a dedicated explanation section and full i18n metadata
- add 100% coverage tests for tool UI, utils, and exports plus registry wiring

## Testing
- pnpm exec vitest --run tools/validator/password-strength-checker/src/**/*.dom.test.ts --coverage --coverage.include='tools/validator/password-strength-checker/src/**'
- pnpm lint
- pnpm format
- pnpm type-check
- pnpm build