### PR TITLE
chore(lint): use vue flat recommended

### DIFF
--- a/apps/web/src/components/search/search-auto-complete/SearchAutoComplete.vue
+++ b/apps/web/src/components/search/search-auto-complete/SearchAutoComplete.vue
@@ -9,9 +9,9 @@
     :placeholder="t('searchPlaceholder')"
     clear-after-select
     :render-label="renderLabel"
-    @select="handleSearch"
     :menu-props="{ class: 'page-search-auto-complete-menu' }"
     role="search"
+    @select="handleSearch"
   />
 </template>
 

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -33,7 +33,7 @@ export default defineConfigWithVueTs(
 
   globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
 
-  pluginVue.configs['flat/essential'],
+  pluginVue.configs['flat/recommended'],
   vueTsConfigs.recommended,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ...(vueI18n.configs.recommended as unknown as any),
@@ -105,6 +105,15 @@ export default defineConfigWithVueTs(
     files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
     rules: {
       'max-lines': 'off',
+    },
+  },
+  {
+    name: 'app/vue-tests',
+    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
+    rules: {
+      'vue/one-component-per-file': 'off',
+      'vue/require-prop-types': 'off',
+      'vue/require-default-prop': 'off',
     },
   },
   {

--- a/shared/ui/src/components/base/buttons/CopyToClipboardButton.vue
+++ b/shared/ui/src/components/base/buttons/CopyToClipboardButton.vue
@@ -1,11 +1,11 @@
 <template>
   <n-button
-    @click="onClick"
     :text="variant === 'text'"
     :tertiary="variant === 'tertiary'"
     :secondary="variant === 'secondary'"
     :quaternary="variant === 'quaternary'"
     :disabled="disabled"
+    @click="onClick"
   >
     <template #icon>
       <slot name="icon">

--- a/shared/ui/src/components/base/buttons/RegenerateButton.vue
+++ b/shared/ui/src/components/base/buttons/RegenerateButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-button @click="emit('click')" text>
+  <n-button text @click="emit('click')">
     <template #icon>
       <slot name="icon">
         <n-icon :component="Icon" />

--- a/shared/ui/src/components/base/input/text-or-file/TextOrFileInput.vue
+++ b/shared/ui/src/components/base/input/text-or-file/TextOrFileInput.vue
@@ -28,10 +28,10 @@
 
     <n-divider v-if="!selectedFile && !textValue">{{ t('or') }}</n-divider>
     <n-upload
-      @before-upload="beforeUpload"
+      v-if="!textValue"
       :show-file-list="false"
       :accept="accept"
-      v-if="!textValue"
+      @before-upload="beforeUpload"
     >
       <n-upload-dragger>
         <div style="margin-bottom: 12px">
@@ -53,7 +53,7 @@
     </n-upload>
 
     <div v-if="selectedFile" class="file-actions">
-      <n-button @click="clearFile" type="error" size="small">
+      <n-button type="error" size="small" @click="clearFile">
         {{ t('clear-file') }}
       </n-button>
     </div>
@@ -92,6 +92,11 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   accept: '*',
+  placeholder: undefined,
+  label: undefined,
+  status: undefined,
+  validationStatus: undefined,
+  feedback: undefined,
   showFeedback: false,
   wrapWithFormItem: true,
 })

--- a/shared/ui/src/components/base/link/CustomRouterLink.vue
+++ b/shared/ui/src/components/base/link/CustomRouterLink.vue
@@ -1,8 +1,8 @@
 <template>
   <router-link
+    v-slot="{ navigate, href }"
     v-bind="props"
     :to="localizedPath"
-    v-slot="{ navigate, href }"
     @mouseenter.passive="prefetch"
     @touchstart.passive="prefetch"
   >

--- a/shared/ui/src/components/base/markdown/MarkdownArticle.vue
+++ b/shared/ui/src/components/base/markdown/MarkdownArticle.vue
@@ -1,6 +1,7 @@
 <template>
   <n-el>
-    <p v-html="markdownHtml" class="markdown"></p>
+    <!-- eslint-disable-next-line vue/no-v-html -->
+    <p class="markdown" v-html="markdownHtml"></p>
   </n-el>
 </template>
 

--- a/shared/ui/src/components/domain/ip/info/IPInfo.vue
+++ b/shared/ui/src/components/domain/ip/info/IPInfo.vue
@@ -1,24 +1,24 @@
 <template>
   <n-descriptions label-placement="left" bordered :column="1" content-style="width: 100%">
     <n-descriptions-item :label="t('ip-address')">
-      <CopyToClipboardTooltip :content="ip" #="{ copy }" v-if="ip">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="ip" :content="ip" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ ip }}
         </span>
       </CopyToClipboardTooltip>
       <IPInfoDataLoadingUnknown :data="ip" />
     </n-descriptions-item>
     <n-descriptions-item :label="t('hostname')">
-      <CopyToClipboardTooltip :content="info.hostname" #="{ copy }" v-if="info.hostname">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.hostname" :content="info.hostname" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.hostname }}
         </span>
       </CopyToClipboardTooltip>
       <IPInfoDataLoadingUnknown :data="info.hostname" />
     </n-descriptions-item>
     <n-descriptions-item label-style="white-space: nowrap" :label="t('isp')">
-      <CopyToClipboardTooltip :content="info.isp" #="{ copy }" v-if="info.isp">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.isp" :content="info.isp" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.isp }}
         </span>
       </CopyToClipboardTooltip>
@@ -26,8 +26,8 @@
     </n-descriptions-item>
 
     <n-descriptions-item label-style="white-space: nowrap" :label="t('ip-organization')">
-      <CopyToClipboardTooltip :content="info.organization" #="{ copy }" v-if="info.organization">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.organization" :content="info.organization" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.organization }}
         </span>
       </CopyToClipboardTooltip>
@@ -35,8 +35,8 @@
     </n-descriptions-item>
 
     <n-descriptions-item :label="t('asn')">
-      <CopyToClipboardTooltip :content="info.asn" #="{ copy }" v-if="info.asn">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.asn" :content="info.asn" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.asn }}
         </span>
       </CopyToClipboardTooltip>
@@ -45,11 +45,11 @@
 
     <n-descriptions-item label-style="white-space: nowrap" :label="t('asn-organization')">
       <CopyToClipboardTooltip
+        v-if="info.asn_organization"
         :content="info.asn_organization"
         #="{ copy }"
-        v-if="info.asn_organization"
       >
-        <span @click="copy" class="cursor-pointer">
+        <span class="cursor-pointer" @click="copy">
           {{ info.asn_organization }}
         </span>
       </CopyToClipboardTooltip>
@@ -66,8 +66,8 @@
     </n-descriptions-item>
 
     <n-descriptions-item :label="t('country')">
-      <CopyToClipboardTooltip :content="info.country" #="{ copy }" v-if="info.country">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.country" :content="info.country" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.country }}
         </span>
       </CopyToClipboardTooltip>
@@ -75,8 +75,8 @@
     </n-descriptions-item>
 
     <n-descriptions-item :label="t('timezone')">
-      <CopyToClipboardTooltip :content="info.timezone" #="{ copy }" v-if="info.timezone">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="info.timezone" :content="info.timezone" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ info.timezone }}
         </span>
       </CopyToClipboardTooltip>

--- a/shared/ui/src/components/domain/ip/info/IPInfoDataLoadingUnknown.vue
+++ b/shared/ui/src/components/domain/ip/info/IPInfoDataLoadingUnknown.vue
@@ -1,6 +1,6 @@
 <template>
-  <n-skeleton text style="width: 10em" v-if="data === undefined" />
-  <n-tag :bordered="false" size="small" type="error" v-if="data === null">{{ t('unknown') }}</n-tag>
+  <n-skeleton v-if="data === undefined" text style="width: 10em" />
+  <n-tag v-if="data === null" :bordered="false" size="small" type="error">{{ t('unknown') }}</n-tag>
 </template>
 
 <script setup lang="ts">

--- a/shared/ui/src/components/domain/ip/input/IPAddressSearchInput.vue
+++ b/shared/ui/src/components/domain/ip/input/IPAddressSearchInput.vue
@@ -1,14 +1,14 @@
 <template>
   <n-input-group>
-    <n-input :placeholder="t('placeholder')" v-model:value="value" @keydown.enter="goToIPInfo" />
+    <n-input v-model:value="value" :placeholder="t('placeholder')" @keydown.enter="goToIPInfo" />
     <n-button
       ghost
-      @click="goToIPInfo"
       tag="a"
       v-bind="{
         ...(href && { href: href }),
       }"
       :disabled="ipDomain === ''"
+      @click="goToIPInfo"
     >
       <template #icon>
         <n-icon>

--- a/shared/ui/src/components/domain/pdf/PDFUpload.vue
+++ b/shared/ui/src/components/domain/pdf/PDFUpload.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-upload @before-upload="beforeUpload" accept="application/pdf">
+  <n-upload accept="application/pdf" @before-upload="beforeUpload">
     <n-upload-dragger>
       <div style="margin-bottom: 12px">
         <n-icon size="48" :depth="3">

--- a/shared/ui/src/components/domain/uuid/UUIDInput.vue
+++ b/shared/ui/src/components/domain/uuid/UUIDInput.vue
@@ -4,7 +4,7 @@
     :placeholder="placeholder ?? uuidv4()"
     :status="validated ? undefined : 'error'"
   >
-    <template #suffix v-if="showRandom ?? true">
+    <template v-if="showRandom ?? true" #suffix>
       <n-icon style="cursor: pointer" :component="RefreshOutline" @click="uuidRef = uuidv4()" />
     </template>
   </n-input>

--- a/shared/ui/src/components/layouts/nav/menus/NavMenusCollapsed.vue
+++ b/shared/ui/src/components/layouts/nav/menus/NavMenusCollapsed.vue
@@ -3,11 +3,11 @@
     <AirplaneModeToggle />
     <LanguageMenuIcon />
     <n-popover
+      v-model:show="show"
       style="padding: 0; width: 288px"
       placement="bottom-end"
       display-directive="show"
       trigger="click"
-      v-model:show="show"
     >
       <template #trigger>
         <n-icon size="22" class="menu-icon">

--- a/shared/ui/src/components/layouts/nav/menus/sub-menus/AirplaneModeToggle.vue
+++ b/shared/ui/src/components/layouts/nav/menus/sub-menus/AirplaneModeToggle.vue
@@ -9,8 +9,8 @@
             ? t('airplane-mode-enabled')
             : t('airplane-mode-disabled')
         "
-        @click="airplaneModeStore.toggleAirplaneMode"
         :type="airplaneModeStore.isAirplaneMode ? 'warning' : 'tertiary'"
+        @click="airplaneModeStore.toggleAirplaneMode"
       >
         <template #icon>
           <n-icon>

--- a/shared/ui/src/components/layouts/nav/menus/sub-menus/LanguageMenuIcon.vue
+++ b/shared/ui/src/components/layouts/nav/menus/sub-menus/LanguageMenuIcon.vue
@@ -1,10 +1,10 @@
 <template>
   <n-popselect
     :value="language ?? 'auto'"
-    @update:value="handleUpdateValue"
     :options="options"
     trigger="click"
     scrollable
+    @update:value="handleUpdateValue"
   >
     <n-button quaternary circle :aria-label="t('language-selector')">
       <template #icon>

--- a/shared/ui/src/components/tool/grid/RelatedTools.vue
+++ b/shared/ui/src/components/tool/grid/RelatedTools.vue
@@ -1,7 +1,7 @@
 <template>
   <ToolSectionHeader v-if="!noRelatedTools">{{ t('related-tools') }}</ToolSectionHeader>
   <ToolSection>
