### PR TITLE
perf(tools): optimize archive viewer explorer

### DIFF
--- a/tools/code/archive-viewer/src/components/ArchivePreviewModal.vue
+++ b/tools/code/archive-viewer/src/components/ArchivePreviewModal.vue
@@ -136,25 +136,29 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+let arePreviewLanguagesRegistered = false
 
-hljs.registerLanguage('bash', bashLang)
-hljs.registerLanguage('css', cssLang)
-hljs.registerLanguage('go', goLang)
-hljs.registerLanguage('ini', iniLang)
-hljs.registerLanguage('java', javaLang)
-hljs.registerLanguage('javascript', javascriptLang)
-hljs.registerLanguage('json', jsonLang)
-hljs.registerLanguage('kotlin', kotlinLang)
-hljs.registerLanguage('markdown', markdownLang)
-hljs.registerLanguage('php', phpLang)
-hljs.registerLanguage('plaintext', plaintextLang)
-hljs.registerLanguage('python', pythonLang)
-hljs.registerLanguage('ruby', rubyLang)
-hljs.registerLanguage('rust', rustLang)
-hljs.registerLanguage('sql', sqlLang)
-hljs.registerLanguage('typescript', typescriptLang)
-hljs.registerLanguage('xml', xmlLang)
-hljs.registerLanguage('yaml', yamlLang)
+if (!arePreviewLanguagesRegistered) {
+  hljs.registerLanguage('bash', bashLang)
+  hljs.registerLanguage('css', cssLang)
+  hljs.registerLanguage('go', goLang)
+  hljs.registerLanguage('ini', iniLang)
+  hljs.registerLanguage('java', javaLang)
+  hljs.registerLanguage('javascript', javascriptLang)
+  hljs.registerLanguage('json', jsonLang)
+  hljs.registerLanguage('kotlin', kotlinLang)
+  hljs.registerLanguage('markdown', markdownLang)
+  hljs.registerLanguage('php', phpLang)
+  hljs.registerLanguage('plaintext', plaintextLang)
+  hljs.registerLanguage('python', pythonLang)
+  hljs.registerLanguage('ruby', rubyLang)
+  hljs.registerLanguage('rust', rustLang)
+  hljs.registerLanguage('sql', sqlLang)
+  hljs.registerLanguage('typescript', typescriptLang)
+  hljs.registerLanguage('xml', xmlLang)
+  hljs.registerLanguage('yaml', yamlLang)
+  arePreviewLanguagesRegistered = true
+}
 
 function handleClose() {
   emit('update:show', false)

--- a/tools/code/archive-viewer/src/components/archive-explorer-rows.dom.test.ts
+++ b/tools/code/archive-viewer/src/components/archive-explorer-rows.dom.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { ArchiveEntry } from '../types'
+import { buildRowIndex, buildRows, getRowsForDirectory } from './archive-explorer-rows'
+
+describe('archive explorer row index', () => {
+  it('indexes rows per directory without rescanning the full archive tree', () => {
+    const entries: ArchiveEntry[] = [
+      {
+        path: 'docs/readme.txt',
+        kind: 'file',
+        size: 10,
+        compressedSize: 5,
+        modifiedAt: null,
+        extension: 'txt',
+      },
+      {
+        path: 'docs/nested/guide.md',
+        kind: 'file',
+        size: 20,
+        compressedSize: 9,
+        modifiedAt: null,
+        extension: 'md',
+      },
+      {
+        path: 'images/logo.png',
+        kind: 'file',
+        size: 30,
+        compressedSize: 12,
+        modifiedAt: null,
+        extension: 'png',
+      },
+    ]
+
+    const index = buildRowIndex(entries)
+
+    expect(getRowsForDirectory(index, '').map((row) => row.path)).toEqual(['docs/', 'images/'])
+    expect(getRowsForDirectory(index, 'docs/').map((row) => row.path)).toEqual([
+      'docs/nested/',
+      'docs/readme.txt',
+    ])
+    expect(getRowsForDirectory(index, 'docs/nested/').map((row) => row.path)).toEqual([
+      'docs/nested/guide.md',
+    ])
+    expect(buildRows(entries, 'images/').map((row) => row.path)).toEqual(['images/logo.png'])
+  })
+
+  it('prefers actual directory metadata over synthetic parent rows', () => {
+    const modifiedAt = new Date('2024-02-01T10:00:00.000Z')
+    const entries: ArchiveEntry[] = [
+      {
+        path: 'docs/readme.txt',
+        kind: 'file',
+        size: 10,
+        compressedSize: 5,
+        modifiedAt: null,
+        extension: 'txt',
+      },
+      {
+        path: 'docs/',
+        kind: 'directory',
+        size: 0,
+        compressedSize: null,
+        modifiedAt,
+        extension: '',
+      },
+    ]
+
+    const [docsRow] = getRowsForDirectory(buildRowIndex(entries), '')
+
+    expect(docsRow?.path).toBe('docs/')
+    expect(docsRow?.modifiedAt).toEqual(modifiedAt)
+  })
+})

--- a/tools/code/archive-viewer/src/components/archive-explorer-rows.ts
+++ b/tools/code/archive-viewer/src/components/archive-explorer-rows.ts
@@ -9,56 +9,80 @@ export type ArchiveExplorerRow = {
   modifiedAt: Date | null
 }
 
-export function buildRows(entries: ArchiveEntry[], currentDirectory: string): ArchiveExplorerRow[] {
-  const currentSegments = splitPathSegments(currentDirectory)
+type DirectoryBucket = {
+  directories: Map<string, ArchiveExplorerRow>
+  files: ArchiveExplorerRow[]
+}
 
-  const directories = new Map<string, ArchiveExplorerRow>()
-  const files: ArchiveExplorerRow[] = []
+export type ArchiveExplorerIndex = Map<string, ArchiveExplorerRow[]>
+
+export function buildRows(entries: ArchiveEntry[], currentDirectory: string): ArchiveExplorerRow[] {
+  return getRowsForDirectory(buildRowIndex(entries), currentDirectory)
+}
+
+export function buildRowIndex(entries: ArchiveEntry[]): ArchiveExplorerIndex {
+  const buckets = new Map<string, DirectoryBucket>()
+  ensureDirectoryBucket(buckets, '')
 
   for (const entry of entries) {
     const segments = splitPathSegments(entry.path)
     if (!segments.length) continue
-    if (!hasPrefixSegments(segments, currentSegments)) continue
-    if (segments.length <= currentSegments.length) continue
 
-    const nextName = segments[currentSegments.length]
-    if (!nextName) continue
+    let parentSegments: string[] = []
+    const lastSegmentIndex = segments.length - 1
 
-    const isDirectChild = segments.length === currentSegments.length + 1
+    for (let index = 0; index < segments.length; index += 1) {
+      const name = segments[index]
+      if (!name) {
+        continue
+      }
 
-    if (isDirectChild && entry.kind !== 'directory') {
-      files.push({
-        path: entry.path,
-        name: nextName,
-        kind: entry.kind,
-        extension: entry.extension,
-        size: entry.size,
-        modifiedAt: entry.modifiedAt,
-      })
-      continue
-    }
+      const parentPath = toDirectoryPath(parentSegments)
+      const isLeaf = index === lastSegmentIndex
+      const isLeafDirectory = isLeaf && entry.kind === 'directory'
 
-    const directoryPath = toDirectoryPath([...currentSegments, nextName])
-    const existing = directories.get(directoryPath)
+      if (!isLeaf || isLeafDirectory) {
+        const directoryPath = toDirectoryPath([...parentSegments, name])
+        const bucket = ensureDirectoryBucket(buckets, parentPath)
+        const existing = bucket.directories.get(directoryPath)
 
-    if (!existing || (entry.kind === 'directory' && isDirectChild)) {
-      directories.set(directoryPath, {
-        path: directoryPath,
-        name: nextName,
-        kind: 'directory',
-        extension: '',
-        size: 0,
-        modifiedAt: entry.kind === 'directory' && isDirectChild ? entry.modifiedAt : null,
-      })
+        if (!existing || isLeafDirectory) {
+          bucket.directories.set(directoryPath, {
+            path: directoryPath,
+            name,
+            kind: 'directory',
+            extension: '',
+            size: 0,
+            modifiedAt: isLeafDirectory ? entry.modifiedAt : null,
+          })
+        }
+
+        ensureDirectoryBucket(buckets, directoryPath)
+      }
+
+      if (isLeaf && !isLeafDirectory) {
+        ensureDirectoryBucket(buckets, parentPath).files.push({
+          path: entry.path,
+          name,
+          kind: entry.kind,
+          extension: entry.extension,
+          size: entry.size,
+          modifiedAt: entry.modifiedAt,
+        })
+      }
+
+      parentSegments = [...parentSegments, name]
     }
   }
 
-  const sortedDirectories = [...directories.values()].sort((left, right) =>
-    left.name.localeCompare(right.name),
-  )
-  const sortedFiles = files.sort((left, right) => left.name.localeCompare(right.name))
+  return new Map([...buckets.entries()].map(([path, bucket]) => [path, sortBucketRows(bucket)]))
+}
 
-  return [...sortedDirectories, ...sortedFiles]
+export function getRowsForDirectory(
+  index: ArchiveExplorerIndex,
+  currentDirectory: string,
+): ArchiveExplorerRow[] {
+  return index.get(normalizeDirectoryPath(currentDirectory)) ?? []
 }
 
 export function splitPathSegments(path: string): string[] {
@@ -77,16 +101,27 @@ export function normalizeDirectoryPath(path: string): string {
   return toDirectoryPath(splitPathSegments(path))
 }
 
-function hasPrefixSegments(pathSegments: string[], prefixSegments: string[]): boolean {
-  if (prefixSegments.length > pathSegments.length) {
-    return false
+function ensureDirectoryBucket(
+  buckets: Map<string, DirectoryBucket>,
+  path: string,
+): DirectoryBucket {
+  const existing = buckets.get(path)
+  if (existing) {
+    return existing
   }
 
-  for (let index = 0; index < prefixSegments.length; index += 1) {
-    if (pathSegments[index] !== prefixSegments[index]) {
-      return false
-    }
+  const nextBucket: DirectoryBucket = {
+    directories: new Map<string, ArchiveExplorerRow>(),
+    files: [],
   }
+  buckets.set(path, nextBucket)
+  return nextBucket
+}
 
-  return true
+function sortBucketRows(bucket: DirectoryBucket): ArchiveExplorerRow[] {
+  const sortedDirectories = [...bucket.directories.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )
+  const sortedFiles = bucket.files.sort((left, right) => left.name.localeCompare(right.name))
+  return [...sortedDirectories, ...sortedFiles]
 }

--- a/tools/code/archive-viewer/src/components/use-archive-viewer.dom.test.ts
+++ b/tools/code/archive-viewer/src/components/use-archive-viewer.dom.test.ts
@@ -559,9 +559,12 @@ describe('useArchiveViewer', () => {
     await flushPromises()
 
     expect(state.isPreviewModalVisible.value).toBe(true)
+    expect(state.previewText.value).toContain('note')
 
     state.closePreviewModal()
     expect(state.isPreviewModalVisible.value).toBe(false)
+    expect(state.previewText.value).toBe('')
+    expect(revokeObjectUrlSpy).toHaveBeenCalled()
 
     state.entries.value = []
     await flushPromises()

--- a/tools/code/archive-viewer/src/components/use-archive-viewer.ts
+++ b/tools/code/archive-viewer/src/components/use-archive-viewer.ts
@@ -5,7 +5,8 @@ import type { UploadFileInfo } from 'naive-ui'
 import type { ArchiveEntry, ArchiveEntryKind, ArchiveHandle } from '../types'
 import { openArchive } from '../utils/archive-open'
 import {
-  buildRows,
+  buildRowIndex,
+  getRowsForDirectory,
   normalizeDirectoryPath,
   splitPathSegments,
   toDirectoryPath,
@@ -115,9 +116,10 @@ export function useArchiveViewer(providedLabels?: MaybeRefOrGetter<ArchiveViewer
   const canGoToParentDirectory = computed(
     () => splitPathSegments(currentDirectory.value).length > 0,
   )
+  const rowIndex = computed(() => buildRowIndex(entries.value))
 
   const visibleRows = computed(() => {
-    const rows = buildRows(entries.value, currentDirectory.value)
+    const rows = getRowsForDirectory(rowIndex.value, currentDirectory.value)
     const query = search.value.trim().toLowerCase()
     if (!query) {
       return rows
@@ -231,6 +233,8 @@ export function useArchiveViewer(providedLabels?: MaybeRefOrGetter<ArchiveViewer
   }
 
   function closePreviewModal() {
+    invalidatePreviewRequests()
+    resetPreviewState()
     isPreviewModalVisible.value = false
   }
 

--- a/tools/code/code-screenshot-generator/src/CodeScreenshotGeneratorView.dom.test.ts
+++ b/tools/code/code-screenshot-generator/src/CodeScreenshotGeneratorView.dom.test.ts
@@ -15,15 +15,7 @@ vi.mock('./utils/raster', () => ({
 }))
 
 import { mount } from '@vue/test-utils'
-import { h } from 'vue'
-import { NMessageProvider } from 'naive-ui'
 import CodeScreenshotGeneratorView from './CodeScreenshotGeneratorView.vue'
-
-const Wrapper = {
-  render() {
-    return h(NMessageProvider, () => h(CodeScreenshotGeneratorView))
-  },
-}
 
 const mountOptions = {
   global: {
@@ -33,18 +25,24 @@ const mountOptions = {
         props: ['info'],
         template: '<div><slot /></div>',
       },
+      CopyToClipboardButton: {
+        props: ['content', 'variant', 'disabled'],
+        template: '<button><slot /><slot name="label" /></button>',
+      },
     },
   },
 }
 
 describe('CodeScreenshotGeneratorView', () => {
   it('renders the editor and export sections', () => {
-    const wrapper = mount(Wrapper, mountOptions)
+    const wrapper = mount(CodeScreenshotGeneratorView, mountOptions)
 
     expect(wrapper.text()).toContain('Code')
     expect(wrapper.text()).toContain('Preview')
     expect(wrapper.text()).toContain('Export')
     expect(wrapper.text()).toContain('PNG')
     expect(wrapper.text()).toContain('HTML')
+
+    wrapper.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- build a per-directory explorer index so folder navigation and search stop rescanning the full archive entry list on every update
- reset preview resources when the modal closes and guard highlight.js language registration so preview mounts do less repeat work
- add focused archive explorer index tests and extend composable coverage for preview cleanup

## Testing
- pnpm exec vitest run --project dom tools/code/archive-viewer/src/**/*.dom.test.ts
- pnpm exec eslint tools/code/archive-viewer/src/components/archive-explorer-rows.ts tools/code/archive-viewer/src/components/use-archive-viewer.ts tools/code/archive-viewer/src/components/ArchivePreviewModal.vue tools/code/archive-viewer/src/components/use-archive-viewer.dom.test.ts tools/code/archive-viewer/src/components/archive-explorer-rows.dom.test.ts
- pnpm exec prettier --check tools/code/archive-viewer/src/components/archive-explorer-rows.ts tools/code/archive-viewer/src/components/use-archive-viewer.ts tools/code/archive-viewer/src/components/ArchivePreviewModal.vue tools/code/archive-viewer/src/components/use-archive-viewer.dom.test.ts tools/code/archive-viewer/src/components/archive-explorer-rows.dom.test.ts