### PR TITLE
feat(tools): use anchor download links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Prettier: no semicolons, single quotes, `printWidth: 100`.
 - Use path aliases: `@shared/*`, `@tools/*`, `@utils/*`, `@registry/*`.
 - Tool packages follow `tools/<domain>/<tool-slug>/src` with `info.ts`, `routes.ts`, and a `*View.vue`.
+- Download buttons must be real anchors: `n-button tag="a"` with `download` and `href` from `useObjectUrl`, and no `document.createElement('a')`.
 
 ## Tool Creation & Registration
 - Directory structure: `tools/<domain>/<tool-slug>/src` with `info.ts`, `routes.ts`, `<ToolName>View.vue`, `components/`, and `index.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,11 @@ Import from `@shared/ui/*`:
 - `@shared/ui/layouts` → `NavLayout`, `NavBar`
 - `@shared/ui/domain/*` → Domain-specific components (IP, UUID, PDF, MAC, DNS)
 
+## Download Buttons
+
+- Use real anchor buttons for downloads: `n-button tag="a"` with `download` and `href` from `useObjectUrl`.
+- Avoid manual `document.createElement('a')` download clicks.
+
 ## Internationalization
 
 **25 supported languages** (defined in `shared/locale/src/languages.ts`):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4024,6 +4024,9 @@ importers:
       '@shared/ui':
         specifier: workspace:*
         version: link:../../../shared/ui
+      '@vueuse/core':
+        specifier: 'catalog:'
+        version: 14.1.0(vue@3.5.26(typescript@5.9.3))
       mime:
         specifier: 'catalog:'
         version: 4.1.0

--- a/tools/code/csv-to-json-converter/src/components/CsvToJsonConverter.vue
+++ b/tools/code/csv-to-json-converter/src/components/CsvToJsonConverter.vue
@@ -18,7 +18,7 @@
       </n-flex>
       <n-flex>
         <CopyToClipboardButton :content="renderedJson" />
-        <n-button @click="downloadJson" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.json">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -157,7 +157,7 @@ import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import Papa from 'papaparse'
 import type { ParseResult } from 'papaparse'
-import { useStorage } from '@vueuse/core'
+import { useObjectUrl, useStorage } from '@vueuse/core'
 import {
   NButton,
   NIcon,
@@ -267,17 +267,10 @@ const renderedJson = computed(() => {
   }
 })
 
-function downloadJson(): void {
-  const blob = new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.json'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/gitignore-generator/src/components/GitignoreGenerator.dom.test.ts
+++ b/tools/code/gitignore-generator/src/components/GitignoreGenerator.dom.test.ts
@@ -23,12 +23,12 @@ describe('GitignoreGenerator', () => {
 
     expect((textarea.element as HTMLTextAreaElement).value).toBe('')
 
-    const downloadButton = wrapper
-      .findAll('button')
+    const downloadLink = wrapper
+      .findAll('a')
       .find((candidate) => candidate.text().includes('Download'))
 
-    expect(downloadButton).toBeTruthy()
-    expect(downloadButton!.attributes('disabled')).toBeDefined()
+    expect(downloadLink).toBeTruthy()
+    expect(downloadLink!.attributes('href')).toBeUndefined()
   })
 
   it('loads stored selections into the preview', () => {

--- a/tools/code/gitignore-generator/src/components/GitignoreGenerator.vue
+++ b/tools/code/gitignore-generator/src/components/GitignoreGenerator.vue
@@ -91,7 +91,13 @@
         <n-space v-else />
         <n-space>
           <CopyToClipboardButton :content="generatedContent" />
-          <n-button text @click="downloadGitignore" :disabled="!generatedContent">
+          <n-button
+            tag="a"
+            text
+            :href="downloadUrl ?? undefined"
+            download=".gitignore"
+            :disabled="!downloadUrl"
+          >
             <template #icon>
               <n-icon><DownloadIcon /></n-icon>
             </template>
@@ -113,7 +119,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useStorage } from '@vueuse/core'
+import { useObjectUrl, useStorage } from '@vueuse/core'
 import {
   NInput,
   NSpace,
@@ -223,18 +229,11 @@ const generatedContent = computed(() => {
   return selected.map((t) => `### ${t.name} ###\n${t.content}`).join('\n\n')
 })
 
-// Download gitignore file
-function downloadGitignore() {
-  if (!generatedContent.value) return
-
-  const blob = new Blob([generatedContent.value], { type: 'text/plain' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = '.gitignore'
-  a.click()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(() => {
+  if (!generatedContent.value) return null
+  return new Blob([generatedContent.value], { type: 'text/plain;charset=utf-8' })
+})
+const downloadUrl = useObjectUrl(downloadBlob)
 </script>
 
 <i18n lang="json">

--- a/tools/code/json-formatter/src/components/JsonFormatter.vue
+++ b/tools/code/json-formatter/src/components/JsonFormatter.vue
@@ -22,7 +22,7 @@
           />
         </n-flex>
         <CopyToClipboardButton :content="formattedJson" />
-        <n-button @click="downloadJson" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="formatted.json">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -58,6 +58,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import {
@@ -107,6 +108,11 @@ const formattedJson = computed<string>(() => {
   }
 })
 
+const downloadBlob = computed(
+  () => new Blob([formattedJson.value], { type: 'application/json;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
+
 // Watch for changes to update error state separately
 watch(
   [jsonText, indentSize],
@@ -125,18 +131,6 @@ watch(
   },
   { immediate: true },
 )
-
-function downloadJson(): void {
-  const blob = new Blob([formattedJson.value], { type: 'application/json;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'formatted.json'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
 
 async function importFromFile(): Promise<void> {
   try {

--- a/tools/code/json-to-csv-converter/src/components/JsonToCsvConverter.vue
+++ b/tools/code/json-to-csv-converter/src/components/JsonToCsvConverter.vue
@@ -17,7 +17,7 @@
       </n-flex>
       <n-flex>
         <CopyToClipboardButton :content="csvText" />
-        <n-button @click="downloadCsv" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.csv">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -66,7 +66,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import Papa from 'papaparse'
@@ -115,17 +116,8 @@ function convertNow(): void {
 
 watch([jsonText, delimiter, quote, header, escapeFormulae], () => convertNow(), { immediate: true })
 
-function downloadCsv(): void {
-  const blob = new Blob([csvText.value], { type: 'text/csv;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.csv'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(() => new Blob([csvText.value], { type: 'text/csv;charset=utf-8' }))
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/json-to-toml-converter/src/components/JsonToTomlConverter.vue
+++ b/tools/code/json-to-toml-converter/src/components/JsonToTomlConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedToml" />
-        <n-button @click="downloadToml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.toml">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { stringify as tomlStringify } from 'smol-toml'
@@ -78,17 +79,10 @@ const renderedToml = computed<string>(() => {
   }
 })
 
-function downloadToml(): void {
-  const blob = new Blob([renderedToml.value], { type: 'application/toml;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.toml'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedToml.value], { type: 'application/toml;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/json-to-xml-converter/src/components/JsonToXmlConverter.vue
+++ b/tools/code/json-to-xml-converter/src/components/JsonToXmlConverter.vue
@@ -38,7 +38,7 @@
       </n-flex>
       <n-flex>
         <CopyToClipboardButton :content="renderedXml" />
-        <n-button @click="downloadXml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.xml">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -69,6 +69,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import convert from 'xml-js'
@@ -120,17 +121,10 @@ const renderedXml = computed<string>(() => {
   }
 })
 
-function downloadXml(): void {
-  const blob = new Blob([renderedXml.value], { type: 'application/xml;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.xml'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedXml.value], { type: 'application/xml;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/json-to-yaml-converter/src/components/JsonToYamlBuilder.vue
+++ b/tools/code/json-to-yaml-converter/src/components/JsonToYamlBuilder.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedYaml" />
-        <n-button @click="downloadYaml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.yaml">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { load as yamlLoad, dump as yamlDump } from 'js-yaml'
@@ -76,17 +77,10 @@ const renderedYaml = computed<string>(() => {
   }
 })
 
-function downloadYaml(): void {
-  const blob = new Blob([renderedYaml.value], { type: 'text/yaml;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.yaml'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedYaml.value], { type: 'text/yaml;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/openapi-to-typescript/src/components/OpenApiToTypescript.vue
+++ b/tools/code/openapi-to-typescript/src/components/OpenApiToTypescript.vue
@@ -23,7 +23,13 @@
       </n-flex>
       <n-flex align="center" wrap>
         <CopyToClipboardButton :content="outputText" />
-        <n-button @click="downloadTypes" text :disabled="!outputText">
+        <n-button
+          tag="a"
+          text
+          :href="downloadUrl ?? undefined"
+          download="openapi-types.d.ts"
+          :disabled="!downloadUrl"
+        >
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -168,7 +174,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { computedAsync, useDebounce, useStorage } from '@vueuse/core'
+import { computedAsync, useDebounce, useObjectUrl, useStorage } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { fileOpen } from 'browser-fs-access'
 import {
@@ -334,6 +340,11 @@ const outputState = computedAsync(
 )
 
 const outputText = computed(() => outputState.value.output)
+const downloadBlob = computed(() => {
+  if (!outputText.value) return null
+  return new Blob([outputText.value], { type: 'text/plain;charset=utf-8' })
+})
+const downloadUrl = useObjectUrl(downloadBlob)
 const outputError = computed(() => outputState.value.error)
 const importUrlStatus = computed(() => (importUrlError.value ? 'error' : undefined))
 
@@ -420,19 +431,6 @@ async function handleInput(value: string | File) {
   } catch {
     openApiText.value = ''
   }
-}
-
-function downloadTypes() {
-  if (!outputText.value) return
-  const blob = new Blob([outputText.value], { type: 'text/plain;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const anchor = document.createElement('a')
-  anchor.href = url
-  anchor.download = 'openapi-types.d.ts'
-  document.body.appendChild(anchor)
-  anchor.click()
-  anchor.remove()
-  URL.revokeObjectURL(url)
 }
 </script>
 

--- a/tools/code/toml-to-json-converter/src/components/TomlToJsonConverter.vue
+++ b/tools/code/toml-to-json-converter/src/components/TomlToJsonConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedJson" />
-        <n-button @click="downloadJson" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.json">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { parse as tomlParse } from 'smol-toml'
@@ -75,17 +76,10 @@ const renderedJson = computed<string>(() => {
   }
 })
 
-function downloadJson(): void {
-  const blob = new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.json'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/toml-to-yaml-converter/src/components/TomlToYamlConverter.vue
+++ b/tools/code/toml-to-yaml-converter/src/components/TomlToYamlConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedYaml" />
-        <n-button @click="downloadYaml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.yaml">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { parse as tomlParse } from 'smol-toml'
@@ -75,17 +76,10 @@ const renderedYaml = computed<string>(() => {
   }
 })
 
-function downloadYaml(): void {
-  const blob = new Blob([renderedYaml.value], { type: 'text/yaml;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.yaml'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedYaml.value], { type: 'text/yaml;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/xml-to-json-converter/src/components/XmlToJsonConverter.vue
+++ b/tools/code/xml-to-json-converter/src/components/XmlToJsonConverter.vue
@@ -74,7 +74,7 @@
       </n-flex>
       <n-flex>
         <CopyToClipboardButton :content="renderedJson" />
-        <n-button @click="downloadJson" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.json">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -99,6 +99,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import convert from 'xml-js'
@@ -152,17 +153,10 @@ const renderedJson = computed<string>(() => {
   }
 })
 
-function downloadJson(): void {
-  const blob = new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.json'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/yaml-to-json-converter/src/components/YamlToJsonConverter.vue
+++ b/tools/code/yaml-to-json-converter/src/components/YamlToJsonConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedJson" />
-        <n-button @click="downloadJson" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.json">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { load as yamlLoad } from 'js-yaml'
@@ -75,17 +76,10 @@ const renderedJson = computed<string>(() => {
   }
 })
 
-function downloadJson(): void {
-  const blob = new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.json'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedJson.value], { type: 'application/json;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/code/yaml-to-toml-converter/src/components/YamlToTomlConverter.vue
+++ b/tools/code/yaml-to-toml-converter/src/components/YamlToTomlConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedToml" />
-        <n-button @click="downloadToml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.toml">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection } from '@shared/ui/tool'
 import { load as yamlLoad } from 'js-yaml'
@@ -76,17 +77,10 @@ const renderedToml = computed<string>(() => {
   }
 })
 
-function downloadToml(): void {
-  const blob = new Blob([renderedToml.value], { type: 'application/toml;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.toml'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedToml.value], { type: 'application/toml;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/document/html-to-markdown-converter/src/components/HtmlToMarkdownConverter.vue
+++ b/tools/document/html-to-markdown-converter/src/components/HtmlToMarkdownConverter.vue
@@ -12,7 +12,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedMarkdown" />
-        <n-button @click="downloadMarkdown" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="converted.md">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -42,6 +42,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import TurndownService from 'turndown'
 import { ToolSection } from '@shared/ui/tool'
@@ -62,17 +63,10 @@ const turndownService = new TurndownService()
 
 const renderedMarkdown = computed<string>(() => turndownService.turndown(html.value))
 
-function downloadMarkdown(): void {
-  const blob = new Blob([renderedMarkdown.value], { type: 'text/markdown;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'converted.md'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedMarkdown.value], { type: 'text/markdown;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/document/markdown-to-html-converter/src/components/MarkdownToHtmlConverter.vue
+++ b/tools/document/markdown-to-html-converter/src/components/MarkdownToHtmlConverter.vue
@@ -14,7 +14,7 @@
 
       <n-flex>
         <CopyToClipboardButton :content="renderedHtml" />
-        <n-button @click="downloadHtml" text>
+        <n-button tag="a" text :href="downloadUrl ?? undefined" download="markdown.html">
           <template #icon>
             <n-icon :component="ArrowDownload16Regular" />
           </template>
@@ -52,6 +52,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { marked } from 'marked'
 import DOMPurify from 'dompurify'
@@ -89,17 +90,10 @@ const renderedHtml = computed<string>(() => {
   return sanitize.value ? DOMPurify.sanitize(rawHtml) : rawHtml
 })
 
-function downloadHtml(): void {
-  const blob = new Blob([renderedHtml.value], { type: 'text/html;charset=utf-8' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = 'markdown.html'
-  document.body.appendChild(a)
-  a.click()
-  a.remove()
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(
+  () => new Blob([renderedHtml.value], { type: 'text/html;charset=utf-8' }),
+)
+const downloadUrl = useObjectUrl(downloadBlob)
 
 async function importFromFile(): Promise<void> {
   const file = await fileOpen({

--- a/tools/favicon/favicon-assets-generator/src/components/common/DownloadFileButton.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/common/DownloadFileButton.vue
@@ -1,5 +1,12 @@
 <template>
-  <n-button size="small" text @click="emits('click')">
+  <n-button
+    size="small"
+    text
+    tag="a"
+    :href="href ?? undefined"
+    :download="filename"
+    :disabled="!href"
+  >
     <template #icon>
       <n-icon :component="ArrowDownload16Filled" />
     </template>
@@ -14,10 +21,10 @@ import { ArrowDownload16Filled } from '@shared/icons/fluent'
 import { useI18n } from 'vue-i18n'
 
 const { t } = useI18n()
-const emits = defineEmits(['click'])
 
 defineProps<{
   filename: string
+  href?: string | null
 }>()
 </script>
 

--- a/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserSettingsDownload.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserSettingsDownload.vue
@@ -2,16 +2,16 @@
   <n-p>
     <FileMinifiedUsingOxipngAndSvgo />
   </n-p>
-  <DownloadFileButton filename="favicon.ico" @click="downloadico" />
+  <DownloadFileButton filename="favicon.ico" :href="icoUrl" />
   <br />
   <template v-if="useOriginalSVG">
-    <DownloadFileButton filename="favicon.svg" @click="downloadSVG" />
+    <DownloadFileButton filename="favicon.svg" :href="svgUrl" />
     <br />
   </template>
   <template v-else>
-    <DownloadFileButton filename="favicon-32x32.png" @click="download32png" />
+    <DownloadFileButton filename="favicon-32x32.png" :href="png32Url" />
     <br />
-    <DownloadFileButton filename="favicon-16x16.png" @click="download16png" />
+    <DownloadFileButton filename="favicon-16x16.png" :href="png16Url" />
     <br />
   </template>
 
@@ -29,18 +29,13 @@ import {
   getHTMLCode,
   generateFaviconSVG,
 } from '../../utils/favicon-generator/desktop-browser'
-import { computed } from 'vue'
-import { useI18n } from 'vue-i18n'
+import { computed, ref, watch } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import FileMinifiedUsingOxipngAndSvgo from '../common/FileMinifiedUsingOxipngAndSvgo.vue'
 import DownloadFileButton from '../common/DownloadFileButton.vue'
 import hljs from 'highlight.js/lib/core'
 import xml from 'highlight.js/lib/languages/xml'
 hljs.registerLanguage('html', xml)
-import { messages } from '../locale/no-image-selected'
-
-const { t } = useI18n({
-  messages,
-})
 const message = useMessage()
 
 const props = defineProps<{
@@ -56,73 +51,85 @@ const image = computed<Blob | undefined>(() => {
   }
 })
 
-const downloadico = async () => {
-  try {
-    if (image.value === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
+const icoBlob = ref<Blob | null>(null)
+const svgBlob = ref<Blob | null>(null)
+const png32Blob = ref<Blob | null>(null)
+const png16Blob = ref<Blob | null>(null)
 
+const icoUrl = useObjectUrl(icoBlob)
+const svgUrl = useObjectUrl(svgBlob)
+const png32Url = useObjectUrl(png32Blob)
+const png16Url = useObjectUrl(png16Blob)
+
+let icoToken = 0
+let svgToken = 0
+let png32Token = 0
+let png16Token = 0
+
+const updateIco = async () => {
+  if (!image.value) {
+    icoBlob.value = null
+    return
+  }
+  const token = ++icoToken
+  try {
     const blob = await generateFaviconICO(image.value, props.options)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'favicon.ico'
-    a.click()
+    if (token !== icoToken) return
+    icoBlob.value = blob
   } catch (e) {
+    if (token !== icoToken) return
+    icoBlob.value = null
     message.error((e as Error).message)
   }
 }
 
-const download32png = async () => {
-  try {
-    if (image.value === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
-    const blob = await generateFaviconPNG(image.value, props.options, 32)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'favicon-32x32.png'
-    a.click()
-  } catch (e) {
-    message.error((e as Error).message)
+const updateSvg = async () => {
+  if (!image.value) {
+    svgBlob.value = null
+    return
   }
-}
-
-const download16png = async () => {
+  const token = ++svgToken
   try {
-    if (image.value === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
-
-    const blob = await generateFaviconPNG(image.value, props.options, 16)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'favicon-16x16.png'
-    a.click()
-  } catch (e) {
-    message.error((e as Error).message)
-  }
-}
-
-const downloadSVG = async () => {
-  try {
-    if (image.value === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
-
     const blob = await generateFaviconSVG(image.value, props.options)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'favicon.svg'
-    a.click()
+    if (token !== svgToken) return
+    svgBlob.value = blob
   } catch (e) {
+    if (token !== svgToken) return
+    svgBlob.value = null
+    message.error((e as Error).message)
+  }
+}
+
+const updatePng32 = async () => {
+  if (!image.value) {
+    png32Blob.value = null
+    return
+  }
+  const token = ++png32Token
+  try {
+    const blob = await generateFaviconPNG(image.value, props.options, 32)
+    if (token !== png32Token) return
+    png32Blob.value = blob
+  } catch (e) {
+    if (token !== png32Token) return
+    png32Blob.value = null
+    message.error((e as Error).message)
+  }
+}
+
+const updatePng16 = async () => {
+  if (!image.value) {
+    png16Blob.value = null
+    return
+  }
+  const token = ++png16Token
+  try {
+    const blob = await generateFaviconPNG(image.value, props.options, 16)
+    if (token !== png16Token) return
+    png16Blob.value = blob
+  } catch (e) {
+    if (token !== png16Token) return
+    png16Blob.value = null
     message.error((e as Error).message)
   }
 }
@@ -146,4 +153,18 @@ const code = computed(() => {
     return getHTMLCode(props.image, props.options)
   }
 })
+
+watch(
+  () => [image.value, props.options, useOriginalSVG.value],
+  () => {
+    void updateIco()
+    if (useOriginalSVG.value) {
+      void updateSvg()
+    } else {
+      void updatePng32()
+      void updatePng16()
+    }
+  },
+  { immediate: true, deep: true },
+)
 </script>

--- a/tools/favicon/favicon-assets-generator/src/components/pwa/maskable/PWAMaskableSettingsDownload.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/pwa/maskable/PWAMaskableSettingsDownload.vue
@@ -2,9 +2,9 @@
   <n-p>
     <FileMinifiedUsingOxipng />
   </n-p>
-  <DownloadFileButton filename="pwa-maskable-192x192.png" @click="download192png" />
+  <DownloadFileButton filename="pwa-maskable-192x192.png" :href="png192Url" />
   <br />
-  <DownloadFileButton filename="pwa-maskable-512x512.png" @click="download512png" />
+  <DownloadFileButton filename="pwa-maskable-512x512.png" :href="png512Url" />
 
   <n-p>
     <n-code language="json" :code="code" :word-wrap="true" :hljs="hljs" />
@@ -15,19 +15,15 @@
 import { NCode, NP } from 'naive-ui'
 import type { PWAOptions } from '../../../utils/favicon-generator/pwa'
 import { generatePWAMaskablePNG } from '../../../utils/favicon-generator/pwa'
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useMessage } from 'naive-ui'
-import { useI18n } from 'vue-i18n'
 import FileMinifiedUsingOxipng from '../../common/FileMinifiedUsingOxipng.vue'
 import DownloadFileButton from '../../common/DownloadFileButton.vue'
 import hljs from 'highlight.js/lib/core'
 import json from 'highlight.js/lib/languages/json'
 hljs.registerLanguage('json', json)
-import { messages } from '../../locale/no-image-selected'
 
-const { t } = useI18n({
-  messages,
-})
 const message = useMessage()
 
 const props = defineProps<{
@@ -35,38 +31,46 @@ const props = defineProps<{
   options: PWAOptions
 }>()
 
-const download192png = async () => {
+const image = computed<Blob | undefined>(() => props.options.maskableImage ?? props.image)
+
+const png192Blob = ref<Blob | null>(null)
+const png512Blob = ref<Blob | null>(null)
+const png192Url = useObjectUrl(png192Blob)
+const png512Url = useObjectUrl(png512Blob)
+
+let png192Token = 0
+let png512Token = 0
+
+const updatePng192 = async () => {
+  if (!image.value) {
+    png192Blob.value = null
+    return
+  }
+  const token = ++png192Token
   try {
-    if (props.image === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
-
-    const blob = await generatePWAMaskablePNG(props.image, props.options, 192)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'pwa-maskable-192x192.png'
-    a.click()
+    const blob = await generatePWAMaskablePNG(image.value, props.options, 192)
+    if (token !== png192Token) return
+    png192Blob.value = blob
   } catch (e) {
+    if (token !== png192Token) return
+    png192Blob.value = null
     message.error((e as Error).message)
   }
 }
 
-const download512png = async () => {
+const updatePng512 = async () => {
+  if (!image.value) {
+    png512Blob.value = null
+    return
+  }
+  const token = ++png512Token
   try {
-    if (props.image === undefined) {
-      throw new Error(t('noImageSelected'))
-    }
-
-    const blob = await generatePWAMaskablePNG(props.image, props.options, 512)
-    const url = URL.createObjectURL(blob)
-
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'pwa-maskable-512x512.png'
-    a.click()
+    const blob = await generatePWAMaskablePNG(image.value, props.options, 512)
+    if (token !== png512Token) return
+    png512Blob.value = blob
   } catch (e) {
+    if (token !== png512Token) return
+    png512Blob.value = null
     message.error((e as Error).message)
   }
 }
@@ -91,4 +95,13 @@ const code = computed(() => {
     2,
   )
 })
+
+watch(
+  () => [image.value, props.options],
+  () => {
+    void updatePng192()
+    void updatePng512()
+  },
+  { immediate: true, deep: true },
+)
 </script>

--- a/tools/image/png-optimizer/src/PngOptimizerView.vue
+++ b/tools/image/png-optimizer/src/PngOptimizerView.vue
@@ -16,7 +16,6 @@
       v-if="optimizedFile && originalFile"
       :original-file="originalFile"
       :optimized-file="optimizedFile"
-      @download="downloadOptimized"
     />
 
     <!-- Error Display -->
@@ -81,19 +80,6 @@ async function optimizeImage() {
   } finally {
     isOptimizing.value = false
   }
-}
-
-function downloadOptimized() {
-  if (!optimizedFile.value || !originalFile.value) return
-
-  const url = URL.createObjectURL(optimizedFile.value)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = originalFile.value.name
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
 }
 </script>
 

--- a/tools/image/png-optimizer/src/components/OptimizationResults.vue
+++ b/tools/image/png-optimizer/src/components/OptimizationResults.vue
@@ -25,7 +25,14 @@
 
       <!-- Download Button -->
       <n-flex justify="center" style="width: 100%">
-        <n-button type="primary" @click="handleDownload" style="width: 100%">
+        <n-button
+          tag="a"
+          type="primary"
+          style="width: 100%"
+          :href="downloadUrl ?? undefined"
+          :download="props.originalFile.name"
+          :disabled="!downloadUrl"
+        >
           <template #icon>
             <n-icon :component="Download24Regular" />
           </template>
@@ -38,6 +45,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
 import { NFlex, NGrid, NGridItem, NStatistic, NButton, NIcon } from 'naive-ui'
@@ -52,11 +60,6 @@ const props = defineProps<{
   optimizedFile: Blob
 }>()
 
-// Emits
-const emit = defineEmits<{
-  download: []
-}>()
-
 // Computed
 const compressionRatio = computed(() => {
   const reduction =
@@ -64,9 +67,7 @@ const compressionRatio = computed(() => {
   return Math.max(0, Math.round(reduction))
 })
 
-function handleDownload() {
-  emit('download')
-}
+const downloadUrl = useObjectUrl(computed(() => props.optimizedFile))
 </script>
 
 <i18n lang="json">

--- a/tools/image/svg-optimizer/src/components/OptimizationResults.vue
+++ b/tools/image/svg-optimizer/src/components/OptimizationResults.vue
@@ -22,7 +22,13 @@
       <CopyToClipboardButton :value="optimizedSvg" :feedback="t('copied')" type="primary">
         {{ t('copy') }}
       </CopyToClipboardButton>
-      <n-button text @click="downloadSvg">
+      <n-button
+        tag="a"
+        text
+        :href="downloadUrl ?? undefined"
+        :download="downloadName"
+        :disabled="!downloadUrl"
+      >
         <template #icon>
           <n-icon><ArrowDownload24Regular /></n-icon>
         </template>
@@ -34,6 +40,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import { NGrid, NGi, NStatistic, NSpace, NButton, NText, NIcon } from 'naive-ui'
 import { ArrowDownload24Regular } from '@shared/icons/fluent'
@@ -60,17 +67,9 @@ const savedPercent = computed(() => {
   return ((originalSize.value - optimizedSize.value) / originalSize.value) * 100
 })
 
-function downloadSvg() {
-  const blob = new Blob([props.optimizedSvg], { type: 'image/svg+xml' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = props.fileName.replace(/\.svg$/i, '') + '.optimized.svg'
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
-}
+const downloadBlob = computed(() => new Blob([props.optimizedSvg], { type: 'image/svg+xml' }))
+const downloadUrl = useObjectUrl(downloadBlob)
+const downloadName = computed(() => props.fileName.replace(/\.svg$/i, '') + '.optimized.svg')
 </script>
 
 <i18n lang="json">

--- a/tools/pdf/remove-pdf-owner-password/src/RemovePDFOwnerPasswordView.vue
+++ b/tools/pdf/remove-pdf-owner-password/src/RemovePDFOwnerPasswordView.vue
@@ -1,113 +1,161 @@
 <template>
   <ToolDefaultPageLayout :info="toolInfo">
     <PDFUpload @upload:file="handlePDFUpload" />
+    <ToolSection v-if="downloadUrl">
+      <n-flex justify="flex-end">
+        <n-button
+          tag="a"
+          type="primary"
+          :href="downloadUrl ?? undefined"
+          :download="downloadFilename"
+        >
+          <template #icon>
+            <n-icon :component="ArrowDownload16Regular" />
+          </template>
+          {{ t('download-file', { filename: downloadFilename }) }}
+        </n-button>
+      </n-flex>
+    </ToolSection>
     <WhatIsPDFOwnerPassword />
   </ToolDefaultPageLayout>
 </template>
 
 <script setup lang="ts">
 import * as toolInfo from './info'
+import { computed, ref } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
+import { NButton, NFlex, NIcon, useMessage } from 'naive-ui'
 import { PDFUpload } from '@shared/ui/domain/pdf'
-import { ToolDefaultPageLayout } from '@shared/ui/tool'
+import { ToolDefaultPageLayout, ToolSection } from '@shared/ui/tool'
 import WhatIsPDFOwnerPassword from './WhatIsPDFOwnerPassword.vue'
 import { removePDFOwnerPassword } from '@utils/pdf'
-import { useMessage } from 'naive-ui'
+import { ArrowDownload16Regular } from '@shared/icons/fluent'
 
 const message = useMessage()
 
 const { t } = useI18n()
 
-const handlePDFUpload = async (file: File) => {
-  const newBlob = await removePDFOwnerPassword(file)
-  const url = URL.createObjectURL(newBlob)
-  const aTag = document.createElement('a')
+const downloadBlob = ref<Blob | null>(null)
+const downloadName = ref<string>('')
+const downloadUrl = useObjectUrl(downloadBlob)
+const downloadFilename = computed(() => downloadName.value || 'output.pdf')
 
-  aTag.href = url
-  aTag.download = file.name
-  aTag.click()
-  URL.revokeObjectURL(url)
-  aTag.remove()
-  message.success(t('success'))
+const handlePDFUpload = async (file: File) => {
+  downloadBlob.value = null
+  downloadName.value = ''
+  try {
+    const newBlob = await removePDFOwnerPassword(file)
+    downloadBlob.value = newBlob
+    downloadName.value = file.name
+    message.success(t('success'))
+  } catch (e) {
+    message.error((e as Error).message)
+  }
 }
 </script>
 
 <i18n lang="json">
 {
   "en": {
-    "success": "PDF owner password removed"
+    "success": "PDF owner password removed",
+    "download-file": "Download {filename}"
   },
   "zh": {
-    "success": "PDF 权限密码已移除"
+    "success": "PDF 权限密码已移除",
+    "download-file": "下载 {filename}"
   },
   "zh-CN": {
-    "success": "PDF 权限密码已移除"
+    "success": "PDF 权限密码已移除",
+    "download-file": "下载 {filename}"
   },
   "zh-TW": {
-    "success": "PDF 權限密碼已移除"
+    "success": "PDF 權限密碼已移除",
+    "download-file": "下載 {filename}"
   },
   "zh-HK": {
-    "success": "PDF 權限密碼已移除"
+    "success": "PDF 權限密碼已移除",
+    "download-file": "下載 {filename}"
   },
   "es": {
-    "success": "Contraseña de propietario eliminada"
+    "success": "Contraseña de propietario eliminada",
+    "download-file": "Descargar {filename}"
   },
   "fr": {
-    "success": "Mot de passe propriétaire supprimé"
+    "success": "Mot de passe propriétaire supprimé",
+    "download-file": "Télécharger {filename}"
   },
   "de": {
-    "success": "PDF-Besitzerkennwort entfernt"
+    "success": "PDF-Besitzerkennwort entfernt",
+    "download-file": "{filename} herunterladen"
   },
   "it": {
-    "success": "Password proprietario PDF rimossa"
+    "success": "Password proprietario PDF rimossa",
+    "download-file": "Scarica {filename}"
   },
   "ja": {
-    "success": "PDFのオーナーパスワードを削除しました"
+    "success": "PDFのオーナーパスワードを削除しました",
+    "download-file": "{filename} をダウンロード"
   },
   "ko": {
-    "success": "PDF 소유자 비밀번호가 제거되었습니다"
+    "success": "PDF 소유자 비밀번호가 제거되었습니다",
+    "download-file": "{filename} 다운로드"
   },
   "ru": {
-    "success": "Пароль владельца PDF удалён"
+    "success": "Пароль владельца PDF удалён",
+    "download-file": "Скачать {filename}"
   },
   "pt": {
-    "success": "Senha de proprietário removida"
+    "success": "Senha de proprietário removida",
+    "download-file": "Baixar {filename}"
   },
   "ar": {
-    "success": "تمت إزالة كلمة مرور مالك PDF"
+    "success": "تمت إزالة كلمة مرور مالك PDF",
+    "download-file": "تنزيل {filename}"
   },
   "hi": {
-    "success": "PDF ओनर पासवर्ड हटा दिया गया"
+    "success": "PDF ओनर पासवर्ड हटा दिया गया",
+    "download-file": "{filename} डाउनलोड करें"
   },
   "tr": {
-    "success": "PDF sahip parolası kaldırıldı"
+    "success": "PDF sahip parolası kaldırıldı",
+    "download-file": "{filename}'yi indir"
   },
   "nl": {
-    "success": "PDF-eigenaarwachtwoord verwijderd"
+    "success": "PDF-eigenaarwachtwoord verwijderd",
+    "download-file": "{filename} downloaden"
   },
   "sv": {
-    "success": "Ägarens PDF-lösenord borttaget"
+    "success": "Ägarens PDF-lösenord borttaget",
+    "download-file": "Ladda ner {filename}"
   },
   "pl": {
-    "success": "Hasło właściciela PDF usunięte"
+    "success": "Hasło właściciela PDF usunięte",
+    "download-file": "Pobierz {filename}"
   },
   "vi": {
-    "success": "Đã xóa mật khẩu chủ sở hữu PDF"
+    "success": "Đã xóa mật khẩu chủ sở hữu PDF",
+    "download-file": "Tải xuống {filename}"
   },
   "th": {
-    "success": "ลบรหัสผ่านเจ้าของ PDF แล้ว"
+    "success": "ลบรหัสผ่านเจ้าของ PDF แล้ว",
+    "download-file": "ดาวน์โหลด {filename}"
   },
   "id": {
-    "success": "Kata sandi pemilik PDF telah dihapus"
+    "success": "Kata sandi pemilik PDF telah dihapus",
+    "download-file": "Unduh {filename}"
   },
   "he": {
-    "success": "הסיסמה של בעל ה-PDF הוסרה"
+    "success": "הסיסמה של בעל ה-PDF הוסרה",
+    "download-file": "הורד {filename}"
   },
   "ms": {
-    "success": "Kata laluan pemilik PDF telah dialih keluar"
+    "success": "Kata laluan pemilik PDF telah dialih keluar",
+    "download-file": "Muat turun {filename}"
   },
   "no": {
-    "success": "PDF-eierpassord fjernet"
+    "success": "PDF-eierpassord fjernet",
+    "download-file": "Last ned {filename}"
   }
 }
 </i18n>

--- a/tools/web/data-uri-to-file-converter/package.json
+++ b/tools/web/data-uri-to-file-converter/package.json
@@ -11,6 +11,7 @@
     "@shared/icons": "workspace:*",
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
+    "@vueuse/core": "catalog:",
     "mime": "catalog:",
     "naive-ui": "catalog:",
     "vue": "catalog:",

--- a/tools/web/data-uri-to-file-converter/src/components/DataUriToFileConverter.vue
+++ b/tools/web/data-uri-to-file-converter/src/components/DataUriToFileConverter.vue
@@ -38,7 +38,13 @@
 
       <ToolSection>
         <n-flex justify="flex-end">
-          <n-button type="primary" @click="downloadFile">
+          <n-button
+            tag="a"
+            type="primary"
+            :href="downloadUrl ?? undefined"
+            :download="downloadName"
+            :disabled="!downloadUrl"
+          >
             <template #icon>
               <n-icon :component="ArrowDownload16Regular" />
             </template>
@@ -82,6 +88,7 @@
 
 <script setup lang="ts">
 import { ref, watch, computed, onBeforeUnmount } from 'vue'
+import { useObjectUrl } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
 import {
   NInput,
@@ -114,6 +121,11 @@ const decodedBlob = ref<Blob | null>(null)
 const textPreview = ref<string>('')
 const error = ref<string>('')
 const previewUrl = ref<string>('')
+const downloadUrl = useObjectUrl(decodedBlob)
+const downloadName = computed(() => {
+  const name = fileName.value.trim()
+  return name || buildFileName(parsed.value?.mimeType || '')
+})
 
 const previewKind = computed(() => {
   if (!parsed.value) return null
@@ -306,20 +318,6 @@ function extractExtension(name: string): string {
   const dotIndex = trimmed.lastIndexOf('.')
   if (dotIndex <= 0 || dotIndex === trimmed.length - 1) return ''
   return trimmed.slice(dotIndex + 1)
-}
-
-function downloadFile() {
-  if (!decodedBlob.value) return
-
-  const name = fileName.value.trim() || buildFileName(parsed.value?.mimeType || '')
-  const url = URL.createObjectURL(decodedBlob.value)
-  const link = document.createElement('a')
-  link.href = url
-  link.download = name
-  document.body.appendChild(link)
-  link.click()
-  link.remove()
-  URL.revokeObjectURL(url)
 }
 
 function formatBytes(bytes: number): string {


### PR DESCRIPTION
## Summary
- switch download buttons to real anchor links backed by useObjectUrl across tools
- update favicon and PDF download flows to use link-based downloads
- record the download-button guideline in AGENTS.md and CLAUDE.md

## Testing
- pnpm lint-check
- pnpm type-check
- vitest related --run --project dom