-    <ToolsGrid :tools="relatedTools" v-if="!noRelatedTools" />
+    <ToolsGrid v-if="!noRelatedTools" :tools="relatedTools" />
   </ToolSection>
 </template>
 

--- a/shared/ui/src/components/tool/grid/ToolThing.vue
+++ b/shared/ui/src/components/tool/grid/ToolThing.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- eslint-disable @intlify/vue-i18n/no-missing-keys -->
-  <CustomRouterLink :to="path" class="tool-link" v-if="!props.tool.external">
+  <CustomRouterLink v-if="!props.tool.external" :to="path" class="tool-link">
     <n-thing>
       <template v-if="showIcon" #avatar>
         <n-avatar>
@@ -15,7 +15,7 @@
       </template>
     </n-thing>
   </CustomRouterLink>
-  <a :href="path" class="tool-link" v-else>
+  <a v-else :href="path" class="tool-link">
     <n-thing>
       <template v-if="showIcon" #avatar>
         <n-avatar>

--- a/shared/ui/src/components/tool/layouts/ToolDefaultPageLayout.vue
+++ b/shared/ui/src/components/tool/layouts/ToolDefaultPageLayout.vue
@@ -17,7 +17,7 @@
     <slot />
 
     <slot name="related-tools">
-      <RelatedTools :tool="info" v-if="!hideRelatedTools" />
+      <RelatedTools v-if="!hideRelatedTools" :tool="info" />
     </slot>
   </div>
 </template>

--- a/tools/code/csv-to-json-converter/src/components/CsvToJsonConverter.vue
+++ b/tools/code/csv-to-json-converter/src/components/CsvToJsonConverter.vue
@@ -1,6 +1,6 @@
 <template>
   <CsvToJsonToolbar
-    v-model:showSettings="showSettings"
+    v-model:show-settings="showSettings"
     :rendered-json="renderedJson"
     :download-url="downloadUrl ?? undefined"
     @import="importFromFile"
@@ -10,29 +10,29 @@
     <n-form label-placement="left" :show-feedback="false">
       <CsvToJsonSettingsBasics
         v-model:noheader="noheader"
-        v-model:headersText="headersText"
+        v-model:headers-text="headersText"
         v-model:delimiter="delimiter"
         v-model:quote="quote"
         v-model:trim="trim"
-        v-model:checkType="checkType"
-        v-model:skipEmpty="skipEmpty"
-        v-model:escapeChar="escapeChar"
+        v-model:check-type="checkType"
+        v-model:skip-empty="skipEmpty"
+        v-model:escape-char="escapeChar"
         v-model:newline="newline"
       />
       <CsvToJsonSettingsAdvanced
         v-model:preview="preview"
         v-model:comments="comments"
-        v-model:fastMode="fastMode"
-        v-model:skipFirstNLines="skipFirstNLines"
-        v-model:delimitersToGuessText="delimitersToGuessText"
-        v-model:includeColumns="includeColumns"
-        v-model:ignoreColumns="ignoreColumns"
+        v-model:fast-mode="fastMode"
+        v-model:skip-first-n-lines="skipFirstNLines"
+        v-model:delimiters-to-guess-text="delimitersToGuessText"
+        v-model:include-columns="includeColumns"
+        v-model:ignore-columns="ignoreColumns"
         v-model:spaces="spaces"
       />
     </n-form>
   </n-collapse-transition>
 
-  <CsvToJsonEditor v-model:csvText="csvText" :rendered-json="renderedJson" />
+  <CsvToJsonEditor v-model:csv-text="csvText" :rendered-json="renderedJson" />
 </template>
 
 <script setup lang="ts">

--- a/tools/code/csv-to-json-converter/src/components/CsvToJsonToolbar.vue
+++ b/tools/code/csv-to-json-converter/src/components/CsvToJsonToolbar.vue
@@ -2,14 +2,14 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="emit('import')" text>
+        <n-button text @click="emit('import')">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>
           {{ t('import-from-file') }}
         </n-button>
 
-        <n-button @click="toggleSettings" text>
+        <n-button text @click="toggleSettings">
           <template #icon>
             <n-icon :component="Settings16Regular" />
           </template>

--- a/tools/code/jmespath-tester/src/components/JmesPathInputs.vue
+++ b/tools/code/jmespath-tester/src/components/JmesPathInputs.vue
@@ -7,13 +7,13 @@
           <n-flex align="center" justify="space-between" class="field-label">
             <span>{{ t('jsonLabel') }}</span>
             <n-flex align="center" :size="8" class="field-action">
-              <n-button @click="importFromFile" text>
+              <n-button text @click="importFromFile">
                 <template #icon>
                   <n-icon :component="Document16Regular" />
                 </template>
                 {{ t('import-from-file') }}
               </n-button>
-              <n-button @click="formatJson" text>
+              <n-button text @click="formatJson">
                 <template #icon>
                   <n-icon :component="TextNumberFormat20Regular" />
                 </template>

--- a/tools/code/json-formatter/src/components/JsonFormatter.vue
+++ b/tools/code/json-formatter/src/components/JsonFormatter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/json-to-csv-converter/src/components/JsonToCsvConverter.vue
+++ b/tools/code/json-to-csv-converter/src/components/JsonToCsvConverter.vue
@@ -2,13 +2,13 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>
           {{ t('import-from-file') }}
         </n-button>
-        <n-button @click="showSettings = !showSettings" text>
+        <n-button text @click="showSettings = !showSettings">
           <template #icon>
             <n-icon :component="Settings16Regular" />
           </template>

--- a/tools/code/json-to-toml-converter/src/components/JsonToTomlConverter.vue
+++ b/tools/code/json-to-toml-converter/src/components/JsonToTomlConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/json-to-xml-converter/src/components/JsonToXmlConverter.vue
+++ b/tools/code/json-to-xml-converter/src/components/JsonToXmlConverter.vue
@@ -29,7 +29,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/json-to-yaml-converter/src/components/JsonToYamlBuilder.vue
+++ b/tools/code/json-to-yaml-converter/src/components/JsonToYamlBuilder.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/jsonpath-tester/src/components/JsonPathInputs.vue
+++ b/tools/code/jsonpath-tester/src/components/JsonPathInputs.vue
@@ -7,13 +7,13 @@
           <n-flex align="center" justify="space-between" class="field-label">
             <span>{{ t('jsonLabel') }}</span>
             <n-flex align="center" :size="8" class="field-action">
-              <n-button @click="importFromFile" text>
+              <n-button text @click="importFromFile">
                 <template #icon>
                   <n-icon :component="Document16Regular" />
                 </template>
                 {{ t('import-from-file') }}
               </n-button>
-              <n-button @click="formatJson" text>
+              <n-button text @click="formatJson">
                 <template #icon>
                   <n-icon :component="TextNumberFormat20Regular" />
                 </template>

--- a/tools/code/openapi-to-typescript/src/components/OpenApiImportUrlModal.vue
+++ b/tools/code/openapi-to-typescript/src/components/OpenApiImportUrlModal.vue
@@ -34,7 +34,7 @@
     </n-space>
     <template #footer>
       <n-flex justify="end" :wrap="false">
-        <n-button @click="onClose" :disabled="isImporting">
+        <n-button :disabled="isImporting" @click="onClose">
           {{ t('importUrlCancel') }}
         </n-button>
         <n-button type="primary" :loading="isImporting" @click="onConfirm">

--- a/tools/code/openapi-to-typescript/src/components/OpenApiToolbar.vue
+++ b/tools/code/openapi-to-typescript/src/components/OpenApiToolbar.vue
@@ -2,19 +2,19 @@
   <ToolSection>
     <n-flex align="center" justify="space-between" wrap>
       <n-flex align="center" wrap>
-        <n-button @click="emit('import')" text>
+        <n-button text @click="emit('import')">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>
           {{ t('actionsImport') }}
         </n-button>
-        <n-button @click="emit('import-url')" text>
+        <n-button text @click="emit('import-url')">
           <template #icon>
             <n-icon :component="Link16Regular" />
           </template>
           {{ t('actionsImportUrl') }}
         </n-button>
-        <n-button @click="emit('load-sample')" text>
+        <n-button text @click="emit('load-sample')">
           <template #icon>
             <n-icon :component="Wand16Regular" />
           </template>

--- a/tools/code/prettier-code-formatter/src/components/PrettierInputOutput.vue
+++ b/tools/code/prettier-code-formatter/src/components/PrettierInputOutput.vue
@@ -2,8 +2,8 @@
   <n-grid cols="1 s:2" responsive="screen" :x-gap="12" :y-gap="12">
     <n-form-item-gi :label="t('input-code')" :show-feedback="false">
       <n-input
-        class="code-input"
         v-model:value="sourceCode"
+        class="code-input"
         type="textarea"
         :autosize="{ minRows: 10, maxRows: 24 }"
         :placeholder="t('input-placeholder')"

--- a/tools/code/prettier-code-formatter/src/components/PrettierToolbar.vue
+++ b/tools/code/prettier-code-formatter/src/components/PrettierToolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <n-flex align="center" justify="space-between" wrap>
     <n-flex align="center" wrap>
-      <n-button @click="emitImport" text>
+      <n-button text @click="emitImport">
         <template #icon>
           <n-icon :component="Document16Regular" />
         </template>

--- a/tools/code/toml-to-json-converter/src/components/TomlToJsonConverter.vue
+++ b/tools/code/toml-to-json-converter/src/components/TomlToJsonConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/toml-to-yaml-converter/src/components/TomlToYamlConverter.vue
+++ b/tools/code/toml-to-yaml-converter/src/components/TomlToYamlConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/xml-to-json-converter/src/components/XmlToJsonToolbar.vue
+++ b/tools/code/xml-to-json-converter/src/components/XmlToJsonToolbar.vue
@@ -1,7 +1,7 @@
 <template>
   <n-flex align="center" justify="space-between">
     <n-flex align="center">
-      <n-button @click="emitImport" text>
+      <n-button text @click="emitImport">
         <template #icon>
           <n-icon :component="Document16Regular" />
         </template>

--- a/tools/code/yaml-to-json-converter/src/components/YamlToJsonConverter.vue
+++ b/tools/code/yaml-to-json-converter/src/components/YamlToJsonConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/code/yaml-to-toml-converter/src/components/YamlToTomlConverter.vue
+++ b/tools/code/yaml-to-toml-converter/src/components/YamlToTomlConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/document/html-to-markdown-converter/src/components/HtmlToMarkdownConverter.vue
+++ b/tools/document/html-to-markdown-converter/src/components/HtmlToMarkdownConverter.vue
@@ -2,7 +2,7 @@
   <ToolSection>
     <n-flex align="center" justify="space-between">
       <n-flex align="center">
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>

--- a/tools/document/markdown-previewer/src/components/MarkdownPreviewerControls.vue
+++ b/tools/document/markdown-previewer/src/components/MarkdownPreviewerControls.vue
@@ -20,7 +20,7 @@
         <n-text depth="3">{{ t('theme') }}</n-text>
         <n-select v-model:value="theme" :options="themeOptions" size="small" style="width: 140px" />
       </n-flex>
-      <n-button @click="emitImport" text>
+      <n-button text @click="emitImport">
         <template #icon>
           <n-icon :component="Document16Regular" />
         </template>
@@ -40,7 +40,7 @@
         </template>
         {{ t('download-html') }}
       </n-button>
