### PR TITLE
[codex] add Workers preview deployments for pull requests

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -156,6 +156,9 @@ jobs:
 
       - name: Deploy Cloudflare Workers preview
         id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -128,7 +128,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: cloudflare-workers-preview
+      name: cloudflare-workers-staging
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-web
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev/astro-rewrite-base'
     permissions:
       contents: read
     environment:
@@ -118,3 +118,48 @@ jobs:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/web
           environment: staging
+
+  deploy-preview:
+    name: Deploy Preview
+    runs-on: ubuntu-latest
+    needs:
+      - build-web
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+    environment:
+      name: cloudflare-workers-preview
+      url: ${{ steps.deploy.outputs.deployment-url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist
+
+      - name: Deploy Cloudflare Workers preview
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/web
+          environment: staging
+          command: versions upload --preview-alias pr-${{ github.event.pull_request.number }}

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -8,6 +8,7 @@
   "env": {
     "staging": {
       "name": "inbrowserapp-web-astro-staging",
+      "preview_urls": true,
       "workers_dev": true,
     },
   },


### PR DESCRIPTION
## What changed
- split the staging workflow into two deployment paths
- keep `push`/manual deployments to `dev/astro-rewrite-base` on the shared staging Worker URL
- deploy pull requests with `wrangler versions upload` and a per-PR preview alias
- enable `preview_urls` explicitly for the `staging` Wrangler environment

## Why
The current workflow publishes every PR to the same fixed `workers.dev` staging URL. That is useful as an integration environment, but it is not a real preview model because PRs overwrite each other.

This change keeps the shared staging environment for the rewrite branch while switching pull requests to Cloudflare Workers preview deployments, which gives each PR its own preview URL.

## Impact
- PRs get isolated preview deployments instead of reusing the shared staging URL
- `dev/astro-rewrite-base` still has a stable staging target for integration testing
- the workflow environment URL can point at the preview URL returned by `wrangler-action`

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm build`
