### PR TITLE
Remove card wrapper from tool intro sections

### DIFF
--- a/tools/base64-encoder-decoder/index.astro
+++ b/tools/base64-encoder-decoder/index.astro
@@ -2,7 +2,6 @@
 import { resolveLocale } from "@workspace/tool-sdk"
 import { ToolArticle } from "@workspace/ui/components/tool/tool-article"
 import { ToolPageShell } from "@workspace/ui/components/tool/tool-page-shell"
-import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
 import Base64EncoderDecoderClient from "./client"
 
 import type { AstroComponentFactory } from "astro/runtime/server/index.js"
@@ -49,11 +48,9 @@ const messages = { meta, ...localizedMessages }
 
   {
     IntroSection ? (
-      <ToolSurface>
-        <ToolArticle>
-          <IntroSection />
-        </ToolArticle>
-      </ToolSurface>
+      <ToolArticle>
+        <IntroSection />
+      </ToolArticle>
     ) : null
   }
 </ToolPageShell>

--- a/tools/image-resizer/index.astro
+++ b/tools/image-resizer/index.astro
@@ -2,7 +2,6 @@
 import { resolveLocale } from "@workspace/tool-sdk"
 import { ToolArticle } from "@workspace/ui/components/tool/tool-article"
 import { ToolPageShell } from "@workspace/ui/components/tool/tool-page-shell"
-import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
 import ImageResizerClient from "./client"
 
 import type { AstroComponentFactory } from "astro/runtime/server/index.js"
@@ -74,11 +73,9 @@ const messages = { meta, ...localizedMessages }
 
   {
     IntroSection ? (
-      <ToolSurface>
-        <ToolArticle>
-          <IntroSection />
-        </ToolArticle>
-      </ToolSurface>
+      <ToolArticle>
+        <IntroSection />
+      </ToolArticle>
     ) : null
   }
 </ToolPageShell>

--- a/tools/json-schema-validator/index.astro
+++ b/tools/json-schema-validator/index.astro
@@ -2,7 +2,6 @@
 import { resolveLocale } from "@workspace/tool-sdk"
 import { ToolArticle } from "@workspace/ui/components/tool/tool-article"
 import { ToolPageShell } from "@workspace/ui/components/tool/tool-page-shell"
-import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
 import JsonSchemaValidatorClient from "./client"
 
 import type { AstroComponentFactory } from "astro/runtime/server/index.js"
@@ -69,11 +68,9 @@ const messages = { meta, ...localizedMessages }
 
   {
     IntroSection ? (
-      <ToolSurface>
-        <ToolArticle>
-          <IntroSection />
-        </ToolArticle>
-      </ToolSurface>
+      <ToolArticle>
+        <IntroSection />
+      </ToolArticle>
     ) : null
   }
 </ToolPageShell>


### PR DESCRIPTION
## Summary
- Remove `ToolSurface` card wrapper (border, background, shadow, blur) from tool page intro/article sections
- Intro content now renders directly on the page background, only wrapped by `ToolArticle` for typography styling
- Applies to all 3 tools: base64-encoder-decoder, json-schema-validator, image-resizer

## Test plan
- [ ] Check `/tools/base64-encoder-decoder/` — intro text should render without card container
- [ ] Check `/tools/json-schema-validator/` — same
- [ ] Check `/tools/image-resizer/` — same
- [ ] Compare visual feel vs the card-wrapped version

🤖 Generated with [Claude Code](https://claude.com/claude-code)