-      <n-button @click="emitPrint" text>
+      <n-button text @click="emitPrint">
         <template #icon>
           <n-icon :component="Print20Regular" />
         </template>

--- a/tools/document/markdown-previewer/src/components/MarkdownPreviewerPanels.vue
+++ b/tools/document/markdown-previewer/src/components/MarkdownPreviewerPanels.vue
@@ -11,8 +11,9 @@
     <n-form-item-gi :label="t('preview')" :show-feedback="false">
       <n-flex :wrap="true" :size="12" align="start" class="preview-row">
         <n-card size="small" class="preview-card">
-          <component :is="'style'" :textContent="scopedMarkdownCss" />
+          <component :is="'style'" :text-content="scopedMarkdownCss" />
           <div :class="markdownScopeClass">
+            <!-- eslint-disable-next-line vue/no-v-html -->
             <article class="markdown-body" v-html="renderedHtml"></article>
           </div>
         </n-card>

--- a/tools/document/markdown-to-html-converter/src/components/MarkdownToHtmlConverter.vue
+++ b/tools/document/markdown-to-html-converter/src/components/MarkdownToHtmlConverter.vue
@@ -4,7 +4,7 @@
       <n-flex align="center">
         <n-switch v-model:value="sanitize" size="small"></n-switch>
         <span>{{ t('sanitize-html') }}</span>
-        <n-button @click="importFromFile" text>
+        <n-button text @click="importFromFile">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>
@@ -20,7 +20,7 @@
           </template>
           {{ t('download-html') }}
         </n-button>
-        <n-button @click="printHtml" text>
+        <n-button text @click="printHtml">
           <template #icon>
             <n-icon :component="Print20Regular" />
           </template>
@@ -43,6 +43,7 @@
         <n-card size="small">
           <n-code :code="renderedHtml" language="html" :hljs="hljs" word-wrap></n-code>
           <n-divider></n-divider>
+          <!-- eslint-disable-next-line vue/no-v-html -->
           <article :class="$style['markdown-body']" v-html="renderedHtml"></article>
         </n-card>
       </n-form-item-gi>

--- a/tools/document/text-diff/src/components/TextDiff.vue
+++ b/tools/document/text-diff/src/components/TextDiff.vue
@@ -2,19 +2,19 @@
   <ToolSection>
     <n-flex justify="space-between" align="center" :wrap="false">
       <n-flex align="center" :size="8">
-        <n-button @click="importOriginal" text>
+        <n-button text @click="importOriginal">
           <template #icon>
             <n-icon :component="Document16Regular" />
           </template>
           {{ t('import-original') }}
         </n-button>
-        <n-button @click="importModified" text>
+        <n-button text @click="importModified">
           <template #icon>
             <n-icon :component="DocumentAdd16Regular" />
           </template>
           {{ t('import-modified') }}
         </n-button>
-        <n-button @click="swapTexts" text>
+        <n-button text @click="swapTexts">
           <template #icon>
             <n-icon :component="ArrowSwap20Regular" />
           </template>

--- a/tools/favicon/favicon-assets-generator/src/components/FaviconGenerator.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/FaviconGenerator.vue
@@ -2,16 +2,16 @@
   <SelectFile v-model:image="image" />
   <GeneralInfo v-model:options="generalInfoOptions" />
   <DesktopBrowser
-    :image="image"
     v-model:options="desktopOptions"
+    :image="image"
     :general-info-options="generalInfoOptions"
   />
   <iOSWebClip
-    :image="image"
     v-model:options="iosOptions"
+    :image="image"
     :general-info-options="generalInfoOptions"
   />
-  <PWA :image="image" v-model:options="pwaOptions" :general-info-options="generalInfoOptions" />
+  <PWA v-model:options="pwaOptions" :image="image" :general-info-options="generalInfoOptions" />
   <GenerateAssets
     :image="image"
     :ios-web-clip-options="iosOptions"

--- a/tools/favicon/favicon-assets-generator/src/components/ImageUpload.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/ImageUpload.vue
@@ -1,5 +1,5 @@
 <template>
-  <n-upload @before-upload="beforeUpload" accept="image/*">
+  <n-upload accept="image/*" @before-upload="beforeUpload">
     <n-upload-dragger>
       <div style="margin-bottom: 12px">
         <n-icon size="48" :depth="3">

--- a/tools/favicon/favicon-assets-generator/src/components/desktop-browser/ChromeTabPreview.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/desktop-browser/ChromeTabPreview.vue
@@ -6,7 +6,7 @@
       '--chrome-tab-preview-tab-height': height + 'px',
     }"
   >
-    <img :src="chromeTabURL" class="chrome-tab-image" ref="tab" alt="Chrome Tab" />
+    <img ref="tab" :src="chromeTabURL" class="chrome-tab-image" alt="Chrome Tab" />
     <DesktopBrowserImage :image="image" :options="options" class="icon" />
     <div
       class="site-name"

--- a/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserPreview.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserPreview.vue
@@ -3,19 +3,19 @@
     <GoogleSearchResult
       :image="image"
       :options="options"
-      :generalInfoOptions="generalInfoOptions"
+      :general-info-options="generalInfoOptions"
     />
     <n-divider />
     <ChromeTabPreview
       :image="image"
       :options="options"
-      :generalInfoOptions="generalInfoOptions"
+      :general-info-options="generalInfoOptions"
       :dark="false"
     />
     <ChromeTabPreview
       :image="image"
       :options="options"
-      :generalInfoOptions="generalInfoOptions"
+      :general-info-options="generalInfoOptions"
       :dark="true"
     />
     <ChromeTabDarkNote v-if="image?.type === 'image/svg+xml'" />

--- a/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserSettingsDisplay.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/desktop-browser/DesktopBrowserSettingsDisplay.vue
@@ -11,9 +11,9 @@
     <n-collapse-transition :show="options.background">
       <n-form-item :label="t('backgroundColor')">
         <n-color-picker
+          v-model:value="options.backgroundColor"
           :show-alpha="false"
           :show-preview="true"
-          v-model:value="options.backgroundColor"
         />
       </n-form-item>
 

--- a/tools/favicon/favicon-assets-generator/src/components/general-info/GeneralInfoThemeColors.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/general-info/GeneralInfoThemeColors.vue
@@ -2,9 +2,9 @@
   <n-grid-item :span="2">
     <n-form-item :label="t('themeColor')">
       <n-color-picker
+        v-model:value="options.theme_color"
         :show-alpha="false"
         :show-preview="true"
-        v-model:value="options.theme_color"
       />
     </n-form-item>
   </n-grid-item>
@@ -28,20 +28,20 @@
       <n-checkbox v-model:checked="options.theme_color_dark_enabled" style="margin-right: 0.7em" />
       <span v-show="!options.theme_color_dark_enabled">{{ t('disabled') }}</span>
       <n-color-picker
+        v-show="options.theme_color_dark_enabled"
+        v-model:value="options.theme_color_dark"
         :show-alpha="false"
         :show-preview="true"
-        v-model:value="options.theme_color_dark"
         :disabled="!options.theme_color_dark_enabled"
-        v-show="options.theme_color_dark_enabled"
       />
     </n-form-item>
   </n-grid-item>
   <n-grid-item :span="2">
     <n-form-item :label="t('backgroundColor')">
       <n-color-picker
+        v-model:value="options.background_color"
         :show-alpha="false"
         :show-preview="true"
-        v-model:value="options.background_color"
       />
     </n-form-item>
   </n-grid-item>

--- a/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClip.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClip.vue
@@ -9,7 +9,7 @@
       <iOSWebClipPreview :image="image" :options="options" :name="generalInfoOptions.short_name" />
     </n-grid-item>
     <n-grid-item span="5 s:3">
-      <iOSWebClipSettings :image="image" v-model:options="options" />
+      <iOSWebClipSettings v-model:options="options" :image="image" />
     </n-grid-item>
   </n-grid>
 </template>

--- a/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClipPreview.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClipPreview.vue
@@ -7,9 +7,9 @@
     }"
   >
     <img
+      ref="iosHomescreenBackground"
       :src="PreviewBackground"
       class="background"
-      ref="iosHomescreenBackground"
       alt="iOS Homescreen Background"
     />
     <div class="icon-container">

--- a/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClipSettingsDisplay.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/ios-web-clip/iOSWebClipSettingsDisplay.vue
@@ -1,9 +1,9 @@
 <template>
   <n-form-item :label="t('backgroundColor')">
     <n-color-picker
+      v-model:value="options.backgroundColor"
       :show-alpha="false"
       :show-preview="true"
-      v-model:value="options.backgroundColor"
     />
   </n-form-item>
   <n-form-item :label="t('margin')">

--- a/tools/favicon/favicon-assets-generator/src/components/pwa/PWA.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/pwa/PWA.vue
@@ -28,7 +28,7 @@
       <PWAPreview :image="image" :options="options" :general-info-options="generalInfoOptions" />
     </n-grid-item>
     <n-grid-item span="5 s:3">
-      <PWASettings :image="image" v-model:options="options" />
+      <PWASettings v-model:options="options" :image="image" />
     </n-grid-item>
   </n-grid>
   <n-h3 prefix="bar" align-text>
@@ -45,7 +45,7 @@
       />
     </n-grid-item>
     <n-grid-item span="5 s:3">
-      <PWAMaskableSettings :image="image" v-model:options="options" />
+      <PWAMaskableSettings v-model:options="options" :image="image" />
     </n-grid-item>
   </n-grid>
 </template>

--- a/tools/favicon/favicon-assets-generator/src/components/pwa/any/PWASettingsDisplay.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/pwa/any/PWASettingsDisplay.vue
@@ -6,9 +6,9 @@
   <n-collapse-transition :show="options.background">
     <n-form-item :label="t('backgroundColor')">
       <n-color-picker
+        v-model:value="options.backgroundColor"
         :show-alpha="false"
         :show-preview="true"
-        v-model:value="options.backgroundColor"
       />
     </n-form-item>
 

--- a/tools/favicon/favicon-assets-generator/src/components/pwa/maskable/PWAMaskableSettingsDisplay.vue
+++ b/tools/favicon/favicon-assets-generator/src/components/pwa/maskable/PWAMaskableSettingsDisplay.vue
@@ -1,9 +1,9 @@
 <template>
   <n-form-item :label="t('backgroundColor')">
     <n-color-picker
+      v-model:value="options.maskableBackgroundColor"
       :show-alpha="false"
       :show-preview="true"
-      v-model:value="options.maskableBackgroundColor"
     />
   </n-form-item>
   <n-form-item :label="t('margin')">

--- a/tools/hash/bcrypt-hash-password/src/BcryptHashPasswordView.vue
+++ b/tools/hash/bcrypt-hash-password/src/BcryptHashPasswordView.vue
@@ -25,9 +25,9 @@
       <CopyToClipboardTooltip :content="result" #="{ copy }">
         <n-text
           code
-          @click="copy"
           class="bcrypt-result"
           :class="{ 'bcrypt-result-processing': processing }"
+          @click="copy"
         >
           {{ result }}
         </n-text>

--- a/tools/hash/crc-checksum-calculator/src/CRCChecksumCalculatorView.vue
+++ b/tools/hash/crc-checksum-calculator/src/CRCChecksumCalculatorView.vue
@@ -8,17 +8,17 @@
       {{ t('crc-result') }}
     </ToolSectionHeader>
     <ToolSection v-show="textOrFile">
