### PR TITLE
feat: formalize the tool manifest contract

### DIFF
--- a/docs/architecture/workspace-boundaries.md
+++ b/docs/architecture/workspace-boundaries.md
@@ -36,7 +36,7 @@ tools/
 ### `packages/tool-sdk`
 
 - Owns the framework-agnostic tool contract.
-- Future responsibilities include `defineTool()`, shared tool types, localization helpers, and manifest validation.
+- Owns `defineTool()`, shared tool types, localized asset helpers, and manifest/message validation.
 - Must not depend on app shell, UI packages, registry code, or tool implementations.
 
 ### `packages/tool-registry`

--- a/packages/tool-sdk/README.md
+++ b/packages/tool-sdk/README.md
@@ -1,9 +1,70 @@
 # `@workspace/tool-sdk`
 
-This package will own the framework-agnostic tool contract introduced in issue `#318`.
+`packages/tool-sdk` owns the framework-agnostic tool contract for the Astro rewrite.
 
-It exists in `#316` to reserve the boundary:
+## Responsibilities
 
-- `defineTool()` and manifest types belong here.
-- Localization and schema helpers belong here.
-- UI, Astro routing, and tool implementation code do not.
+- defines the stable tool manifest shape
+- defines localized message/content asset references
+- validates required metadata and required language coverage
+- exposes `defineTool()` for authoring manifests
+- keeps UI, Astro routing, and framework component types out of the contract
+
+## Required languages
+
+The current rewrite baseline requires:
+
+- `en`
+- `zh-CN`
+
+Every tool manifest must provide message assets for those languages. Long-form content is optional, but if a tool opts into content it must cover the required languages as well.
+
+## Example
+
+```ts
+import {
+  DEFAULT_REQUIRED_TOOL_LANGUAGES,
+  createLocalizedContentFiles,
+  createLocalizedMessageFiles,
+  defineTool,
+} from "@workspace/tool-sdk"
+
+export const tool = defineTool({
+  id: "base64-encoder-decoder",
+  slug: "base64-encoder-decoder",
+  category: "encoding",
+  group: "encoding",
+  icon: "binary",
+  tags: ["encoding", "text"],
+  searchTerms: ["base64 encoder", "base64 decoder"],
+  features: ["offline", "copy"],
+  messages: createLocalizedMessageFiles(DEFAULT_REQUIRED_TOOL_LANGUAGES),
+  content: createLocalizedContentFiles(DEFAULT_REQUIRED_TOOL_LANGUAGES),
+  island: {
+    path: "./client.tsx",
+  },
+})
+```
+
+## Message catalog validation
+
+`tool-sdk` also validates the actual message catalogs once they are loaded by tooling such as the registry generator:
+
+```ts
+import { assertToolMessageCatalogs } from "@workspace/tool-sdk"
+
+assertToolMessageCatalogs({
+  en: {
+    meta: {
+      name: "Base64 Encoder / Decoder",
+      description: "Encode and decode Base64 strings in your browser.",
+    },
+  },
+  "zh-CN": {
+    meta: {
+      name: "Base64 编码 / 解码",
+      description: "在浏览器中进行 Base64 编码和解码。",
+    },
+  },
+})
+```

--- a/packages/tool-sdk/package.json
+++ b/packages/tool-sdk/package.json
@@ -10,6 +10,9 @@
     "format:check": "oxfmt --check .",
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "zod": "^4.1.12"
+  },
   "devDependencies": {
     "typescript": "^5.9.3"
   },

--- a/packages/tool-sdk/src/define-tool.ts
+++ b/packages/tool-sdk/src/define-tool.ts
@@ -1,0 +1,13 @@
+import type { ToolManifest, ToolValidationOptions } from "./types"
+import { assertToolDefinition } from "./validate"
+
+function defineTool<const TManifest extends ToolManifest>(
+  definition: TManifest,
+  options?: ToolValidationOptions
+) {
+  assertToolDefinition(definition, options)
+
+  return definition
+}
+
+export { defineTool }

