### PR TITLE
refactor(web): drop unused exports and wire knip into CI

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Dep boundaries
         run: pnpm depcruise
 
+      - name: Knip
+        run: pnpm knip
+
   build-web:
     name: Build Web
     runs-on: ubuntu-latest

--- a/.knip.json
+++ b/.knip.json
@@ -1,3 +1,14 @@
 {
-  "$schema": "./node_modules/knip/schema.json"
+  "$schema": "./node_modules/knip/schema.json",
+  "workspaces": {
+    "apps/web": {
+      "astro": true
+    },
+    "packages/*": {
+      "astro": false
+    },
+    "tools/*": {
+      "astro": false
+    }
+  }
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -5,7 +5,6 @@ import type { AlternateLink } from "./site"
 
 import {
   DEFAULT_SITE_LANGUAGE,
-  SITE_URL,
   SUPPORTED_SITE_LANGUAGES,
   getAlternateLinks,
   getCanonicalUrl,
@@ -118,5 +117,4 @@ ${urls}
 `
 }
 
-export { SITE_URL, buildSitemapXml, createPageSeo, getSitemapEntries }
-export type { PageSeo, SitemapEntry }
+export { buildSitemapXml, createPageSeo, getSitemapEntries }

--- a/apps/web/src/lib/site-messages.ts
+++ b/apps/web/src/lib/site-messages.ts
@@ -75,4 +75,3 @@ function loadSiteMessages(language: SiteLanguage) {
 }
 
 export { loadSiteMessages }
-export type { SiteMessageCatalog }

--- a/apps/web/src/lib/site.ts
+++ b/apps/web/src/lib/site.ts
@@ -1,4 +1,3 @@
-const SITE_NAME = "InBrowser.App"
 const SITE_URL = "https://inbrowser.app"
 const DEFAULT_SITE_LANGUAGE = "en"
 const SUPPORTED_SITE_LANGUAGES = [
@@ -30,7 +29,6 @@ const NON_DEFAULT_SITE_LANGUAGES = SUPPORTED_SITE_LANGUAGES.filter(
   (language) => language !== DEFAULT_SITE_LANGUAGE
 ) as readonly Exclude<(typeof SUPPORTED_SITE_LANGUAGES)[number], "en">[]
 const RTL_SITE_LANGUAGES = ["ar", "he"] as const
-type RtlSiteLanguage = (typeof RTL_SITE_LANGUAGES)[number]
 
 function getSiteLanguageDirection(language: string): "ltr" | "rtl" {
   return (RTL_SITE_LANGUAGES as readonly string[]).includes(language)
@@ -46,11 +44,6 @@ type AlternateLink = Readonly<{
 type SiteLanguageOption = Readonly<{
   code: SiteLanguage
   href: string
-  current: boolean
-}>
-type SiteNavigationItem = Readonly<{
-  href: string
-  label: string
   current: boolean
 }>
 
@@ -157,53 +150,17 @@ function createLanguageOptions(
   })) as readonly SiteLanguageOption[]
 }
 
-function createPrimaryNavigation(
-  language: SiteLanguage,
-  labels: Readonly<{
-    home: string
-    tools: string
-  }>,
-  current: "home" | "tools"
-) {
-  return [
-    {
-      current: current === "home",
-      href: localizePath("/", language),
-      label: labels.home,
-    },
-    {
-      current: current === "tools",
-      href: localizePath("/tools", language),
-      label: labels.tools,
-    },
-  ] as const satisfies readonly SiteNavigationItem[]
-}
-
 export {
   DEFAULT_SITE_LANGUAGE,
-  NON_DEFAULT_SITE_LANGUAGES,
-  RTL_SITE_LANGUAGES,
-  SITE_NAME,
-  SITE_URL,
   SUPPORTED_SITE_LANGUAGES,
   createLanguageOptions,
   createNonDefaultLanguageStaticPaths,
-  createPrimaryNavigation,
   getAlternateLinks,
   getCanonicalUrl,
   getSiteLanguageDirection,
-  isDefaultSiteLanguage,
   isSupportedSiteLanguage,
   localizePath,
-  normalizePathname,
   resolveLocalizedAssetLanguage,
   resolveSiteLanguage,
-  toAbsoluteUrl,
 }
-export type {
-  AlternateLink,
-  RtlSiteLanguage,
-  SiteLanguage,
-  SiteLanguageOption,
-  SiteNavigationItem,
-}
+export type { AlternateLink, SiteLanguage }

--- a/apps/web/src/lib/tool-pages.ts
+++ b/apps/web/src/lib/tool-pages.ts
@@ -88,5 +88,4 @@ async function loadToolPageData(
   }
 }
 
-export { getToolBySlug, loadToolPageData }
-export type { LoadedToolPageData }
+export { loadToolPageData }

--- a/tools/json-schema-validator/core/validate-json-schema.ts
+++ b/tools/json-schema-validator/core/validate-json-schema.ts
@@ -167,9 +167,4 @@ function validateJsonSchemaText(
 }
 
 export { validateJsonSchemaText }
-export type {
-  SchemaDraft,
-  ValidationIssue,
-  ValidationOptions,
-  ValidationResult,
-}
+export type { ValidationOptions, ValidationResult }


### PR DESCRIPTION
## Summary
Knip flagged 18 exports across \`apps/web/src/lib\` and one tool core file with zero importers anywhere in the repo. Pay them down and add knip to \`Code Check\` so they cannot regrow.

### Deletions (truly dead — no internal use either)
| Symbol | File |
|---|---|
| \`SITE_NAME\` | \`apps/web/src/lib/site.ts\` |
| \`createPrimaryNavigation\` | \`apps/web/src/lib/site.ts\` |
| \`RtlSiteLanguage\` (type) | \`apps/web/src/lib/site.ts\` |
| \`SiteNavigationItem\` (type) | \`apps/web/src/lib/site.ts\` |

### Demoted from \`export\` to file-private (still used inside the module)
| Symbol | File |
|---|---|
| \`NON_DEFAULT_SITE_LANGUAGES\`, \`RTL_SITE_LANGUAGES\`, \`SITE_URL\`, \`isDefaultSiteLanguage\`, \`normalizePathname\`, \`toAbsoluteUrl\`, \`SiteLanguageOption\` | \`apps/web/src/lib/site.ts\` |
| \`SITE_URL\` re-export, \`PageSeo\`, \`SitemapEntry\` | \`apps/web/src/lib/seo.ts\` |
| \`SiteMessageCatalog\` | \`apps/web/src/lib/site-messages.ts\` |
| \`getToolBySlug\`, \`LoadedToolPageData\` | \`apps/web/src/lib/tool-pages.ts\` |
| \`SchemaDraft\`, \`ValidationIssue\` | \`tools/json-schema-validator/core/validate-json-schema.ts\` |

### Knip configuration
\`.knip.json\` now scopes the Astro plugin to \`apps/web\` only. Remaining \"Missing pages directory\" WARN lines are a known knip cosmetic issue with cross-workspace auto-detection — the run still exits 0 and there are no actual unused-export findings.

### CI
\`.github/workflows/staging.yml\` Code Check now runs \`pnpm knip\` after the existing \`format:check\` / \`test\` / \`depcruise\` steps from #354.

## Test plan
- [x] \`pnpm lint\` — clean
- [x] \`pnpm format:check\` — clean
- [x] \`pnpm typecheck\` — all 4 workspaces green
- [x] \`pnpm test\` — 241/241
- [x] \`pnpm depcruise\` — 0 violations
- [x] \`pnpm knip\` — exit 0
- [x] \`pnpm build\` — 115 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)