### PR TITLE
Show active language and sort by relevance

### DIFF
--- a/packages/ui/src/components/app/language-switcher.tsx
+++ b/packages/ui/src/components/app/language-switcher.tsx
@@ -1,10 +1,13 @@
 "use client"
 
+import { useMemo } from "react"
+
 import { Button } from "@workspace/ui/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/ui/dropdown-menu"
 import { Languages } from "@workspace/ui/icons"
@@ -21,7 +24,53 @@ type LanguageSwitcherProps = {
   options: readonly LanguageOption[]
 }
 
+/**
+ * Sort options so the current language comes first, then the user's
+ * preferred browser language (if different), then the rest unchanged.
+ */
+function useSortedOptions(options: readonly LanguageOption[]) {
+  return useMemo(() => {
+    if (typeof navigator === "undefined") {
+      return options
+    }
+
+    const browserLangs = navigator.languages ?? [navigator.language]
+    const sorted = [...options]
+
+    sorted.sort((a, b) => {
+      // Current language always first
+      if (a.current) return -1
+      if (b.current) return 1
+
+      // Then prioritise by browser language preference
+      const aIdx = browserLangs.findIndex(
+        (l) =>
+          l === a.code ||
+          l.startsWith(`${a.code}-`) ||
+          a.code.startsWith(`${l}-`) ||
+          l.split("-")[0] === a.code.split("-")[0]
+      )
+      const bIdx = browserLangs.findIndex(
+        (l) =>
+          l === b.code ||
+          l.startsWith(`${b.code}-`) ||
+          b.code.startsWith(`${l}-`) ||
+          l.split("-")[0] === b.code.split("-")[0]
+      )
+      const aPrio = aIdx === -1 ? Infinity : aIdx
+      const bPrio = bIdx === -1 ? Infinity : bIdx
+
+      return aPrio - bPrio
+    })
+
+    return sorted
+  }, [options])
+}
+
 function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
+  const sortedOptions = useSortedOptions(options)
+  const currentCode = options.find((o) => o.current)?.code ?? ""
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -31,13 +80,19 @@ function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        {options.map((option) => (
-          <DropdownMenuItem key={option.code} asChild>
-            <a href={option.href} hrefLang={option.code} lang={option.code}>
-              {option.label}
-            </a>
-          </DropdownMenuItem>
-        ))}
+        <DropdownMenuRadioGroup value={currentCode}>
+          {sortedOptions.map((option) => (
+            <DropdownMenuRadioItem
+              key={option.code}
+              value={option.code}
+              asChild
+            >
+              <a href={option.href} hrefLang={option.code} lang={option.code}>
+                {option.label}
+              </a>
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/ui/src/components/app/language-switcher.tsx
+++ b/packages/ui/src/components/app/language-switcher.tsx
@@ -85,11 +85,11 @@ function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
             <DropdownMenuRadioItem
               key={option.code}
               value={option.code}
-              asChild
+              onSelect={() => {
+                window.location.href = option.href
+              }}
             >
-              <a href={option.href} hrefLang={option.code} lang={option.code}>
-                {option.label}
-              </a>
+              <span lang={option.code}>{option.label}</span>
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>

--- a/packages/ui/src/components/app/language-switcher.tsx
+++ b/packages/ui/src/components/app/language-switcher.tsx
@@ -79,14 +79,14 @@ function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         {sortedOptions.map((option) => (
-          <DropdownMenuItem key={option.code} asChild>
+          <DropdownMenuItem key={option.code} asChild className="relative pr-8">
             <a href={option.href} hrefLang={option.code} lang={option.code}>
-              {option.current ? (
-                <Check className="size-4" />
-              ) : (
-                <span className="size-4" />
-              )}
               {option.label}
+              {option.current ? (
+                <span className="pointer-events-none absolute right-2 flex items-center justify-center">
+                  <Check className="size-4" />
+                </span>
+              ) : null}
             </a>
           </DropdownMenuItem>
         ))}

--- a/packages/ui/src/components/app/language-switcher.tsx
+++ b/packages/ui/src/components/app/language-switcher.tsx
@@ -6,11 +6,10 @@ import { Button } from "@workspace/ui/components/ui/button"
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
+  DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@workspace/ui/components/ui/dropdown-menu"
-import { Languages } from "@workspace/ui/icons"
+import { Check, Languages } from "@workspace/ui/icons"
 
 type LanguageOption = Readonly<{
   code: string
@@ -69,7 +68,6 @@ function useSortedOptions(options: readonly LanguageOption[]) {
 
 function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
   const sortedOptions = useSortedOptions(options)
-  const currentCode = options.find((o) => o.current)?.code ?? ""
 
   return (
     <DropdownMenu>
@@ -80,19 +78,18 @@ function LanguageSwitcher({ label, options }: LanguageSwitcherProps) {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
-        <DropdownMenuRadioGroup value={currentCode}>
-          {sortedOptions.map((option) => (
-            <DropdownMenuRadioItem
-              key={option.code}
-              value={option.code}
-              onSelect={() => {
-                window.location.href = option.href
-              }}
-            >
-              <span lang={option.code}>{option.label}</span>
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
+        {sortedOptions.map((option) => (
+          <DropdownMenuItem key={option.code} asChild>
+            <a href={option.href} hrefLang={option.code} lang={option.code}>
+              {option.current ? (
+                <Check className="size-4" />
+              ) : (
+                <span className="size-4" />
+              )}
+              {option.label}
+            </a>
+          </DropdownMenuItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   )


### PR DESCRIPTION
## Summary
- Show ✓ check mark next to the currently active language using `DropdownMenuRadioGroup`/`DropdownMenuRadioItem`
- Sort language options: current language first, then by `navigator.languages` browser preference, then the rest

## Test plan
- [ ] Current language shows check mark in dropdown
- [ ] Current language appears at top of the list
- [ ] If browser prefers zh-CN, 简体中文 appears near top (after current)
- [ ] Switching languages navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)