-      <n-grid cols="1 400:2 800:4 1200:5" v-if="crcResults">
+      <n-grid v-if="crcResults" cols="1 400:2 800:4 1200:5">
         <n-grid-item v-for="result in crcResults" :key="result.name">
           <n-text>
             <n-text strong>{{ result.name }}: </n-text>
             <CopyToClipboardTooltip :content="result.crc" #="{ copy }">
               <n-text
                 code
-                @click="copy"
                 style="cursor: pointer"
                 class="crc-result"
                 :class="{ processing: processing }"
+                @click="copy"
               >
                 {{ result.crc }}
               </n-text>

--- a/tools/hash/hash-text-or-file-template/src/components/HashTextOrFileTemplate.vue
+++ b/tools/hash/hash-text-or-file-template/src/components/HashTextOrFileTemplate.vue
@@ -8,9 +8,9 @@
   </ToolSectionHeader>
   <ToolSection>
     <HashResult
+      v-show="textOrFile"
       :hash="props.hash"
       :content="textOrFile"
-      v-show="textOrFile"
       :hide-hex="props.hideHex"
       :hide-base64="props.hideBase64"
       :hide-binary="props.hideBinary"

--- a/tools/hash/hmac-generator/src/components/HmacForm.vue
+++ b/tools/hash/hmac-generator/src/components/HmacForm.vue
@@ -4,18 +4,18 @@
     <n-form-item :label="t('secret-key')">
       <n-input
         :value="secretKey"
-        @update:value="$emit('update:secretKey', $event)"
         :placeholder="t('secret-key-placeholder')"
         type="password"
         show-password-on="click"
         :input-props="{ autocomplete: 'off' }"
+        @update:value="$emit('update:secretKey', $event)"
       />
     </n-form-item>
     <n-form-item :label="t('algorithm')" :show-feedback="false">
       <n-select
         :value="algorithm"
-        @update:value="$emit('update:algorithm', $event)"
         :options="ALGORITHM_OPTIONS"
+        @update:value="$emit('update:algorithm', $event)"
       />
     </n-form-item>
   </ToolSection>

--- a/tools/hash/sri-hash-generator/src/SRIHashGeneratorView.vue
+++ b/tools/hash/sri-hash-generator/src/SRIHashGeneratorView.vue
@@ -9,11 +9,11 @@
     </ToolSectionHeader>
     <ToolSection v-show="textOrFile">
       <n-descriptions
+        v-if="sri"
         label-placement="left"
         bordered
         :column="1"
         content-style="width: 100%"
-        v-if="sri"
       >
         <n-descriptions-item>
           <template #label>
@@ -23,8 +23,8 @@
             <n-text
               code
               class="hash-result"
-              @click="copy"
               :class="{ 'hash-result-evaluating': processing }"
+              @click="copy"
               >{{ sri.sha256 }}</n-text
             >
           </CopyToClipboardTooltip>
@@ -38,8 +38,8 @@
             <n-text
               code
               class="hash-result"
-              @click="copy"
               :class="{ 'hash-result-evaluating': processing }"
+              @click="copy"
               >{{ sri.sha384 }}</n-text
             >
           </CopyToClipboardTooltip>
@@ -53,8 +53,8 @@
             <n-text
               code
               class="hash-result"
-              @click="copy"
               :class="{ 'hash-result-evaluating': processing }"
+              @click="copy"
               >{{ sri.sha512 }}</n-text
             >
           </CopyToClipboardTooltip>

--- a/tools/image/image-to-ico/src/components/ConversionOptions.vue
+++ b/tools/image/image-to-ico/src/components/ConversionOptions.vue
@@ -45,8 +45,8 @@
         type="primary"
         :loading="isConverting"
         :disabled="!canConvert"
-        @click="$emit('convert')"
         style="margin-top: 12px"
+        @click="$emit('convert')"
       >
         <template #icon>
           <n-icon><Wand16Regular /></n-icon>

--- a/tools/image/png-optimizer/src/components/FileUpload.vue
+++ b/tools/image/png-optimizer/src/components/FileUpload.vue
@@ -3,7 +3,7 @@
     <ToolSectionHeader>{{ t('uploadImage') }}</ToolSectionHeader>
 
     <template v-if="!file">
-      <n-upload @before-upload="handleBeforeUpload" accept=".png,image/png">
+      <n-upload accept=".png,image/png" @before-upload="handleBeforeUpload">
         <n-upload-dragger>
           <div style="margin-bottom: 12px">
             <n-icon size="48" :depth="3">

--- a/tools/image/png-optimizer/src/components/OptimizationOptions.vue
+++ b/tools/image/png-optimizer/src/components/OptimizationOptions.vue
@@ -21,7 +21,7 @@
         </n-checkbox>
       </n-flex>
 
-      <n-button @click="handleOptimize" :loading="isOptimizing" :disabled="isOptimizing">
+      <n-button :loading="isOptimizing" :disabled="isOptimizing" @click="handleOptimize">
         <template #icon>
           <n-icon><ResizeSmall20Regular /></n-icon>
         </template>

--- a/tools/misc/roman-numeral-converter/src/components/ArabicNumberInput.vue
+++ b/tools/misc/roman-numeral-converter/src/components/ArabicNumberInput.vue
@@ -3,10 +3,10 @@
   <ToolSection>
     <n-form-item :show-label="false">
       <n-input-number
+        v-model:value="value"
         :min="1"
         :max="3999"
         style="width: 100%"
-        v-model:value="value"
         :placeholder="t('arabicPlaceholder')"
         size="large"
       />

--- a/tools/network/cidr-parser/src/components/CIDRParseResult.vue
+++ b/tools/network/cidr-parser/src/components/CIDRParseResult.vue
@@ -1,52 +1,52 @@
 <template>
   <n-descriptions
+    v-if="parsed !== undefined"
     label-placement="left"
     bordered
     :column="1"
     content-style="width: 100%"
     label-style="white-space: nowrap"
-    v-if="parsed !== undefined"
   >
     <n-descriptions-item :label="t('ipVersion')"> IPv{{ parsed.version }} </n-descriptions-item>
     <n-descriptions-item :label="t('startIP')">
-      <CopyToClipboardTooltip :content="startIP" #="{ copy }" v-if="startIP">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="startIP" :content="startIP" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ startIP }}
         </span>
       </CopyToClipboardTooltip>
     </n-descriptions-item>
     <n-descriptions-item :label="t('startIPInteger')">
-      <CopyToClipboardTooltip :content="startIPInt" #="{ copy }" v-if="startIPInt">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="startIPInt" :content="startIPInt" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ startIPInt }}
         </span>
       </CopyToClipboardTooltip>
     </n-descriptions-item>
     <n-descriptions-item :label="t('endIP')">
-      <CopyToClipboardTooltip :content="endIP" #="{ copy }" v-if="endIP">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="endIP" :content="endIP" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ endIP }}
         </span>
       </CopyToClipboardTooltip>
     </n-descriptions-item>
     <n-descriptions-item :label="t('endIPInteger')">
-      <CopyToClipboardTooltip :content="endIPInt" #="{ copy }" v-if="endIPInt">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="endIPInt" :content="endIPInt" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ endIPInt }}
         </span>
       </CopyToClipboardTooltip>
     </n-descriptions-item>
     <n-descriptions-item :label="t('numberOfIPs')">
-      <CopyToClipboardTooltip :content="IPSize" #="{ copy }" v-if="IPSize">
-        <span @click="copy" class="cursor-pointer">
+      <CopyToClipboardTooltip v-if="IPSize" :content="IPSize" #="{ copy }">
+        <span class="cursor-pointer" @click="copy">
           {{ IPSize }}
         </span>
       </CopyToClipboardTooltip>
     </n-descriptions-item>
 
-    <n-descriptions-item :label="t('netmask')" v-if="netmask">
+    <n-descriptions-item v-if="netmask" :label="t('netmask')">
       <CopyToClipboardTooltip :content="netmask" #="{ copy }">
-        <span @click="copy" class="cursor-pointer">
+        <span class="cursor-pointer" @click="copy">
           {{ netmask }}
         </span>
       </CopyToClipboardTooltip>

--- a/tools/network/cidrs-merger-excluder/src/components/CIDRMergerExcluder.vue
+++ b/tools/network/cidrs-merger-excluder/src/components/CIDRMergerExcluder.vue
@@ -8,9 +8,9 @@
   >
     <ToolSectionHeader>{{ t('mergeAndExcludeResult') }}</ToolSectionHeader>
     <CIDRsMergeExcludeResult
-      :cidrsToMerge="cidrsToMerge"
-      :cidrsToExclude="cidrsToExclude"
       v-if="cidrsToMerge && cidrsToExclude"
+      :cidrs-to-merge="cidrsToMerge"
+      :cidrs-to-exclude="cidrsToExclude"
     />
   </template>
 </template>

--- a/tools/network/dns-lookup/src/components/DNSLookup.vue
+++ b/tools/network/dns-lookup/src/components/DNSLookup.vue
@@ -2,7 +2,7 @@
   <DNSQuery @update:results="results = $event" />
 
   <n-p v-for="result in results" :key="result.question.type">
-    <DNSResult :result="result.result" v-if="result.result" :title="result.question.type" />
+    <DNSResult v-if="result.result" :result="result.result" :title="result.question.type" />
   </n-p>
 </template>
 

--- a/tools/network/dns-lookup/src/components/query/DNSQuery.vue
+++ b/tools/network/dns-lookup/src/components/query/DNSQuery.vue
@@ -5,7 +5,7 @@
   <DNSRecordTypeInputFormItem v-model:types="recordTypes" />
   <DOHServerSelectFormItem v-model:value="dohServer" />
 
-  <n-button @click="lookup" round :loading="loading">
+  <n-button round :loading="loading" @click="lookup">
     <template #icon>
       <n-icon>
         <DocumentSearch16Regular />

--- a/tools/network/ip-cidr-normalizer/src/components/IPCIDRNormalizedResult.vue
+++ b/tools/network/ip-cidr-normalizer/src/components/IPCIDRNormalizedResult.vue
@@ -1,6 +1,6 @@
 <template>
   <CopyToClipboardTooltip :content="normalized" #="{ copy }">
-    <n-text @click="copy" code style="font-size: 1.5em; cursor: pointer">{{ normalized }}</n-text>
+    <n-text code style="font-size: 1.5em; cursor: pointer" @click="copy">{{ normalized }}</n-text>
   </CopyToClipboardTooltip>
 </template>
 

--- a/tools/network/ip-info-lookup/src/IPInfoView.vue
+++ b/tools/network/ip-info-lookup/src/IPInfoView.vue
@@ -16,7 +16,7 @@
       </template>
 
       <template v-else>
-        <n-collapse display-directive="show" v-model:expanded-names="expandedNames">
+        <n-collapse v-model:expanded-names="expandedNames" display-directive="show">
           <n-collapse-item v-for="ip in ips" :key="ip" :title="ip" :name="ip">
             <template #header-extra>
               <IPVersionTag :ip="ip" />

--- a/tools/network/ip-range-to-cidr/src/components/IPRangeInput.vue
+++ b/tools/network/ip-range-to-cidr/src/components/IPRangeInput.vue
@@ -1,6 +1,6 @@
 <template>
   <n-form-item :label="t('ipRange')" :rule="rule" :show-label="false">
-    <n-input pair separator="-" :placeholder="placeholderText" clearable v-model:value="ipRange" />
+    <n-input v-model:value="ipRange" pair separator="-" :placeholder="placeholderText" clearable />
   </n-form-item>
 </template>
 

