### PR TITLE
chore(tools): clarify X.509 (PEM/DER) support in certificate parser title

### DIFF
--- a/tools/network/certificate-public-key-parser/src/exports.dom.test.ts
+++ b/tools/network/certificate-public-key-parser/src/exports.dom.test.ts
@@ -9,7 +9,7 @@ describe('certificate public key parser exports', () => {
     expect(toolInfo.path).toBe('/tools/certificate-public-key-parser')
     expect(toolInfo.tags).toContain('x509')
     expect(toolInfo.features).toContain('offline')
-    expect(toolInfo.meta.en.name).toBe('Certificate & Public Key Parser')
+    expect(toolInfo.meta.en.name).toBe('X.509 (PEM/DER) Certificate & Public Key Parser')
     expect(Object.keys(toolInfo.meta)).toHaveLength(25)
     expect(index).toHaveProperty('toolInfo')
 

--- a/tools/network/certificate-public-key-parser/src/info.ts
+++ b/tools/network/certificate-public-key-parser/src/info.ts
@@ -6,127 +6,127 @@ export const features = ['offline']
 
 export const meta = {
   en: {
-    name: 'Certificate & Public Key Parser',
+    name: 'X.509 (PEM/DER) Certificate & Public Key Parser',
     description:
       'Parse X.509 certificates and public keys (PEM/DER) offline. View subject, issuer, validity, fingerprints, and key details in your browser.',
   },
   zh: {
-    name: '证书与公钥解析器',
+    name: 'X.509（PEM/DER）证书与公钥解析器',
     description:
       '离线解析 X.509 证书和公钥（PEM/DER）。在浏览器中查看主体、颁发者、有效期、指纹和密钥信息。',
   },
   'zh-CN': {
-    name: '证书与公钥解析器',
+    name: 'X.509（PEM/DER）证书与公钥解析器',
     description:
       '离线解析 X.509 证书和公钥（PEM/DER）。在浏览器中查看主体、颁发者、有效期、指纹和密钥信息。',
   },
   'zh-TW': {
-    name: '憑證與公鑰解析器',
+    name: 'X.509（PEM/DER）憑證與公鑰解析器',
     description:
       '離線解析 X.509 憑證與公鑰（PEM/DER）。在瀏覽器中查看主體、簽發者、有效期、指紋與金鑰資訊。',
   },
   'zh-HK': {
-    name: '證書與公鑰解析器',
+    name: 'X.509（PEM/DER）證書與公鑰解析器',
     description:
       '離線解析 X.509 證書與公鑰（PEM/DER）。在瀏覽器中查看主體、簽發者、有效期、指紋及金鑰資訊。',
   },
   es: {
-    name: 'Analizador de certificados y claves públicas',
+    name: 'Analizador de certificados y claves públicas X.509 (PEM/DER)',
     description:
       'Analiza certificados X.509 y claves públicas (PEM/DER) sin conexión. Consulta sujeto, emisor, validez, huellas y detalles de la clave en tu navegador.',
   },
   fr: {
-    name: 'Analyseur de certificats et de clés publiques',
+    name: 'Analyseur de certificats et de clés publiques X.509 (PEM/DER)',
     description:
       'Analysez des certificats X.509 et des clés publiques (PEM/DER) hors ligne. Consultez sujet, émetteur, validité, empreintes et détails de clé dans votre navigateur.',
   },
   de: {
-    name: 'Zertifikats- und Public-Key-Parser',
+    name: 'X.509 (PEM/DER) Zertifikats- und Public-Key-Parser',
     description:
       'X.509-Zertifikate und öffentliche Schlüssel (PEM/DER) offline analysieren. Betrachte Subjekt, Aussteller, Gültigkeit, Fingerabdrücke und Schlüsseldetails im Browser.',
   },
   it: {
-    name: 'Analizzatore di certificati e chiavi pubbliche',
+    name: 'Analizzatore di certificati e chiavi pubbliche X.509 (PEM/DER)',
     description:
       'Analizza certificati X.509 e chiavi pubbliche (PEM/DER) offline. Visualizza soggetto, emittente, validità, impronte e dettagli della chiave nel browser.',
   },
   ja: {
-    name: '証明書・公開鍵パーサー',
+    name: 'X.509（PEM/DER）証明書・公開鍵パーサー',
     description:
       'X.509 証明書と公開鍵（PEM/DER）をオフラインで解析。ブラウザでサブジェクト、発行者、有効期限、フィンガープリント、鍵情報を確認。',
   },
   ko: {
-    name: '인증서 및 공개키 파서',
+    name: 'X.509 (PEM/DER) 인증서 및 공개키 파서',
     description:
       '오프라인에서 X.509 인증서와 공개키(PEM/DER)를 분석합니다. 브라우저에서 주체, 발급자, 유효 기간, 지문, 키 정보를 확인하세요.',
   },
   ru: {
-    name: 'Парсер сертификатов и публичных ключей',
+    name: 'Парсер сертификатов и публичных ключей X.509 (PEM/DER)',
     description:
       'Разбирайте сертификаты X.509 и публичные ключи (PEM/DER) офлайн. Просматривайте субъект, издателя, срок действия, отпечатки и параметры ключа в браузере.',
   },
   pt: {
-    name: 'Analisador de certificados e chaves públicas',
+    name: 'Analisador de certificados e chaves públicas X.509 (PEM/DER)',
     description:
       'Analise certificados X.509 e chaves públicas (PEM/DER) offline. Veja sujeito, emissor, validade, impressões digitais e detalhes da chave no navegador.',
   },
   ar: {
-    name: 'محلل الشهادات والمفاتيح العامة',
+    name: 'محلل الشهادات والمفاتيح العامة X.509 (PEM/DER)',
     description:
       'حلّل شهادات X.509 والمفاتيح العامة (PEM/DER) دون اتصال. اعرض الموضوع والجهة المُصدِرة والصلاحية والبصمات وتفاصيل المفتاح في المتصفح.',
   },
   hi: {
-    name: 'प्रमाणपत्र और सार्वजनिक कुंजी पार्सर',
+    name: 'X.509 (PEM/DER) प्रमाणपत्र और सार्वजनिक कुंजी पार्सर',
     description:
       'X.509 प्रमाणपत्र और सार्वजनिक कुंजियाँ (PEM/DER) ऑफ़लाइन पार्स करें। ब्राउज़र में विषय, जारीकर्ता, वैधता, फिंगरप्रिंट और कुंजी विवरण देखें।',
   },
   tr: {
-    name: 'Sertifika ve Açık Anahtar Ayrıştırıcı',
+    name: 'X.509 (PEM/DER) Sertifika ve Açık Anahtar Ayrıştırıcı',
     description:
       'X.509 sertifikalarını ve açık anahtarları (PEM/DER) çevrimdışı ayrıştırın. Tarayıcıda konu, düzenleyici, geçerlilik, parmak izleri ve anahtar ayrıntılarını görüntüleyin.',
   },
   nl: {
-    name: 'Certificaat- en publieke-sleutelparser',
+    name: 'X.509 (PEM/DER) Certificaat- en publieke-sleutelparser',
     description:
       'Parse X.509-certificaten en openbare sleutels (PEM/DER) offline. Bekijk onderwerp, uitgever, geldigheid, vingerafdrukken en sleuteldetails in je browser.',
   },
   sv: {
-    name: 'Certifikat- och publiknyckel-parser',
+    name: 'X.509 (PEM/DER) Certifikat- och publiknyckel-parser',
     description:
       'Tolka X.509-certifikat och publika nycklar (PEM/DER) offline. Se ämne, utfärdare, giltighet, fingeravtryck och nyckeldetaljer i webbläsaren.',
   },
   pl: {
-    name: 'Parser certyfikatów i kluczy publicznych',
+    name: 'Parser certyfikatów i kluczy publicznych X.509 (PEM/DER)',
     description:
       'Analizuj certyfikaty X.509 i klucze publiczne (PEM/DER) offline. Zobacz podmiot, wystawcę, ważność, odciski palca i szczegóły klucza w przeglądarce.',
   },
   vi: {
-    name: 'Trình phân tích chứng chỉ và khóa công khai',
+    name: 'Trình phân tích chứng chỉ và khóa công khai X.509 (PEM/DER)',
     description:
       'Phân tích chứng chỉ X.509 và khóa công khai (PEM/DER) ngoại tuyến. Xem chủ thể, tổ chức phát hành, thời hạn, dấu vân tay và chi tiết khóa trong trình duyệt.',
   },
   th: {
-    name: 'ตัวแยกวิเคราะห์ใบรับรองและกุญแจสาธารณะ',
+    name: 'ตัวแยกวิเคราะห์ใบรับรองและกุญแจสาธารณะ X.509 (PEM/DER)',
     description:
       'แยกวิเคราะห์ใบรับรอง X.509 และกุญแจสาธารณะ (PEM/DER) แบบออฟไลน์ ดูหัวข้อ ผู้ออก ระยะเวลาใช้งาน ลายนิ้วมือ และรายละเอียดกุญแจในเบราว์เซอร์',
   },
   id: {
-    name: 'Pengurai sertifikat dan kunci publik',
+    name: 'Pengurai sertifikat dan kunci publik X.509 (PEM/DER)',
     description:
       'Urai sertifikat X.509 dan kunci publik (PEM/DER) secara offline. Lihat subjek, penerbit, masa berlaku, sidik jari, dan detail kunci di browser.',
   },
   he: {
-    name: 'מנתח תעודות ומפתחות ציבוריים',
+    name: 'מנתח תעודות ומפתחות ציבוריים X.509 (PEM/DER)',
     description:
       'נתח תעודות X.509 ומפתחות ציבוריים (PEM/DER) במצב לא מקוון. הצג נושא, מנפיק, תוקף, טביעות אצבע ופרטי מפתח בדפדפן.',
   },
   ms: {
-    name: 'Penghurai sijil dan kunci awam',
+    name: 'Penghurai sijil dan kunci awam X.509 (PEM/DER)',
     description:
       'Huraikan sijil X.509 dan kunci awam (PEM/DER) secara luar talian. Lihat subjek, pengeluar, tempoh sah, cap jari dan butiran kunci dalam pelayar.',
   },
   no: {
-    name: 'Sertifikat- og offentlig-nøkkel-parser',
+    name: 'X.509 (PEM/DER) Sertifikat- og offentlig-nøkkel-parser',
     description:
       'Analyser X.509-sertifikater og offentlige nøkler (PEM/DER) offline. Se subjekt, utsteder, gyldighet, fingeravtrykk og nøkkeldetaljer i nettleseren.',
   },


### PR DESCRIPTION
## Summary
- update `certificate-public-key-parser` localized tool names to explicitly include X.509 and PEM/DER support
- keep route/toolID unchanged to avoid link breakage
- update export test assertion for `meta.en.name`

## Tests
- pnpm test:unit tools/network/certificate-public-key-parser/src/exports.dom.test.ts tools/network/certificate-public-key-parser/src/CertificatePublicKeyParserView.dom.test.ts
