### PR TITLE
Configure Cloudflare static asset routing

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -4,6 +4,8 @@
   "compatibility_date": "2026-04-05",
   "assets": {
     "directory": "./dist",
+    "not_found_handling": "404-page",
+    "html_handling": "drop-trailing-slash",
   },
   "env": {
     "staging": {


### PR DESCRIPTION
## Summary
- Set `html_handling: "drop-trailing-slash"` for clean URLs (e.g. `/tools/image-resizer` instead of `/tools/image-resizer/`)
- Set `not_found_handling: "404-page"` to serve a proper 404 page for unknown routes

Ref:
- https://developers.cloudflare.com/workers/static-assets/routing/static-site-generation/
- https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/

## Test plan
- [ ] `/tools/image-resizer` serves the page (no trailing slash)
- [ ] `/tools/image-resizer/` redirects to `/tools/image-resizer`
- [ ] `/nonexistent` returns 404 page

🤖 Generated with [Claude Code](https://claude.com/claude-code)