### PR TITLE
Set immutable cache for _astro/ assets

### DIFF
--- a/apps/web/public/_headers
+++ b/apps/web/public/_headers
@@ -1,0 +1,2 @@
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Add `public/_headers` file for Cloudflare Workers static assets
- Set `Cache-Control: public, max-age=31536000, immutable` for `/_astro/*`
- All files in `_astro/` have content hashes in filenames, safe to cache indefinitely
- Other assets keep the default `max-age=0, must-revalidate`

Ref: https://github.com/withastro/astro/issues/9106

## Test plan
- [ ] Verify `/_astro/*.js` responses have `Cache-Control: public, max-age=31536000, immutable`
- [ ] Verify HTML pages still have default cache headers
- [ ] Site functionality unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)