### PR TITLE
Defer navbar component hydration to idle

### DIFF
--- a/apps/web/src/components/site-navbar.astro
+++ b/apps/web/src/components/site-navbar.astro
@@ -46,7 +46,7 @@ const navItems = [
   </div>
   <div class="flex items-center gap-1">
     <ThemeToggle
-      client:load
+      client:idle
       labelLight={catalog.site.themeLight}
       labelDark={catalog.site.themeDark}
       labelSystem={catalog.site.themeSystem}
@@ -54,7 +54,7 @@ const navItems = [
     />
     <div class="mx-1 h-4 w-px bg-border" aria-hidden="true" />
     <LanguageSwitcher
-      client:load
+      client:idle
       label={catalog.site.languageLabel}
       options={languageOptions}
     />


### PR DESCRIPTION
## Summary
- Switch `ThemeToggle` and `LanguageSwitcher` from `client:load` to `client:idle`
- Components hydrate when the browser is idle instead of blocking initial load
- No visual difference — SSG pre-renders the button HTML, theme icon is CSS-driven

## Test plan
- [ ] Theme toggle still works after idle hydration
- [ ] Language switcher still works after idle hydration
- [ ] No layout shift or flash on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)