### PR TITLE
chore(tools): use monospace for docker run input

### DIFF
--- a/tools/code/docker-run-to-compose/src/components/DockerRunToCompose.vue
+++ b/tools/code/docker-run-to-compose/src/components/DockerRunToCompose.vue
@@ -123,6 +123,10 @@ function clearInput(): void {
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;
 }
+
+:deep(.n-form-item-label__text) {
+  width: 100%;
+}
 </style>
 
 <i18n lang="json">


### PR DESCRIPTION
## Summary
- style docker run input textarea with monospace font

## Testing
- not run