### PR TITLE
ci: add format:check, test, and depcruise to Code Check

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -38,8 +38,17 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Format check
+        run: pnpm format:check
+
       - name: Typecheck
         run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Dep boundaries
+        run: pnpm depcruise
 
   build-web:
     name: Build Web


### PR DESCRIPTION
## Summary
The \`Code Check\` job currently runs only \`lint\` and \`typecheck\`. Tests, formatting drift, and workspace boundary violations never block a PR.

The previous tools-as-packages refactor brought \`pnpm depcruise\` to zero violations and the test suite is at 241/241, so wiring all three into CI now is a drop-in change.

## Test plan
- [x] \`pnpm format:check\` — clean
- [x] \`pnpm test\` — 241/241
- [x] \`pnpm depcruise\` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)