### PR TITLE
chore(deps): migrate deps to pnpm catalog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,11 @@
 - `pnpm test:e2e`: Run Playwright E2E tests (requires `pnpm exec playwright install`).
 - `pnpm -F <package-name> <command>`: Run commands in a specific workspace package.
 
+## Dependency Management
+- Use pnpm catalogs for third-party dependencies; prefer `catalog:` specifiers in package.json.
+- Install new deps via `pnpm add --save-catalog <pkg>` (use `-F <package>` for workspace packages).
+- Keep `ua-parser-js` on v1 due to license constraints.
+
 ## Coding Style & Naming Conventions
 - TypeScript + Vue Composition API with `<script setup lang="ts">`.
 - Prettier: no semicolons, single quotes, `printWidth: 100`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,11 @@ pnpm -F <package-name> <command>           # Run in specific package
 pnpm -F @registry/tools add --workspace @tools/<name>  # Add tool to registry
 ```
 
+## Dependency Management
+- Use pnpm catalogs for third-party dependencies and keep `catalog:` specifiers in package.json.
+- Install new deps with `pnpm add --save-catalog <pkg>` (add `-F <package>` for workspace packages).
+- Keep `ua-parser-js` on v1 due to license constraints.
+
 ## Architecture Overview
 
 Vue 3 + TypeScript monorepo using pnpm workspaces. All tools run entirely client-side in the browser.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,15 @@ catalogs:
     '@jsquash/oxipng':
       specifier: ^2.3.0
       version: 2.3.0
+    '@noble/ed25519':
+      specifier: ^3.0.0
+      version: 3.0.0
+    '@paralleldrive/cuid2':
+      specifier: ^3.0.6
+      version: 3.0.6
+    '@peculiar/x509':
+      specifier: ^1.14.3
+      version: 1.14.3
     '@playwright/test':
       specifier: ^1.57.0
       version: 1.57.0
@@ -51,6 +60,9 @@ catalogs:
     '@types/emscripten':
       specifier: ^1.41.5
       version: 1.41.5
+    '@types/figlet':
+      specifier: ^1.7.0
+      version: 1.7.0
     '@types/jmespath':
       specifier: ^0.15.2
       version: 0.15.2
@@ -78,6 +90,9 @@ catalogs:
     '@types/turndown':
       specifier: ^5.0.6
       version: 5.0.6
+    '@types/ua-parser-js':
+      specifier: ^0.7.39
+      version: 0.7.39
     '@types/validator':
       specifier: ^13.15.10
       version: 13.15.10
@@ -195,12 +210,21 @@ catalogs:
     eslint-plugin-vue:
       specifier: ~10.7.0
       version: 10.7.0
+    exifr:
+      specifier: ^7.1.3
+      version: 7.1.3
+    figlet:
+      specifier: ^1.9.4
+      version: 1.9.4
     filesize:
       specifier: ^11.0.13
       version: 11.0.13
     github-markdown-css:
       specifier: ^5.8.1
       version: 5.8.1
+    gitignore:
+      specifier: github:github/gitignore
+      version: 0.0.0
     happy-dom:
       specifier: ^20.3.4
       version: 20.3.4
@@ -300,12 +324,18 @@ catalogs:
     svgo:
       specifier: ^4.0.0
       version: 4.0.0
+    transliteration:
+      specifier: ^2.6.0
+      version: 2.6.0
     turndown:
       specifier: ^7.2.2
       version: 7.2.2
     typescript:
       specifier: ~5.9.3
       version: 5.9.3
+    ua-parser-js:
+      specifier: ^1.0.39
+      version: 1.0.41
     ulid:
       specifier: ^3.0.2
       version: 3.0.2
@@ -1089,7 +1119,7 @@ importers:
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.27(typescript@5.9.3))
       gitignore:
-        specifier: github:github/gitignore
+        specifier: 'catalog:'
         version: https://codeload.github.com/github/gitignore/tar.gz/96a44720e8422b56fc195f442316a381bfc6db39
       naive-ui:
         specifier: 'catalog:'
@@ -2409,7 +2439,7 @@ importers:
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.27(typescript@5.9.3))
       exifr:
-        specifier: ^7.1.3
+        specifier: 'catalog:'
         version: 7.1.3
       filesize:
         specifier: 'catalog:'
@@ -2824,7 +2854,7 @@ importers:
   tools/network/certificate-public-key-parser:
     dependencies:
       '@peculiar/x509':
-        specifier: ^1.14.3
+        specifier: 'catalog:'
         version: 1.14.3
       '@shared/tools':
         specifier: workspace:*
@@ -3359,7 +3389,7 @@ importers:
   tools/network/ssh-key-generator:
     dependencies:
       '@noble/ed25519':
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.0.0
       '@shared/tools':
         specifier: workspace:*
@@ -3504,7 +3534,7 @@ importers:
   tools/random/cuid2-generator:
     dependencies:
       '@paralleldrive/cuid2':
-        specifier: ^3.0.6
+        specifier: 'catalog:'
         version: 3.0.6
       '@shared/tools':
         specifier: workspace:*
@@ -3666,7 +3696,7 @@ importers:
         specifier: 'catalog:'
         version: 14.1.0(vue@3.5.27(typescript@5.9.3))
       figlet:
-        specifier: ^1.9.4
+        specifier: 'catalog:'
         version: 1.9.4
       naive-ui:
         specifier: 'catalog:'
@@ -3679,7 +3709,7 @@ importers:
         version: 11.2.8(vue@3.5.27(typescript@5.9.3))
     devDependencies:
       '@types/figlet':
-        specifier: ^1.7.0
+        specifier: 'catalog:'
         version: 1.7.0
 
   tools/text/regex-tester-replacer:
@@ -4756,7 +4786,7 @@ importers:
         specifier: 'catalog:'
         version: 2.43.2(vue@3.5.27(typescript@5.9.3))
       transliteration:
-        specifier: ^2.6.0
+        specifier: 'catalog:'
         version: 2.6.0
       vue:
         specifier: 'catalog:'
@@ -4864,7 +4894,7 @@ importers:
         specifier: 'catalog:'
         version: 2.43.2(vue@3.5.27(typescript@5.9.3))
       ua-parser-js:
-        specifier: ^1.0.39
+        specifier: 'catalog:'
         version: 1.0.41
       vue:
         specifier: 'catalog:'
@@ -4874,7 +4904,7 @@ importers:
         version: 11.2.8(vue@3.5.27(typescript@5.9.3))
     devDependencies:
       '@types/ua-parser-js':
-        specifier: ^0.7.39
+        specifier: 'catalog:'
         version: 0.7.39
 
   utils/aes:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,53 +6,60 @@ packages:
   - shared/*
   - utils/*
   - registry/*
-
+onlyBuiltDependencies:
+  - esbuild
+  - vue-demi
 catalog:
-  '@commitlint/cli': ^20.3.1
-  '@commitlint/config-conventional': ^20.3.1
-  '@commitlint/types': ^20.3.1
-  '@faker-js/faker': ^10.2.0
-  '@guolao/vue-monaco-editor': ^1.6.0
-  '@intlify/eslint-plugin-vue-i18n': ^4.1.1
-  '@intlify/unplugin-vue-i18n': ^11.0.3
-  '@jspawn/qpdf-wasm': ^0.0.2
-  '@jsquash/oxipng': ^2.3.0
-  '@playwright/test': ^1.57.0
-  '@prettier/plugin-oxc': 0.1.3
-  '@tsconfig/node22': ^22.0.5
-  '@types/color-convert': ^2.0.4
-  '@types/crypto-js': ^4.2.2
-  '@types/emscripten': ^1.41.5
-  '@types/jmespath': ^0.15.2
-  '@types/js-yaml': ^4.0.9
-  '@types/jsdom': ^27.0.0
-  '@types/mime-db': ^1.43.6
-  '@types/node': ^25.0.9
-  '@types/papaparse': ^5.5.2
-  '@types/punycode': ^2.1.4
-  '@types/qrcode': ^1.5.6
-  '@types/turndown': ^5.0.6
-  '@types/validator': ^13.15.10
-  '@typescript-eslint/parser': ^8.53.1
-  '@unhead/vue': 2.1.2
-  '@vicons/antd': ^0.13.0
-  '@vicons/carbon': ^0.13.0
-  '@vicons/fa': ^0.13.0
-  '@vicons/fluent': ^0.13.0
-  '@vicons/ionicons4': ^0.13.0
-  '@vicons/ionicons5': ^0.13.0
-  '@vicons/material': ^0.13.0
-  '@vicons/tabler': ^0.13.0
-  '@vitejs/plugin-vue': ^6.0.3
-  '@vitest/coverage-istanbul': ^4.0.16
-  '@vitest/coverage-v8': ^4.0.17
-  '@vitest/eslint-plugin': ^1.6.6
-  '@vue/eslint-config-prettier': ^10.2.0
-  '@vue/eslint-config-typescript': ^14.6.0
-  '@vue/test-utils': ^2.4.6
-  '@vue/tsconfig': ^0.8.1
-  '@vueuse/core': 14.1.0
-  '@zip.js/zip.js': ^2.8.15
+  "@commitlint/cli": ^20.3.1
+  "@commitlint/config-conventional": ^20.3.1
+  "@commitlint/types": ^20.3.1
+  "@faker-js/faker": ^10.2.0
+  "@guolao/vue-monaco-editor": ^1.6.0
+  "@intlify/eslint-plugin-vue-i18n": ^4.1.1
+  "@intlify/unplugin-vue-i18n": ^11.0.3
+  "@jspawn/qpdf-wasm": ^0.0.2
+  "@jsquash/oxipng": ^2.3.0
+  "@noble/ed25519": ^3.0.0
+  "@paralleldrive/cuid2": ^3.0.6
+  "@peculiar/x509": ^1.14.3
+  "@playwright/test": ^1.57.0
+  "@prettier/plugin-oxc": 0.1.3
+  "@tsconfig/node22": ^22.0.5
+  "@types/color-convert": ^2.0.4
+  "@types/crypto-js": ^4.2.2
+  "@types/emscripten": ^1.41.5
+  "@types/figlet": ^1.7.0
+  "@types/jmespath": ^0.15.2
+  "@types/js-yaml": ^4.0.9
+  "@types/jsdom": ^27.0.0
+  "@types/mime-db": ^1.43.6
+  "@types/node": ^25.0.9
+  "@types/papaparse": ^5.5.2
+  "@types/punycode": ^2.1.4
+  "@types/qrcode": ^1.5.6
+  "@types/turndown": ^5.0.6
+  "@types/ua-parser-js": ^0.7.39
+  "@types/validator": ^13.15.10
+  "@typescript-eslint/parser": ^8.53.1
+  "@unhead/vue": 2.1.2
+  "@vicons/antd": ^0.13.0
+  "@vicons/carbon": ^0.13.0
+  "@vicons/fa": ^0.13.0
+  "@vicons/fluent": ^0.13.0
+  "@vicons/ionicons4": ^0.13.0
+  "@vicons/ionicons5": ^0.13.0
+  "@vicons/material": ^0.13.0
+  "@vicons/tabler": ^0.13.0
+  "@vitejs/plugin-vue": ^6.0.3
+  "@vitest/coverage-istanbul": ^4.0.16
+  "@vitest/coverage-v8": ^4.0.17
+  "@vitest/eslint-plugin": ^1.6.6
+  "@vue/eslint-config-prettier": ^10.2.0
+  "@vue/eslint-config-typescript": ^14.6.0
+  "@vue/test-utils": ^2.4.6
+  "@vue/tsconfig": ^0.8.1
+  "@vueuse/core": 14.1.0
+  "@zip.js/zip.js": ^2.8.15
   ajv: ^8.17.1
   ajv-formats: ^3.0.1
   bcrypt-ts: ^8.0.0
@@ -74,8 +81,11 @@ catalog:
   eslint-plugin-oxlint: ~1.41.0
   eslint-plugin-playwright: ^2.5.0
   eslint-plugin-vue: ~10.7.0
+  exifr: ^7.1.3
+  figlet: ^1.9.4
   filesize: ^11.0.13
   github-markdown-css: ^5.8.1
+  gitignore: "github:github/gitignore"
   happy-dom: ^20.3.4
   highlight.js: 11.11.1
   hono: ^4.11.4
@@ -109,8 +119,10 @@ catalog:
   sitemap: ^9.0.0
   smol-toml: ^1.6.0
   svgo: ^4.0.0
+  transliteration: ^2.6.0
   turndown: ^7.2.2
   typescript: ~5.9.3
+  ua-parser-js: ^1.0.39
   ulid: ^3.0.2
   uuid: ^13.0.0
   validator: ^13.15.26
@@ -129,7 +141,3 @@ catalog:
   wrangler: 4.59.2
   xml-js: ^1.6.11
   xxhash-wasm: ^1.1.0
-
-onlyBuiltDependencies:
-  - esbuild
-  - vue-demi

--- a/tools/code/gitignore-generator/package.json
+++ b/tools/code/gitignore-generator/package.json
@@ -14,7 +14,7 @@
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
     "@vueuse/core": "catalog:",
-    "gitignore": "github:github/gitignore",
+    "gitignore": "catalog:",
     "naive-ui": "catalog:",
     "vue": "catalog:",
     "vue-i18n": "catalog:"

--- a/tools/image/exif-viewer/package.json
+++ b/tools/image/exif-viewer/package.json
@@ -12,7 +12,7 @@
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
     "@vueuse/core": "catalog:",
-    "exifr": "^7.1.3",
+    "exifr": "catalog:",
     "filesize": "catalog:",
     "naive-ui": "catalog:",
     "vue": "catalog:",

--- a/tools/network/certificate-public-key-parser/package.json
+++ b/tools/network/certificate-public-key-parser/package.json
@@ -8,7 +8,7 @@
     "./routes": "./src/routes.ts"
   },
   "dependencies": {
-    "@peculiar/x509": "^1.14.3",
+    "@peculiar/x509": "catalog:",
     "@vicons/fluent": "catalog:",
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",

--- a/tools/network/ssh-key-generator/package.json
+++ b/tools/network/ssh-key-generator/package.json
@@ -8,7 +8,7 @@
     "./routes": "./src/routes.ts"
   },
   "dependencies": {
-    "@noble/ed25519": "^3.0.0",
+    "@noble/ed25519": "catalog:",
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
     "@vicons/fluent": "catalog:",

--- a/tools/random/cuid2-generator/package.json
+++ b/tools/random/cuid2-generator/package.json
@@ -9,7 +9,7 @@
     "./routes": "./src/routes.ts"
   },
   "dependencies": {
-    "@paralleldrive/cuid2": "^3.0.6",
+    "@paralleldrive/cuid2": "catalog:",
     "@vicons/fluent": "catalog:",
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",

--- a/tools/text/ascii-art-generator/package.json
+++ b/tools/text/ascii-art-generator/package.json
@@ -12,12 +12,12 @@
     "@shared/tools": "workspace:*",
     "@shared/ui": "workspace:*",
     "@vueuse/core": "catalog:",
-    "figlet": "^1.9.4",
+    "figlet": "catalog:",
     "naive-ui": "catalog:",
     "vue": "catalog:",
     "vue-i18n": "catalog:"
   },
   "devDependencies": {
-    "@types/figlet": "^1.7.0"
+    "@types/figlet": "catalog:"
   }
 }

--- a/tools/web/slug-generator/package.json
+++ b/tools/web/slug-generator/package.json
@@ -13,7 +13,7 @@
     "@shared/ui": "workspace:*",
     "@vueuse/core": "catalog:",
     "naive-ui": "catalog:",
-    "transliteration": "^2.6.0",
+    "transliteration": "catalog:",
     "vue": "catalog:",
     "vue-i18n": "catalog:"
   }

--- a/tools/web/user-agent-parser/package.json
+++ b/tools/web/user-agent-parser/package.json
@@ -14,11 +14,11 @@
     "@vueuse/core": "catalog:",
     "highlight.js": "catalog:",
     "naive-ui": "catalog:",
-    "ua-parser-js": "^1.0.39",
+    "ua-parser-js": "catalog:",
     "vue": "catalog:",
     "vue-i18n": "catalog:"
   },
   "devDependencies": {
-    "@types/ua-parser-js": "^0.7.39"
+    "@types/ua-parser-js": "catalog:"
   }
 }


### PR DESCRIPTION
## Summary
- migrate third-party deps to pnpm catalog entries and update package.json specs
- add catalog guidance to AGENTS.md and CLAUDE.md, including keeping ua-parser-js on v1
- add gitignore catalog entry for GitHub dependency

## Testing
- pnpm format-check
- pnpm lint-check
- pnpm type-check
- pnpm build
- pnpm test:unit