--- a/tools/network/ip-range-to-cidr/src/components/IPRangeToCIDR.vue
+++ b/tools/network/ip-range-to-cidr/src/components/IPRangeToCIDR.vue
@@ -2,14 +2,14 @@
   <ToolSectionHeader>{{ t('ipRange') }}</ToolSectionHeader>
 
   <ToolSection>
-    <IPRangeInput @update:ipRange="ipRange = $event" />
+    <IPRangeInput @update:ip-range="ipRange = $event" />
   </ToolSection>
 
   <template v-if="ipRange[0] !== '' && ipRange[1] !== ''">
     <ToolSectionHeader>{{ t('cidrResult') }}</ToolSectionHeader>
 
     <ToolSection>
-      <IPRangeCIDRResult :ipRange="ipRange" />
+      <IPRangeCIDRResult :ip-range="ipRange" />
     </ToolSection>
   </template>
 </template>

--- a/tools/network/ipv6-to-mac/src/components/IPv6ToMAC.vue
+++ b/tools/network/ipv6-to-mac/src/components/IPv6ToMAC.vue
@@ -1,7 +1,7 @@
 <template>
   <ToolSectionHeader>{{ t('ipv6Address') }}</ToolSectionHeader>
   <ToolSection>
-    <IPv6Input @update:ipv6="ipv6 = $event" :ipv6="ipv6" />
+    <IPv6Input :ipv6="ipv6" @update:ipv6="ipv6 = $event" />
   </ToolSection>
   <template v-if="ipv6 !== ''">
     <ToolSectionHeader>{{ t('macAddress') }}</ToolSectionHeader>

--- a/tools/network/mac-to-ipv6-link-local/src/components/MACToIPv6LinkLocal.vue
+++ b/tools/network/mac-to-ipv6-link-local/src/components/MACToIPv6LinkLocal.vue
@@ -2,13 +2,13 @@
   <ToolSectionHeader>{{ t('macAddress') }}</ToolSectionHeader>
   <MACInput
     :mac="mac"
-    :networkInterface="networkInterface"
+    :network-interface="networkInterface"
     @update:mac="mac = $event"
-    @update:networkInterface="networkInterface = $event"
+    @update:network-interface="networkInterface = $event"
   />
   <template v-if="mac !== ''">
     <ToolSectionHeader>{{ t('ipv6LinkLocalAddress') }}</ToolSectionHeader>
-    <IPv6LinkLocalResult :mac="mac" :networkInterface="networkInterface" />
+    <IPv6LinkLocalResult :mac="mac" :network-interface="networkInterface" />
   </template>
 </template>
 

--- a/tools/network/mime-type-lookup/src/components/MimeTypeSearch.vue
+++ b/tools/network/mime-type-lookup/src/components/MimeTypeSearch.vue
@@ -7,9 +7,16 @@
     </NInput>
     <NRadioGroup v-model:value="category">
       <NRadioButton value="all">{{ t('all') }}</NRadioButton>
-      <NRadioButton v-for="category in categories" :key="category" :value="category">
-        <CategoryIcon :category="category" style="margin-right: 4px; vertical-align: -0.15em" />
-        <CategoryI18n :category="category" />
+      <NRadioButton
+        v-for="categoryOption in categories"
+        :key="categoryOption"
+        :value="categoryOption"
+      >
+        <CategoryIcon
+          :category="categoryOption"
+          style="margin-right: 4px; vertical-align: -0.15em"
+        />
+        <CategoryI18n :category="categoryOption" />
       </NRadioButton>
     </NRadioGroup>
   </NFlex>

--- a/tools/network/reverse-ip-lookup/src/components/ReverseIPLookup.vue
+++ b/tools/network/reverse-ip-lookup/src/components/ReverseIPLookup.vue
@@ -1,7 +1,7 @@
 <template>
   <DNSQuery @update:result="result = $event" />
 
-  <DNSResult :result="result" v-if="result" />
+  <DNSResult v-if="result" :result="result" />
 </template>
 
 <script lang="ts" setup>

--- a/tools/network/reverse-ip-lookup/src/components/query/DNSQuery.vue
+++ b/tools/network/reverse-ip-lookup/src/components/query/DNSQuery.vue
@@ -4,7 +4,7 @@
   <IPInputFormItem v-model:ip="ip" />
   <DOHServerSelectFormItem v-model:value="dohServer" />
 
-  <n-button @click="lookup" round :loading="loading">
+  <n-button round :loading="loading" @click="lookup">
     <template #icon>
       <n-icon>
         <DocumentSearch16Regular />

--- a/tools/random/bip39-mnemonic-generator/src/components/Bip39MnemonicGenerator.vue
+++ b/tools/random/bip39-mnemonic-generator/src/components/Bip39MnemonicGenerator.vue
@@ -2,12 +2,12 @@
   <n-grid cols="1 l:2" responsive="screen" :x-gap="24" :y-gap="24">
     <n-gi>
       <Bip39MnemonicOptions
-        v-model:activeTab="activeTab"
+        v-model:active-tab="activeTab"
         v-model:wordlist="wordlist"
-        v-model:wordCount="wordCount"
-        v-model:validationMnemonic="validationMnemonic"
-        v-model:entropyInput="entropyInput"
-        v-model:convertMnemonic="convertMnemonic"
+        v-model:word-count="wordCount"
+        v-model:validation-mnemonic="validationMnemonic"
+        v-model:entropy-input="entropyInput"
+        v-model:convert-mnemonic="convertMnemonic"
         :wordlist-options="wordlistOptions"
         :word-count-options="wordCountOptions"
         :strength-bits="strengthBits"

--- a/tools/random/ksuid-generator/src/components/KsuidGenerator.vue
+++ b/tools/random/ksuid-generator/src/components/KsuidGenerator.vue
@@ -1,9 +1,9 @@
 <template>
   <KsuidGeneratorOptions
     v-model:count="count"
-    v-model:timestampMode="timestampMode"
-    v-model:customDateMs="customDateMs"
-    v-model:customUnixSeconds="customUnixSeconds"
+    v-model:timestamp-mode="timestampMode"
+    v-model:custom-date-ms="customDateMs"
+    v-model:custom-unix-seconds="customUnixSeconds"
     :max-count="maxCount"
     :min-unix-seconds="minUnixSeconds"
     :max-unix-seconds="maxUnixSeconds"

--- a/tools/random/nanoid-generator/src/components/NanoidGenerator.vue
+++ b/tools/random/nanoid-generator/src/components/NanoidGenerator.vue
@@ -2,8 +2,8 @@
   <NanoidGeneratorOptions
     v-model:count="count"
     v-model:length="length"
-    v-model:alphabetPreset="alphabetPreset"
-    v-model:customAlphabet="customAlphabet"
+    v-model:alphabet-preset="alphabetPreset"
+    v-model:custom-alphabet="customAlphabet"
     :max-count="maxCount"
     :max-length="maxLength"
     :alphabet-error="alphabetError"

--- a/tools/random/random-number-generator/src/components/RandomNumberGeneratorFullscreen.vue
+++ b/tools/random/random-number-generator/src/components/RandomNumberGeneratorFullscreen.vue
@@ -13,8 +13,8 @@
     <n-flex class="fullscreen-actions" align="center" :size="12">
       <RegenerateButton
         :disabled="!canRoll && !isRolling"
-        @click="emit('toggle-rolling')"
         data-testid="fullscreen-regenerate"
+        @click="emit('toggle-rolling')"
       >
         <template #icon>
           <n-icon :component="rollingIcon" />
@@ -23,7 +23,7 @@
           {{ rollingLabel }}
         </template>
       </RegenerateButton>
-      <n-button text @click="emit('close')" data-testid="exit-fullscreen">
+      <n-button text data-testid="exit-fullscreen" @click="emit('close')">
         <template #icon>
           <n-icon :component="ExitFullscreenIcon" />
         </template>

--- a/tools/random/random-number-generator/src/components/RandomNumberGeneratorHistory.vue
+++ b/tools/random/random-number-generator/src/components/RandomNumberGeneratorHistory.vue
@@ -7,8 +7,8 @@
           text
           size="small"
           :disabled="!hasHistory"
-          @click="emit('clear-history')"
           data-testid="clear-history"
+          @click="emit('clear-history')"
         >
           {{ t('clearHistory') }}
         </n-button>

--- a/tools/random/random-number-generator/src/components/RandomNumberGeneratorPresets.vue
+++ b/tools/random/random-number-generator/src/components/RandomNumberGeneratorPresets.vue
@@ -1,16 +1,16 @@
 <template>
   <n-flex align="center" :size="12" wrap>
     <n-text depth="3">{{ t('presets') }}</n-text>
-    <n-button size="small" @click="emit('apply-preset', 'dice')" data-testid="preset-dice">
+    <n-button size="small" data-testid="preset-dice" @click="emit('apply-preset', 'dice')">
       {{ t('presetDice') }}
     </n-button>
-    <n-button size="small" @click="emit('apply-preset', 'ten')" data-testid="preset-ten">
+    <n-button size="small" data-testid="preset-ten" @click="emit('apply-preset', 'ten')">
       {{ t('presetTen') }}
     </n-button>
-    <n-button size="small" @click="emit('apply-preset', 'hundred')" data-testid="preset-hundred">
+    <n-button size="small" data-testid="preset-hundred" @click="emit('apply-preset', 'hundred')">
       {{ t('presetHundred') }}
     </n-button>
-    <n-button size="small" @click="emit('apply-preset', 'lotto')" data-testid="preset-lotto">
+    <n-button size="small" data-testid="preset-lotto" @click="emit('apply-preset', 'lotto')">
       {{ t('presetLotto') }}
     </n-button>
   </n-flex>

--- a/tools/random/random-number-generator/src/components/RandomNumberGeneratorResults.vue
+++ b/tools/random/random-number-generator/src/components/RandomNumberGeneratorResults.vue
@@ -26,8 +26,8 @@
       <n-flex :size="12">
         <RegenerateButton
           :disabled="!canRoll && !isRolling"
-          @click="emit('toggle-rolling')"
           data-testid="regenerate"
+          @click="emit('toggle-rolling')"
         >
           <template #icon>
             <n-icon :component="rollingIcon" />
@@ -53,8 +53,8 @@
         <n-button
           text
           :disabled="!hasResults"
-          @click="openFullscreen"
           data-testid="enter-fullscreen"
+          @click="openFullscreen"
         >
           <template #icon>
             <n-icon :component="EnterFullscreenIcon" />

--- a/tools/text/regex-tester-replacer/src/components/RegexInputs.vue
+++ b/tools/text/regex-tester-replacer/src/components/RegexInputs.vue
@@ -40,7 +40,7 @@
         <n-form-item :label="t('options-title')" :show-feedback="false">
           <n-flex align="center" :size="12" wrap>
             <n-switch v-model:value="autoRun">{{ t('auto-run') }}</n-switch>
-            <n-button @click="handleRun" :disabled="autoRun">
+            <n-button :disabled="autoRun" @click="handleRun">
               {{ t('run') }}
             </n-button>
           </n-flex>
@@ -69,16 +69,24 @@ import {
 } from 'naive-ui'
 import { TextOrFileInput } from '@shared/ui/base'
 import { ToolSection, ToolSectionHeader } from '@shared/ui/tool'
+import { toRefs } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { messages } from './locale/regex-tester-replacer-messages'
 
 const { t } = useI18n({ messages })
 
