### PR TITLE
chore: dedupe react across the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
   "packageManager": "pnpm@9.15.9",
   "engines": {
     "node": ">=20"
-  },
-  "dependencies": {
-    "react": "^19.2.4"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,11 +15,13 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.542.0",
     "radix-ui": "^1.4.3",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
     "shadcn": "^4.1.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      react:
-        specifier: ^19.2.4
-        version: 19.2.4
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.0
@@ -157,10 +153,10 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.2.4
+        specifier: ^19.0.0
         version: 19.2.4
       react-dom:
-        specifier: ^19.2.4
+        specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
       shadcn:
         specifier: ^4.1.2


### PR DESCRIPTION
## Summary
- Drop the unused root \`dependencies.react\` entry. Knip flagged it; the root hosts no code that imports react.
- Convert \`packages/ui\` to declare \`react\` / \`react-dom\` as **peer** dependencies instead of regular dependencies. With the previous shape, pnpm could resolve two react instances (one for \`packages/ui\`, one for \`apps/web\`), risking the classic \"Invalid hook call\" runtime error caused by duplicated react copies.

After the change, \`pnpm why react -r\` shows a single react resolved at \`node_modules/.pnpm/react@19.2.4\` across the entire workspace.

## Test plan
- [x] \`pnpm install\` clean
- [x] \`pnpm why react -r\` → single \`19.2.4\` instance
- [x] \`pnpm lint\`, \`pnpm format:check\`, \`pnpm typecheck\`, \`pnpm test\` (241/241), \`pnpm depcruise\` (0), \`pnpm build\` (115 pages) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)