### PR TITLE
Add View Transitions with no animation

### DIFF
--- a/apps/web/src/components/site-navbar.astro
+++ b/apps/web/src/components/site-navbar.astro
@@ -47,6 +47,7 @@ const navItems = [
   <div class="flex items-center gap-1">
     <ThemeToggle
       client:idle
+      transition:persist="theme-toggle"
       labelLight={catalog.site.themeLight}
       labelDark={catalog.site.themeDark}
       labelSystem={catalog.site.themeSystem}
@@ -55,6 +56,7 @@ const navItems = [
     <div class="mx-1 h-4 w-px bg-border" aria-hidden="true" />
     <LanguageSwitcher
       client:idle
+      transition:persist="lang-switcher"
       label={catalog.site.languageLabel}
       options={languageOptions}
     />

--- a/apps/web/src/layouts/main.astro
+++ b/apps/web/src/layouts/main.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from "astro:transitions"
 import "@workspace/ui/globals.css"
 import SiteNavbar from "@/components/site-navbar.astro"
 import { resolveSiteLanguage, type SiteLanguage } from "@/lib/site"
@@ -33,7 +34,7 @@ const {
 const language = resolveSiteLanguage(lang)
 ---
 
-<html lang={lang} data-theme="system">
+<html lang={lang} data-theme="system" transition:animate="none">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
@@ -50,6 +51,7 @@ const language = resolveSiteLanguage(lang)
     <meta property="og:url" content={canonicalUrl} />
     <meta property="og:type" content="website" />
     <title>{title}</title>
+    <ClientRouter />
     <script is:inline>
       ;(function () {
         var theme = localStorage.getItem("theme") || "system"

--- a/apps/web/src/layouts/main.astro
+++ b/apps/web/src/layouts/main.astro
@@ -54,13 +54,17 @@ const language = resolveSiteLanguage(lang)
     <ClientRouter />
     <script is:inline>
       ;(function () {
-        var theme = localStorage.getItem("theme") || "system"
-        var isDark =
-          theme === "dark" ||
-          (theme === "system" &&
-            window.matchMedia("(prefers-color-scheme: dark)").matches)
-        document.documentElement.classList[isDark ? "add" : "remove"]("dark")
-        document.documentElement.dataset.theme = theme
+        function applyTheme() {
+          var theme = localStorage.getItem("theme") || "system"
+          var isDark =
+            theme === "dark" ||
+            (theme === "system" &&
+              window.matchMedia("(prefers-color-scheme: dark)").matches)
+          document.documentElement.classList[isDark ? "add" : "remove"]("dark")
+          document.documentElement.dataset.theme = theme
+        }
+        applyTheme()
+        document.addEventListener("astro:after-swap", applyTheme)
       })()
     </script>
   </head>


### PR DESCRIPTION
## Summary
- Add `ClientRouter` from `astro:transitions` for client-side navigation
- Set `transition:animate="none"` on `<html>` to disable all transition animations
- Combined with existing prefetch, pages load instantly without full page reload

## Test plan
- [ ] Navigate between pages — no full page reload, instant swap
- [ ] No transition animation (no fade/slide)
- [ ] Theme preference persists across navigations without flash
- [ ] Back/forward browser buttons work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)