-const { patternStatus, patternError, flagOptions } = defineProps<{
-  patternStatus?: 'success' | 'error'
-  patternError: string
-  flagOptions: string[]
-}>()
+const props = withDefaults(
+  defineProps<{
+    patternStatus?: 'success' | 'error'
+    patternError: string
+    flagOptions: string[]
+  }>(),
+  {
+    patternStatus: undefined,
+  },
+)
+
+const { patternStatus, patternError, flagOptions } = toRefs(props)
 
 const emit = defineEmits<{ (event: 'run'): void }>()
 

--- a/tools/text/regex-tester-replacer/src/components/RegexResults.vue
+++ b/tools/text/regex-tester-replacer/src/components/RegexResults.vue
@@ -18,6 +18,7 @@
         <n-tab-pane name="preview" :tab="t('preview-title')">
           <n-card size="small" class="preview-card">
             <n-scrollbar class="preview-scroll">
+              <!-- eslint-disable-next-line vue/no-v-html -->
               <div v-if="previewText" class="preview-text" v-html="previewHtml" />
               <n-text v-else depth="3">{{ t('preview-empty') }}</n-text>
             </n-scrollbar>

--- a/tools/time/current-network-time/src/CurrentNetworkTimeView.vue
+++ b/tools/time/current-network-time/src/CurrentNetworkTimeView.vue
@@ -15,7 +15,7 @@
         <div style="position: relative">
           <n-time class="network-time" :time="networkTime ?? localTime" format="HH:mm:ss" />
           <Transition name="fade" mode="out-in">
-            <div style="position: absolute; top: 8px; right: 8px" v-if="status === 'syncing'">
+            <div v-if="status === 'syncing'" style="position: absolute; top: 8px; right: 8px">
               <n-badge dot processing type="warning" />
               {{ t('syncing') }}
             </div>
@@ -30,12 +30,12 @@
             <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
             {{ Math.round(offset) }} ms (±{{ Math.round(roundTripTimeMs) }} ms)
           </span>
-          <n-skeleton text style="width: 10em" v-else />
+          <n-skeleton v-else text style="width: 10em" />
         </n-text>
         <n-text depth="3">
           <span>{{ t('lastSyncedAt') }}: </span>
           <span v-if="lastSyncAt > 0">{{ new Date(lastSyncAt).toLocaleTimeString() }}</span>
-          <n-skeleton text style="width: 5em" v-else />
+          <n-skeleton v-else text style="width: 5em" />
         </n-text>
       </n-flex>
     </ToolSection>

--- a/tools/time/ical-event-generator/src/components/IcalEventDateTimeSection.vue
+++ b/tools/time/ical-event-generator/src/components/IcalEventDateTimeSection.vue
@@ -2,14 +2,14 @@
   <ToolSectionHeader>{{ t('date-time') }}</ToolSectionHeader>
   <ToolSection>
     <IcalEventDateTimeSettingsSection
-      v-model:isAllDay="isAllDayModel"
-      v-model:timeZone="timeZoneModel"
-      v-model:outputMode="outputModeModel"
+      v-model:is-all-day="isAllDayModel"
+      v-model:time-zone="timeZoneModel"
+      v-model:output-mode="outputModeModel"
       :time-zone-options="timeZoneOptions"
       :offset-label="offsetLabel"
     />
     <IcalEventDateTimeRangeSection
-      v-model:dateRange="dateRangeModel"
+      v-model:date-range="dateRangeModel"
       :is-all-day="isAllDayModel"
       :range-error-key="rangeErrorKey"
     />

--- a/tools/time/ical-event-generator/src/components/IcalEventGenerator.vue
+++ b/tools/time/ical-event-generator/src/components/IcalEventGenerator.vue
@@ -10,31 +10,31 @@
         @regenerate-uid="regenerateUid"
       />
       <IcalEventDateTimeSection
-        v-model:isAllDay="isAllDay"
-        v-model:timeZone="timeZone"
-        v-model:outputMode="outputMode"
-        v-model:dateRange="dateRange"
+        v-model:is-all-day="isAllDay"
+        v-model:time-zone="timeZone"
+        v-model:output-mode="outputMode"
+        v-model:date-range="dateRange"
         :time-zone-options="timeZoneOptions"
         :offset-label="offsetLabel"
         :range-error-key="rangeErrorKey || undefined"
       />
       <IcalEventRecurrenceSection
-        v-model:recurrenceFrequency="recurrenceFrequency"
-        v-model:recurrenceInterval="recurrenceInterval"
-        v-model:recurrenceWeekdays="recurrenceWeekdays"
-        v-model:recurrenceMonthDay="recurrenceMonthDay"
-        v-model:recurrenceMonth="recurrenceMonth"
-        v-model:recurrenceEndMode="recurrenceEndMode"
-        v-model:recurrenceCount="recurrenceCount"
-        v-model:recurrenceUntilInput="recurrenceUntilInput"
+        v-model:recurrence-frequency="recurrenceFrequency"
+        v-model:recurrence-interval="recurrenceInterval"
+        v-model:recurrence-weekdays="recurrenceWeekdays"
+        v-model:recurrence-month-day="recurrenceMonthDay"
+        v-model:recurrence-month="recurrenceMonth"
+        v-model:recurrence-end-mode="recurrenceEndMode"
+        v-model:recurrence-count="recurrenceCount"
+        v-model:recurrence-until-input="recurrenceUntilInput"
         :recurrence-until-status="recurrenceUntilStatus"
         :recurrence-until-error-key="recurrenceUntilErrorKey || undefined"
         :is-all-day="isAllDay"
       />
       <IcalEventRemindersSection
-        v-model:remindersEnabled="remindersEnabled"
+        v-model:reminders-enabled="remindersEnabled"
         v-model:reminders="reminders"
-        v-model:defaultReminder="reminderDefault"
+        v-model:default-reminder="reminderDefault"
       />
     </n-gi>
 

--- a/tools/time/ical-event-generator/src/components/IcalEventRecurrenceSection.vue
+++ b/tools/time/ical-event-generator/src/components/IcalEventRecurrenceSection.vue
@@ -2,20 +2,20 @@
   <ToolSectionHeader>{{ t('recurrence') }}</ToolSectionHeader>
   <ToolSection>
     <IcalEventRecurrenceFrequencySection
-      v-model:recurrenceFrequency="recurrenceFrequencyModel"
-      v-model:recurrenceInterval="recurrenceIntervalModel"
+      v-model:recurrence-frequency="recurrenceFrequencyModel"
+      v-model:recurrence-interval="recurrenceIntervalModel"
     />
     <IcalEventRecurrencePatternSection
-      v-model:recurrenceFrequency="recurrenceFrequencyModel"
-      v-model:recurrenceWeekdays="recurrenceWeekdaysModel"
-      v-model:recurrenceMonthDay="recurrenceMonthDayModel"
-      v-model:recurrenceMonth="recurrenceMonthModel"
+      v-model:recurrence-frequency="recurrenceFrequencyModel"
+      v-model:recurrence-weekdays="recurrenceWeekdaysModel"
+      v-model:recurrence-month-day="recurrenceMonthDayModel"
+      v-model:recurrence-month="recurrenceMonthModel"
     />
     <IcalEventRecurrenceEndsSection
-      v-model:recurrenceFrequency="recurrenceFrequencyModel"
-      v-model:recurrenceEndMode="recurrenceEndModeModel"
-      v-model:recurrenceCount="recurrenceCountModel"
-      v-model:recurrenceUntilInput="recurrenceUntilInputModel"
+      v-model:recurrence-frequency="recurrenceFrequencyModel"
+      v-model:recurrence-end-mode="recurrenceEndModeModel"
+      v-model:recurrence-count="recurrenceCountModel"
+      v-model:recurrence-until-input="recurrenceUntilInputModel"
       :recurrence-until-status="recurrenceUntilStatus"
       :recurrence-until-error-key="recurrenceUntilErrorKey"
       :is-all-day="isAllDay"

--- a/tools/time/radio-timecode/src/components/RadioTimecodeController.vue
+++ b/tools/time/radio-timecode/src/components/RadioTimecodeController.vue
@@ -2,7 +2,7 @@
   <ToolSectionHeader>{{ t('controls') }}</ToolSectionHeader>
   <ToolSection>
     <RadioTimecodeControlsSection
-      v-model:stationId="stationId"
+      v-model:station-id="stationId"
       :station-options="stationOptions"
       :is-playing="isPlaying"
       :is-starting="isStarting"
@@ -17,7 +17,7 @@
   <ToolSection>
     <RadioTimecodeOutputSection
       v-model:volume="volume"
-      v-model:offsetMs="offsetMs"
+      v-model:offset-ms="offsetMs"
       :carrier-hz="station?.carrierHz"
       :base-hz="station?.baseHz"
     />

--- a/tools/time/radio-timecode/src/components/RadioTimecodeControlsSection.vue
+++ b/tools/time/radio-timecode/src/components/RadioTimecodeControlsSection.vue
@@ -6,9 +6,9 @@
         <n-button
           v-if="!isPlaying"
           type="primary"
-          @click="emit('start')"
           :loading="isStarting"
           :disabled="!audioAvailable || isStarting"
+          @click="emit('start')"
         >
           <template #icon>
             <n-icon :component="PlayIcon" />

--- a/tools/time/stopwatch/src/components/StopwatchControlsSection.vue
+++ b/tools/time/stopwatch/src/components/StopwatchControlsSection.vue
@@ -1,25 +1,25 @@
 <template>
   <ToolSection>
     <n-flex :size="12" wrap justify="center">
-      <n-button type="primary" :disabled="running" @click="emit('start')" data-testid="start">
+      <n-button type="primary" :disabled="running" data-testid="start" @click="emit('start')">
         <template #icon>
           <n-icon :component="Play16Regular" />
         </template>
         {{ hasElapsed ? t('resume') : t('start') }}
       </n-button>
-      <n-button :disabled="!running" @click="emit('pause')" data-testid="pause">
+      <n-button :disabled="!running" data-testid="pause" @click="emit('pause')">
         <template #icon>
           <n-icon :component="Pause16Regular" />
         </template>
         {{ t('pause') }}
       </n-button>
-      <n-button :disabled="!canLap" @click="emit('lap')" data-testid="lap">
+      <n-button :disabled="!canLap" data-testid="lap" @click="emit('lap')">
         <template #icon>
           <n-icon :component="Flag16Regular" />
         </template>
         {{ t('lap') }}
       </n-button>
-      <n-button :disabled="!canReset" @click="emit('reset')" data-testid="reset">
+      <n-button :disabled="!canReset" data-testid="reset" @click="emit('reset')">
         <template #icon>
           <n-icon :component="ArrowCounterclockwise16Regular" />
         </template>

--- a/tools/time/stopwatch/src/components/StopwatchLapsSection.vue
+++ b/tools/time/stopwatch/src/components/StopwatchLapsSection.vue
@@ -22,8 +22,8 @@
           size="small"
           type="error"
           :disabled="!canClearLaps"
-          @click="clearLaps"
           data-testid="clear-laps"
+          @click="clearLaps"
         >
           <template #icon>
             <n-icon :component="Delete16Regular" />
@@ -36,6 +36,7 @@
   <ToolSection>
     <n-data-table
       v-if="lapRows.length"
+      ref="tableRef"
       :columns="columns"
       :data="lapRows"
       :bordered="false"
@@ -43,7 +44,6 @@
       :pagination="false"
       :row-key="rowKey"
       :row-props="rowProps"
-      ref="tableRef"
       data-testid="laps-list"
     />
     <n-text v-else depth="3" data-testid="no-laps">