--- a/packages/tool-sdk/src/errors.ts
+++ b/packages/tool-sdk/src/errors.ts
@@ -1,0 +1,11 @@
+class ToolContractError extends Error {
+  readonly issues: readonly string[]
+
+  constructor(message: string, issues: readonly string[]) {
+    super(`${message}\n- ${issues.join("\n- ")}`)
+    this.name = "ToolContractError"
+    this.issues = issues
+  }
+}
+
+export { ToolContractError }

--- a/packages/tool-sdk/src/files.ts
+++ b/packages/tool-sdk/src/files.ts
@@ -1,0 +1,61 @@
+import type {
+  CreateLocalizedAssetFilesOptions,
+  ToolContentFilePath,
+  ToolLanguage,
+  ToolMessageFilePath,
+} from "./types"
+
+function sanitizeDirectory(directory: string) {
+  return directory.replace(/^\.?\//, "").replace(/\/+$/, "")
+}
+
+function createLocalizedAssetFiles<
+  const TLanguages extends readonly ToolLanguage[],
+  TExtension extends ".json" | ".mdx",
+>(
+  languages: TLanguages,
+  options: CreateLocalizedAssetFilesOptions & {
+    extension: TExtension
+  }
+) {
+  const directory = sanitizeDirectory(options.directory)
+
+  return Object.fromEntries(
+    languages.map((language) => [
+      language,
+      `./${directory}/${language}${options.extension}`,
+    ])
+  ) as Readonly<
+    Record<TLanguages[number], `./${string}/${TLanguages[number]}${TExtension}`>
+  >
+}
+
+function createLocalizedMessageFiles<
+  const TLanguages extends readonly ToolLanguage[],
+>(
+  languages: TLanguages,
+  options: Partial<CreateLocalizedAssetFilesOptions> = {}
+) {
+  return createLocalizedAssetFiles(languages, {
+    directory: options.directory ?? "messages",
+    extension: ".json",
+  }) as Readonly<Record<TLanguages[number], ToolMessageFilePath>>
+}
+
+function createLocalizedContentFiles<
+  const TLanguages extends readonly ToolLanguage[],
+>(
+  languages: TLanguages,
+  options: Partial<CreateLocalizedAssetFilesOptions> = {}
+) {
+  return createLocalizedAssetFiles(languages, {
+    directory: options.directory ?? "content",
+    extension: ".mdx",
+  }) as Readonly<Record<TLanguages[number], ToolContentFilePath>>
+}
+
+export {
+  createLocalizedAssetFiles,
+  createLocalizedContentFiles,
+  createLocalizedMessageFiles,
+}

--- a/packages/tool-sdk/src/index.ts
+++ b/packages/tool-sdk/src/index.ts
@@ -1,6 +1,47 @@
-/**
- * Issue #316 scaffold.
- *
- * The actual tool contract is introduced in issue #318.
- */
-export {}
+export { defineTool } from "./define-tool"
+export {
+  createLocalizedAssetFiles,
+  createLocalizedContentFiles,
+  createLocalizedMessageFiles,
+} from "./files"
+export { DEFAULT_REQUIRED_TOOL_LANGUAGES, uniqueLanguages } from "./languages"
+export {
+  toolContentFilePathSchema,
+  toolDefinitionSchema,
+  toolManifestSchema,
+  toolIslandDefinitionSchema,
+  toolLocalizedContentFilesSchema,
+  toolLocalizedMessageFilesSchema,
+  toolMessageCatalogSchema,
+  toolMessageFilePathSchema,
+  toolModuleFilePathSchema,
+  toolSlugSchema,
+} from "./schema"
+export {
+  assertToolDefinition,
+  assertToolManifest,
+  assertToolMessageCatalogs,
+  resolveRequiredLanguages,
+  validateToolDefinition,
+  validateToolManifest,
+  validateToolMessageCatalogs,
+} from "./validate"
+export { ToolContractError } from "./errors"
+export type {
+  CreateLocalizedAssetFilesOptions,
+  DefaultRequiredToolLanguage,
+  RelativeToolPath,
+  ToolContentFilePath,
+  ToolDefinition,
+  ToolIslandDefinition,
+  ToolLanguage,
+  ToolManifest,
+  ToolLocalizedContentFiles,
+  ToolLocalizedMessageFiles,
+  ToolMessageCatalog,
+  ToolMessageCatalogs,
+  ToolMessageFilePath,
+  ToolMessageMeta,
+  ToolModuleFilePath,
+  ToolValidationOptions,
+} from "./types"

--- a/packages/tool-sdk/src/languages.ts
+++ b/packages/tool-sdk/src/languages.ts
@@ -1,0 +1,14 @@
+const DEFAULT_REQUIRED_TOOL_LANGUAGES = ["en", "zh-CN"] as const
+
+type DefaultRequiredToolLanguage =
+  (typeof DEFAULT_REQUIRED_TOOL_LANGUAGES)[number]
+type ToolLanguage = DefaultRequiredToolLanguage | (string & {})
+
+function uniqueLanguages(languages: readonly string[]) {
+  return [
+    ...new Set(languages.map((language) => language.trim()).filter(Boolean)),
+  ]
+}
+
+export { DEFAULT_REQUIRED_TOOL_LANGUAGES, uniqueLanguages }
+export type { DefaultRequiredToolLanguage, ToolLanguage }

--- a/packages/tool-sdk/src/schema.ts
+++ b/packages/tool-sdk/src/schema.ts
@@ -1,0 +1,90 @@
+import { z } from "zod"
+
+const slugPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+const relativePathPattern = /^\.\//
+const moduleFilePattern = /^\.\//u
+const toolStringListSchema = z
+  .array(z.string().trim().min(1))
+  .transform((values) => [...new Set(values)])
+
+const toolSlugSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(96)
+  .regex(slugPattern, "must use lowercase kebab-case")
+
+const relativeToolPathSchema = z
+  .string()
+  .trim()
+  .regex(relativePathPattern, "must be a local relative path starting with ./")
+
+const toolMessageFilePathSchema = relativeToolPathSchema.refine(
+  (path) => path.endsWith(".json"),
+  "must point to a .json file"
+)
+
+const toolContentFilePathSchema = relativeToolPathSchema.refine(
+  (path) => path.endsWith(".mdx"),
+  "must point to a .mdx file"
+)
+
+const toolModuleFilePathSchema = relativeToolPathSchema.refine(
+  (path) => moduleFilePattern.test(path) && /\.(?:js|jsx|ts|tsx)$/.test(path),
+  "must point to a .js, .jsx, .ts, or .tsx module"
+)
+
+const toolMessageCatalogSchema = z
+  .object({
+    meta: z.object({
+      name: z.string().trim().min(1),
+      description: z.string().trim().min(1),
+    }),
+  })
+  .catchall(z.unknown())
+
+const toolLocalizedMessageFilesSchema = z
+  .record(z.string().trim().min(1), toolMessageFilePathSchema)
+  .refine(
+    (record) => Object.keys(record).length > 0,
+    "must declare at least one message language"
+  )
+
+const toolLocalizedContentFilesSchema = z.record(
+  z.string().trim().min(1),
+  toolContentFilePathSchema
+)
+
+const toolIslandDefinitionSchema = z.object({
+  path: toolModuleFilePathSchema,
+  exportName: z.string().trim().min(1).optional(),
+})
+
+const toolDefinitionSchema = z.object({
+  id: toolSlugSchema,
+  slug: toolSlugSchema,
+  category: toolSlugSchema,
+  group: toolSlugSchema.optional(),
+  icon: toolSlugSchema,
+  tags: toolStringListSchema,
+  searchTerms: toolStringListSchema.optional(),
+  features: toolStringListSchema.optional(),
+  messages: toolLocalizedMessageFilesSchema,
+  content: toolLocalizedContentFilesSchema.optional(),
+  island: toolIslandDefinitionSchema.optional(),
+})
+
+const toolManifestSchema = toolDefinitionSchema
+
+export {
+  toolContentFilePathSchema,
+  toolDefinitionSchema,
+  toolManifestSchema,
+  toolIslandDefinitionSchema,
+  toolLocalizedContentFilesSchema,
+  toolLocalizedMessageFilesSchema,
+  toolMessageCatalogSchema,
+  toolMessageFilePathSchema,
+  toolModuleFilePathSchema,
+  toolSlugSchema,
+}

--- a/packages/tool-sdk/src/types.ts
+++ b/packages/tool-sdk/src/types.ts
@@ -1,0 +1,87 @@
+import type { DefaultRequiredToolLanguage, ToolLanguage } from "./languages"
+
+type RelativeToolPath = `./${string}`
+type ToolMessageFilePath = `./${string}.json`
+type ToolContentFilePath = `./${string}.mdx`
+type ToolModuleFilePath = `./${string}.${"js" | "jsx" | "ts" | "tsx"}`
+
+type ToolMessageMeta = Readonly<{
+  name: string
+  description: string
+}>
+
+type ToolMessageCatalog = Readonly<
+  {
+    meta: ToolMessageMeta
+  } & Record<string, unknown>
+>
+
+type ToolLocalizedMessageFiles<TLanguage extends string = ToolLanguage> =
+  Readonly<Record<TLanguage, ToolMessageFilePath>>
+
+type ToolLocalizedContentFiles<TLanguage extends string = ToolLanguage> =
+  Readonly<Record<TLanguage, ToolContentFilePath>>
+
+type ToolMessageCatalogs<TLanguage extends string = ToolLanguage> = Readonly<
+  Record<TLanguage, ToolMessageCatalog>
+>
+
+type ToolIslandDefinition = Readonly<{
+  path: ToolModuleFilePath
+  exportName?: string
+}>
+
+type ToolDefinition<
+  TMessages extends ToolLocalizedMessageFiles =
+    ToolLocalizedMessageFiles<DefaultRequiredToolLanguage>,
+  TContent extends ToolLocalizedContentFiles | undefined =
+    | ToolLocalizedContentFiles<DefaultRequiredToolLanguage>
+    | undefined,
+> = Readonly<{
+  id: string
+  slug: string
+  category: string
+  group?: string
+  icon: string
+  tags: readonly string[]
+  searchTerms?: readonly string[]
+  features?: readonly string[]
+  messages: TMessages
+  content?: TContent
+  island?: ToolIslandDefinition
+}>
+
+type ToolManifest<
+  TMessages extends ToolLocalizedMessageFiles =
+    ToolLocalizedMessageFiles<DefaultRequiredToolLanguage>,
+  TContent extends ToolLocalizedContentFiles | undefined =
+    | ToolLocalizedContentFiles<DefaultRequiredToolLanguage>
+    | undefined,
+> = ToolDefinition<TMessages, TContent>
+
+type ToolValidationOptions<TLanguage extends string = ToolLanguage> = Readonly<{
+  requiredLanguages?: readonly TLanguage[]
+}>
+
+type CreateLocalizedAssetFilesOptions = Readonly<{
+  directory: string
+}>
+
+export type {
+  CreateLocalizedAssetFilesOptions,
+  DefaultRequiredToolLanguage,
+  RelativeToolPath,
+  ToolContentFilePath,
+  ToolDefinition,
+  ToolIslandDefinition,
+  ToolLanguage,
+  ToolManifest,
+  ToolLocalizedContentFiles,
+  ToolLocalizedMessageFiles,
+  ToolMessageCatalog,
+  ToolMessageCatalogs,
+  ToolMessageFilePath,
+  ToolMessageMeta,
+  ToolModuleFilePath,
+  ToolValidationOptions,
+}

--- a/packages/tool-sdk/src/validate.ts
+++ b/packages/tool-sdk/src/validate.ts
@@ -1,0 +1,150 @@
+import type {
+  ToolDefinition,
+  ToolMessageCatalogs,
+  ToolValidationOptions,
+} from "./types"
+import { ToolContractError } from "./errors"
+import { DEFAULT_REQUIRED_TOOL_LANGUAGES, uniqueLanguages } from "./languages"
+import { toolDefinitionSchema, toolMessageCatalogSchema } from "./schema"
+
+function formatPath(path: readonly PropertyKey[]) {
+  return path.length === 0 ? "(root)" : path.map(String).join(".")
+}
+
+function resolveRequiredLanguages<TLanguage extends string>(
+  options?: ToolValidationOptions<TLanguage>
+) {
+  const requiredLanguages =
+    options?.requiredLanguages ?? DEFAULT_REQUIRED_TOOL_LANGUAGES
+
+  return uniqueLanguages(requiredLanguages)
+}
+
+function getMissingLanguages(
+  entries: Record<string, unknown> | undefined,
+  requiredLanguages: readonly string[]
+) {
+  if (!entries) {
+    return [...requiredLanguages]
+  }
+
+  return requiredLanguages.filter((language) => !(language in entries))
+}
+
+function validateToolDefinition<TDefinition extends ToolDefinition>(
+  definition: TDefinition,
+  options?: ToolValidationOptions
+) {
+  const issues: string[] = []
+  const parsedDefinition = toolDefinitionSchema.safeParse(definition)
+
+  if (!parsedDefinition.success) {
+    issues.push(
+      ...parsedDefinition.error.issues.map(
+        (issue) => `${formatPath(issue.path)}: ${issue.message}`
+      )
+    )
+  }
+
+  const requiredLanguages = resolveRequiredLanguages(options)
+
+  const missingMessageLanguages = getMissingLanguages(
+    definition.messages as Record<string, unknown> | undefined,
+    requiredLanguages
+  )
+
+  if (missingMessageLanguages.length > 0) {
+    issues.push(
+      `messages: missing required languages ${missingMessageLanguages.join(", ")}`
+    )
+  }
+
+  if (definition.content) {
+    const missingContentLanguages = getMissingLanguages(
+      definition.content as Record<string, unknown>,
+      requiredLanguages
+    )
+
+    if (missingContentLanguages.length > 0) {
+      issues.push(
+        `content: missing required languages ${missingContentLanguages.join(", ")}`
+      )
+    }
+  }
+
+  return {
+    issues,
+    valid: issues.length === 0,
+  }
+}
+
+function assertToolDefinition<TDefinition extends ToolDefinition>(
+  definition: TDefinition,
+  options?: ToolValidationOptions
+) {
+  const result = validateToolDefinition(definition, options)
+
+  if (!result.valid) {
+    throw new ToolContractError("Invalid tool definition.", result.issues)
+  }
+}
+
+const validateToolManifest = validateToolDefinition
+const assertToolManifest = assertToolDefinition
+
+function validateToolMessageCatalogs<TCatalogs extends ToolMessageCatalogs>(
+  catalogs: TCatalogs,
+  options?: ToolValidationOptions
+) {
+  const issues: string[] = []
+  const requiredLanguages = resolveRequiredLanguages(options)
+
+  for (const [language, catalog] of Object.entries(catalogs)) {
+    const parsedCatalog = toolMessageCatalogSchema.safeParse(catalog)
+
+    if (!parsedCatalog.success) {
+      issues.push(
+        ...parsedCatalog.error.issues.map(
+          (issue) => `${language}.${formatPath(issue.path)}: ${issue.message}`
+        )
+      )
+    }
+  }
+
+  const missingLanguages = getMissingLanguages(
+    catalogs as Record<string, unknown>,
+    requiredLanguages
+  )
+
+  if (missingLanguages.length > 0) {
+    issues.push(
+      `messages: missing required languages ${missingLanguages.join(", ")}`
+    )
+  }
+
+  return {
+    issues,
+    valid: issues.length === 0,
+  }
+}
+
+function assertToolMessageCatalogs<TCatalogs extends ToolMessageCatalogs>(
+  catalogs: TCatalogs,
+  options?: ToolValidationOptions
+) {
+  const result = validateToolMessageCatalogs(catalogs, options)
+
+  if (!result.valid) {
+    throw new ToolContractError("Invalid tool message catalogs.", result.issues)
+  }
+}
+
+export {
+  assertToolDefinition,
+  assertToolManifest,
+  assertToolMessageCatalogs,
+  resolveRequiredLanguages,
+  validateToolDefinition,
+  validateToolManifest,
+  validateToolMessageCatalogs,
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,10 @@ importers:
         version: 5.9.3
 
   packages/tool-sdk:
+    dependencies:
+      zod:
+        specifier: ^4.1.12
+        version: 4.3.6
     devDependencies:
       typescript:
         specifier: ^5.9.3


### PR DESCRIPTION
## Summary\n- turn packages/tool-sdk into the framework-agnostic manifest contract for tools\n- add defineTool, localized asset helpers, manifest/message schemas, and required-language validation\n- document the contract so the upcoming registry generator can consume it consistently\n\n## Validation\n- pnpm lint\n- pnpm typecheck\n- pnpm build\n- pnpm depcruise\n\nRefs #318