### PR TITLE
ci: enforce Conventional Commits on PR titles

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,25 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  lint-pr-title:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a `PR Title` workflow that runs `amannn/action-semantic-pull-request` on PR open/edit/reopen/synchronize.
- Mirrors the commitlint check Husky already runs locally on commit messages — PR titles become the squash-merge subject, so they need the same guarantee.

## Test plan
- [ ] This PR's own title (`ci: ...`) should pass the new check
- [ ] Editing the title to something non-conventional should fail the check