--- a/tools/time/time-diff-calculator/src/components/TimeDifferenceSwapSection.vue
+++ b/tools/time/time-diff-calculator/src/components/TimeDifferenceSwapSection.vue
@@ -1,7 +1,7 @@
 <template>
   <ToolSection>
     <n-flex justify="space-between" align="center" :wrap="true">
-      <n-button @click="emit('swap')" secondary>
+      <n-button secondary @click="emit('swap')">
         <template #icon>
           <n-icon :component="ArrowSwap20Regular" />
         </template>

--- a/tools/time/time-zone-converter/src/components/TimeZoneConverterSwapSection.vue
+++ b/tools/time/time-zone-converter/src/components/TimeZoneConverterSwapSection.vue
@@ -1,7 +1,7 @@
 <template>
   <ToolSection>
     <n-flex justify="space-between" align="center" :wrap="true">
-      <n-button @click="emit('swap')" secondary>
+      <n-button secondary @click="emit('swap')">
         <template #icon>
           <n-icon :component="ArrowSwap20Regular" />
         </template>

--- a/tools/time/timer/src/components/CountdownControls.vue
+++ b/tools/time/timer/src/components/CountdownControls.vue
@@ -1,13 +1,13 @@
 <template>
   <ToolSection>
     <n-flex :size="12" wrap justify="center">
-      <n-button type="primary" @click="toggleRun" data-testid="start">
+      <n-button type="primary" data-testid="start" @click="toggleRun">
         <template #icon>
           <n-icon :component="toggleIcon" />
         </template>
         {{ toggleLabel }}
       </n-button>
-      <n-button :disabled="!canReset" @click="reset" data-testid="reset">
+      <n-button :disabled="!canReset" data-testid="reset" @click="reset">
         <template #icon>
           <n-icon :component="ArrowCounterclockwise16Regular" />
         </template>
@@ -15,8 +15,8 @@
       </n-button>
       <n-button
         v-show="fullscreenAvailable"
-        @click="enterFullscreen"
         data-testid="fullscreen-enter"
+        @click="enterFullscreen"
       >
         <template #icon>
           <n-icon :component="FullScreenMaximize16Regular" />

--- a/tools/time/timer/src/components/CountdownDurationSection.vue
+++ b/tools/time/timer/src/components/CountdownDurationSection.vue
@@ -49,8 +49,8 @@
         :key="preset"
         size="small"
         :disabled="running"
-        @click="applyPreset(preset)"
         :data-testid="`preset-${preset}`"
+        @click="applyPreset(preset)"
       >
         {{ t('presetMinutes', { minutes: preset }) }}
       </n-button>

--- a/tools/time/timer/src/components/CountdownFullscreenControls.vue
+++ b/tools/time/timer/src/components/CountdownFullscreenControls.vue
@@ -1,19 +1,19 @@
 <template>
   <div class="fullscreen-controls" data-testid="fullscreen-controls">
     <n-flex :size="8" align="center">
-      <n-button type="primary" @click="toggleRun" data-testid="fullscreen-start">
+      <n-button type="primary" data-testid="fullscreen-start" @click="toggleRun">
         <template #icon>
           <n-icon :component="toggleIcon" />
         </template>
         {{ toggleLabel }}
       </n-button>
-      <n-button :disabled="!canReset" @click="reset" data-testid="fullscreen-reset">
+      <n-button :disabled="!canReset" data-testid="fullscreen-reset" @click="reset">
         <template #icon>
           <n-icon :component="ArrowCounterclockwise16Regular" />
         </template>
         {{ t('reset') }}
       </n-button>
-      <n-button @click="exitFullscreen" data-testid="fullscreen-exit">
+      <n-button data-testid="fullscreen-exit" @click="exitFullscreen">
         <template #icon>
           <n-icon :component="FullScreenMinimize24Regular" />
         </template>

--- a/tools/uuid/src/uuid-decoder/decode/DecodeDetailResult.vue
+++ b/tools/uuid/src/uuid-decoder/decode/DecodeDetailResult.vue
@@ -27,13 +27,13 @@
     <n-descriptions-item :label="t('binary')">
       <n-text code>{{ result.binary }}</n-text>
     </n-descriptions-item>
-    <n-descriptions-item :label="t('algorithm')" v-if="result.algorithm">
+    <n-descriptions-item v-if="result.algorithm" :label="t('algorithm')">
       {{ algorithmLabel }}
     </n-descriptions-item>
-    <n-descriptions-item :label="t('macAddress')" v-if="result.macAddress">
+    <n-descriptions-item v-if="result.macAddress" :label="t('macAddress')">
       <n-text code>{{ result.macAddress }}</n-text>
     </n-descriptions-item>
-    <n-descriptions-item :label="t('timestamp')" v-if="result.timestamp">
+    <n-descriptions-item v-if="result.timestamp" :label="t('timestamp')">
       <n-text code>{{ result.timestamp }}</n-text>
       (<n-time :time="result.timestamp" />, <n-time :time="result.timestamp" type="relative" />)
     </n-descriptions-item>

--- a/tools/uuid/src/uuid-v1-generator/UUIDV1GeneratorView.vue
+++ b/tools/uuid/src/uuid-v1-generator/UUIDV1GeneratorView.vue
@@ -14,7 +14,7 @@
     <ToolConfigHeader />
     <ToolSection>
       <MACAddressInputFormItem v-model:address="macAddress" />
-      <ClockSeqInput v-model:clockSeq="clockSeq" />
+      <ClockSeqInput v-model:clock-seq="clockSeq" />
     </ToolSection>
 
     <WhatIsUUIDv1 />

--- a/tools/uuid/src/uuid-v3-generator/NamespaceInput.vue
+++ b/tools/uuid/src/uuid-v3-generator/NamespaceInput.vue
@@ -4,10 +4,10 @@
   </n-form-item>
   <n-space style="margin-top: 0.3em; margin-bottom: 1em">
     <n-tag
-      :bordered="false"
-      style="cursor: pointer"
       v-for="predefinedNamespace in predefinedNamespaces"
       :key="predefinedNamespace.value"
+      :bordered="false"
+      style="cursor: pointer"
       @click="namespace = predefinedNamespace.value"
     >
       {{ predefinedNamespace.name }}

--- a/tools/uuid/src/uuid-v6-generator/UUIDV6GeneratorView.vue
+++ b/tools/uuid/src/uuid-v6-generator/UUIDV6GeneratorView.vue
@@ -14,7 +14,7 @@
     <ToolConfigHeader />
     <ToolSection>
       <MACAddressInputFormItem v-model:address="macAddress" />
-      <ClockSeqInput v-model:clockSeq="clockSeq" />
+      <ClockSeqInput v-model:clock-seq="clockSeq" />
     </ToolSection>
 
     <WhatIsUUIDv6 />

--- a/tools/validator/credit-card-validator/src/components/CreditCardResult.vue
+++ b/tools/validator/credit-card-validator/src/components/CreditCardResult.vue
@@ -33,7 +33,7 @@
           <NTag :type="validationResult.isLengthValid ? 'success' : 'error'" size="small">
             {{ validationResult.isLengthValid ? t('pass') : t('fail') }}
           </NTag>
-          <NText depth="3" v-if="validationResult.brand">
+          <NText v-if="validationResult.brand" depth="3">
             ({{ t('expectedLength', { lengths: validationResult.brand.lengths.join(', ') }) }})
           </NText>
         </NFlex>

--- a/tools/validator/json-schema-generator/src/components/JsonSchemaGenerator.vue
+++ b/tools/validator/json-schema-generator/src/components/JsonSchemaGenerator.vue
@@ -10,7 +10,7 @@
     :input-error="inputError"
     :schema-text="schemaText"
     :output-error="outputError"
-    @update:inputValue="handleInput"
+    @update:input-value="handleInput"
   />
   <SchemaGeneratorOptions
     :draft="draft"
@@ -19,9 +19,9 @@
     :allow-additional-properties="allowAdditionalProperties"
     :detect-format="detectFormat"
     @update:draft="draft = $event"
-    @update:inferRequired="inferRequired = $event"
-    @update:allowAdditionalProperties="allowAdditionalProperties = $event"
-    @update:detectFormat="detectFormat = $event"
+    @update:infer-required="inferRequired = $event"
+    @update:allow-additional-properties="allowAdditionalProperties = $event"
+    @update:detect-format="detectFormat = $event"
   />
 </template>
 

--- a/tools/web/color-contrast-checker/src/components/ColorContrastInputSection.vue
+++ b/tools/web/color-contrast-checker/src/components/ColorContrastInputSection.vue
@@ -36,7 +36,7 @@
       </n-gi>
     </n-grid>
     <n-flex class="controls" align="center" justify="end" :size="12" wrap>
-      <n-button secondary @click="onSwap" data-testid="swap-button">
+      <n-button secondary data-testid="swap-button" @click="onSwap">
         <template #icon>
           <n-icon :component="ArrowSwap20Regular" />
         </template>

