### PR TITLE
ci: enforce vitest coverage thresholds in Code Check

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -45,7 +45,7 @@ jobs:
         run: pnpm typecheck
 
       - name: Test
-        run: pnpm test
+        run: pnpm test:coverage
 
       - name: Dep boundaries
         run: pnpm depcruise


### PR DESCRIPTION
## Summary
- Swap `pnpm test` for `pnpm test:coverage` in the Code Check job so the v8 coverage thresholds defined in `vitest.config.ts` (100% for `tool-sdk/src` and `tools/*/core`, 90/85 for `tools/*`) actually fail the build when violated. Today the thresholds are decorative.

## Test plan
- [ ] CI passes on this PR (current code is above thresholds locally)
- [ ] Future regressions in covered modules will fail Code Check