### PR TITLE
docs(agents): note component splitting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@
 - Prettier: no semicolons, single quotes, `printWidth: 100`.
 - Use path aliases: `@shared/*`, `@tools/*`, `@utils/*`, `@registry/*`.
 - Tool packages follow `tools/<domain>/<tool-slug>/src` with `info.ts`, `routes.ts`, and a `*View.vue`.
+- Split tool UI logic into `components/`; keep the main `*View.vue` focused on layout and composition.
 - Download buttons must be real anchors: `n-button tag="a"` with `download` and `href` from `useObjectUrl`, and no `document.createElement('a')`.
 
 ## Tool Creation & Registration


### PR DESCRIPTION
## Summary
- add component-splitting guidance to AGENTS.md

## Testing
- not run (docs change)