--- a/tools/web/css-box-shadow-generator/src/components/CssBoxShadowGenerator.dom.test.ts
+++ b/tools/web/css-box-shadow-generator/src/components/CssBoxShadowGenerator.dom.test.ts
@@ -33,13 +33,13 @@ vi.mock('naive-ui', async () => {
   const NButton = defineComponent({
     name: 'NButton',
     inheritAttrs: false,
-    emits: ['click'],
     props: {
       disabled: {
         type: Boolean,
         default: false,
       },
     },
+    emits: ['click'],
     template:
       '<button v-bind="$attrs" :disabled="disabled" @click="!disabled && $emit(\'click\')"><slot name="icon" /><slot /></button>',
   })

--- a/tools/web/css-gradient-generator/src/components/CssGradientGeneratorTool.vue
+++ b/tools/web/css-gradient-generator/src/components/CssGradientGeneratorTool.vue
@@ -10,11 +10,11 @@
             @randomize-all="handleRandomizeAll"
           />
           <CssGradientStopsPanel
+            v-model:stop-color="activeStopColor"
+            v-model:stop-position="activeStopPosition"
             :stops="activeStops"
             :active-stop-id="activeStopId"
             :gradient-css="activeTrackCss"
-            v-model:stop-color="activeStopColor"
-            v-model:stop-position="activeStopPosition"
             :show-error="showStopError"
             @add-stop="handleAddStop"
             @select-stop="setActiveStop"
@@ -81,8 +81,8 @@
       </n-gi>
       <n-gi>
         <CssGradientJsonPanel
-          :serialized-config="serializedConfig"
           v-model:json-input="jsonInput"
+          :serialized-config="serializedConfig"
           :json-url="jsonUrl"
           :show-error="showJsonError"
           @load-json="loadJson"

--- a/tools/web/css-gradient-generator/src/components/CssGradientLayerSettingsPanel.vue
+++ b/tools/web/css-gradient-generator/src/components/CssGradientLayerSettingsPanel.vue
@@ -14,9 +14,9 @@
         v-model:layer-center-y="layerCenterYModel"
       />
       <CssGradientLayerRadialControls
-        :layer-type="layerTypeModel"
         v-model:layer-shape="layerShapeModel"
         v-model:layer-size="layerSizeModel"
+        :layer-type="layerTypeModel"
       />
       <n-divider />
       <CssGradientLayerColorSpaceSelect v-model:layer-color-space="layerColorSpaceModel" />

--- a/tools/web/css-gradient-generator/src/components/GradientStopsTrack.vue
+++ b/tools/web/css-gradient-generator/src/components/GradientStopsTrack.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="track" ref="trackRef" data-testid="stops-track" @click="handleTrackClick">
+  <div ref="trackRef" class="track" data-testid="stops-track" @click="handleTrackClick">
     <div class="track__fill" :style="{ backgroundImage: gradientCss }" />
     <button
       v-for="stop in sortedStops"

--- a/tools/web/data-uri-to-file-converter/src/components/DataUriPreviewSection.vue
+++ b/tools/web/data-uri-to-file-converter/src/components/DataUriPreviewSection.vue
@@ -2,7 +2,7 @@
   <template v-if="previewKind && previewKind !== 'text'">
     <ToolSectionHeader>{{ t('preview') }}</ToolSectionHeader>
     <ToolSection>
-      <n-card size="small" v-if="previewKind === 'image'">
+      <n-card v-if="previewKind === 'image'" size="small">
         <img :src="previewUrl" alt="Preview" style="max-width: 100%" />
       </n-card>
       <audio v-else-if="previewKind === 'audio'" :src="previewUrl" controls style="width: 100%" />

--- a/tools/web/file-to-data-uri-converter/src/components/FileToDataUriConverter.vue
+++ b/tools/web/file-to-data-uri-converter/src/components/FileToDataUriConverter.vue
@@ -3,7 +3,7 @@
     <ToolSectionHeader>{{ t('file') }}</ToolSectionHeader>
     <ToolSection>
       <template v-if="!selectedFile">
-        <n-upload @before-upload="handleBeforeUpload" :show-file-list="false">
+        <n-upload :show-file-list="false" @before-upload="handleBeforeUpload">
           <n-upload-dragger>
             <div style="margin-bottom: 12px">
               <n-icon size="48" :depth="3">

--- a/tools/web/local-font-book/src/components/LocalFontBookLibraryCard.vue
+++ b/tools/web/local-font-book/src/components/LocalFontBookLibraryCard.vue
@@ -12,8 +12,8 @@
           size="small"
           :disabled="!isSupported || isLoading"
           :loading="isLoading"
-          @click="emit('load-fonts')"
           data-testid="load-fonts"
+          @click="emit('load-fonts')"
         >
           <template #icon>
             <n-icon :component="FolderOpen16Regular" />

--- a/tools/web/local-font-book/src/components/LocalFontBookTool.vue
+++ b/tools/web/local-font-book/src/components/LocalFontBookTool.vue
@@ -2,6 +2,10 @@
   <n-grid cols="1 l:2" :x-gap="24" :y-gap="24" responsive="screen">
     <n-gi>
       <LocalFontBookLibraryCard
+        v-model:search-query="searchQuery"
+        v-model:filter-style="filterStyle"
+        v-model:sort-by="sortBy"
+        v-model:group-by-family="groupByFamily"
         :title="labels.libraryTitle"
         :is-supported="isSupported"
         :is-loading="isLoading"
@@ -13,10 +17,6 @@
         :display-groups="displayGroups"
         :active-font-id="activeFontId"
         :font-card-style="fontCardStyle"
-        v-model:search-query="searchQuery"
-        v-model:filter-style="filterStyle"
-        v-model:sort-by="sortBy"
-        v-model:group-by-family="groupByFamily"
         @load-fonts="loadFonts"
         @select-font="setActiveFont"
       />
@@ -24,10 +24,10 @@
 
     <n-gi>
       <LocalFontBookPreviewCard
-        :active-font="activeFont"
-        :preview-style="previewStyle"
         v-model:sample-text="sampleText"
         v-model:dark-background="darkBackground"
+        :active-font="activeFont"
+        :preview-style="previewStyle"
       />
       <LocalFontBookDetailsCard :active-font="activeFont" :css-snippet="cssSnippet" />
     </n-gi>

--- a/tools/web/number-base-converter/src/components/BaseInput.vue
+++ b/tools/web/number-base-converter/src/components/BaseInput.vue
@@ -6,10 +6,10 @@
     </n-flex>
     <n-input
       :value="modelValue"
-      @update:value="$emit('update:modelValue', $event)"
       :status="status"
       :placeholder="placeholder"
       class="monospace-input"
+      @update:value="$emit('update:modelValue', $event)"
     />
   </ToolSection>
 </template>

--- a/tools/web/number-base-converter/src/components/NumberBaseConverter.vue
+++ b/tools/web/number-base-converter/src/components/NumberBaseConverter.vue
@@ -23,9 +23,9 @@
       :on-input="onInput"
     />
     <NumberBaseCustomInput
+      v-model:custom-base-value="customBaseValue"
       :custom="custom"
       :custom-status="customStatus"
-      v-model:custom-base-value="customBaseValue"
       :on-input="onInput"
     />
   </n-grid>

--- a/tools/web/robots-txt-generator/src/components/RobotsTxtGroupsSection.vue
+++ b/tools/web/robots-txt-generator/src/components/RobotsTxtGroupsSection.vue
@@ -29,7 +29,7 @@
         </n-space>
       </n-card>
 
-      <n-button type="primary" dashed @click="addGroup" data-testid="add-group">
+      <n-button type="primary" dashed data-testid="add-group" @click="addGroup">
         <template #icon>
           <n-icon :component="Add16Regular" />
         </template>

--- a/tools/web/robots-txt-generator/src/components/RobotsTxtPresetsSection.vue
+++ b/tools/web/robots-txt-generator/src/components/RobotsTxtPresetsSection.vue
@@ -6,17 +6,17 @@
   <ToolSectionHeader>{{ t('presets') }}</ToolSectionHeader>
   <ToolSection>
     <n-flex :wrap="true" :size="8">
-      <n-button size="small" @click="onApplyPreset('allowAll')" data-testid="preset-allow-all">
+      <n-button size="small" data-testid="preset-allow-all" @click="onApplyPreset('allowAll')">
         {{ t('presetAllowAll') }}
       </n-button>
       <n-button
         size="small"
-        @click="onApplyPreset('disallowAll')"
         data-testid="preset-disallow-all"
+        @click="onApplyPreset('disallowAll')"
       >
         {{ t('presetDisallowAll') }}
       </n-button>
-      <n-button size="small" @click="onApplyPreset('blockAdmin')" data-testid="preset-block-admin">
+      <n-button size="small" data-testid="preset-block-admin" @click="onApplyPreset('blockAdmin')">
         {{ t('presetBlockAdmin') }}
       </n-button>
     </n-flex>

--- a/tools/web/robots-txt-generator/src/components/RobotsTxtUserAgentsSection.vue
+++ b/tools/web/robots-txt-generator/src/components/RobotsTxtUserAgentsSection.vue
@@ -10,12 +10,12 @@
   <n-flex :wrap="true" :size="8">
     <n-button
       size="small"
-      @click="addUserAgents(searchEngineUserAgents)"
       data-testid="preset-useragent-search"
+      @click="addUserAgents(searchEngineUserAgents)"
     >
       {{ t('presetSearchEngines') }}
     </n-button>
-    <n-button size="small" @click="addUserAgents(aiUserAgents)" data-testid="preset-useragent-ai">
+    <n-button size="small" data-testid="preset-useragent-ai" @click="addUserAgents(aiUserAgents)">
       {{ t('presetAiCrawlers') }}
     </n-button>
   </n-flex>

--- a/tools/web/sitemap-xml-generator/src/components/SitemapIndexEntries.vue
+++ b/tools/web/sitemap-xml-generator/src/components/SitemapIndexEntries.vue
@@ -13,8 +13,8 @@
           <n-button
             text
             :disabled="sitemaps.length === 1"
-            @click="removeSitemap(index)"
             :data-testid="`remove-sitemap-${index}`"
+            @click="removeSitemap(index)"
           >
             <template #icon>
               <n-icon :component="Delete16Regular" />
@@ -36,7 +36,7 @@
         </n-space>
       </n-card>
 
-      <n-button type="primary" dashed @click="addSitemap" data-testid="add-sitemap">
+      <n-button type="primary" dashed data-testid="add-sitemap" @click="addSitemap">
         <template #icon>
           <n-icon :component="Add16Regular" />
         </template>

--- a/tools/web/sitemap-xml-generator/src/components/SitemapPresetsSection.vue
+++ b/tools/web/sitemap-xml-generator/src/components/SitemapPresetsSection.vue
@@ -2,19 +2,19 @@
   <ToolSectionHeader>{{ t('presets') }}</ToolSectionHeader>
   <ToolSection>
     <n-flex :wrap="true" :size="8">
-      <n-button size="small" @click="emit('apply', 'basic')" data-testid="preset-basic">
+      <n-button size="small" data-testid="preset-basic" @click="emit('apply', 'basic')">
         {{ t('presetBasic') }}
       </n-button>
-      <n-button size="small" @click="emit('apply', 'image')" data-testid="preset-image">
+      <n-button size="small" data-testid="preset-image" @click="emit('apply', 'image')">
         {{ t('presetImage') }}
       </n-button>
-      <n-button size="small" @click="emit('apply', 'video')" data-testid="preset-video">
+      <n-button size="small" data-testid="preset-video" @click="emit('apply', 'video')">
         {{ t('presetVideo') }}
       </n-button>
-      <n-button size="small" @click="emit('apply', 'news')" data-testid="preset-news">
+      <n-button size="small" data-testid="preset-news" @click="emit('apply', 'news')">
         {{ t('presetNews') }}
       </n-button>
-      <n-button size="small" @click="emit('apply', 'index')" data-testid="preset-index">
+      <n-button size="small" data-testid="preset-index" @click="emit('apply', 'index')">
         {{ t('presetIndex') }}
       </n-button>
     </n-flex>

--- a/tools/web/sitemap-xml-generator/src/components/SitemapUrlsetEntries.vue
+++ b/tools/web/sitemap-xml-generator/src/components/SitemapUrlsetEntries.vue
@@ -8,8 +8,8 @@
           <n-button
             text
             :disabled="urls.length === 1"
-            @click="removeUrl(index)"
             :data-testid="`remove-url-${index}`"
+            @click="removeUrl(index)"
           >
             <template #icon>
               <n-icon :component="Delete16Regular" />
@@ -48,7 +48,7 @@
         </n-space>
       </n-card>
 
-      <n-button type="primary" dashed @click="addUrl" data-testid="add-url">
+      <n-button type="primary" dashed data-testid="add-url" @click="addUrl">
         <template #icon>
           <n-icon :component="Add16Regular" />
         </template>

--- a/tools/web/url-parser-builder/src/components/URLInput.vue
+++ b/tools/web/url-parser-builder/src/components/URLInput.vue
@@ -1,7 +1,7 @@
 <template>
   <n-input
-    style="width: 100%"
     v-model:value="url"
+    style="width: 100%"
     :placeholder="t('url-placeholder')"
     :autosize="{ minRows: 3, maxRows: 6 }"
     :status="urlStatus"

--- a/tools/web/user-agent-parser/src/components/UserAgentParser.vue
+++ b/tools/web/user-agent-parser/src/components/UserAgentParser.vue
@@ -1,6 +1,6 @@
 <template>
   <UserAgentInputPanel
-    v-model:userAgent="userAgent"
+    v-model:user-agent="userAgent"
     :input-status="inputStatus"
     :input-error="inputError"
     :can-use-current="canUseCurrent"


### PR DESCRIPTION
## Summary
- switch eslint-plugin-vue to flat/recommended and add test overrides
- address new vue warnings (prop defaults, v-html exemptions, template var rename)
- apply eslint auto-fixes across templates

## Testing
- pnpm lint
