### PR TITLE
ci: detect stale generated tool registry in Code Check

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,6 +41,11 @@ jobs:
       - name: Format check
         run: pnpm format:check
 
+      - name: Verify generated tool registry is up to date
+        run: |
+          pnpm tool-registry:generate
+          git diff --exit-code -- packages/tool-registry/src/generated
+
       - name: Typecheck
         run: pnpm typecheck
 


### PR DESCRIPTION
## Summary
- Add a Code Check step that runs `pnpm tool-registry:generate` and `git diff --exit-code` against `packages/tool-registry/src/generated`. The generated files are committed (per CLAUDE.md), so any drift between the manifests/locales on disk and the generated registry will now fail CI instead of silently rotting.

## Test plan
- [ ] CI passes on this PR (no drift expected)
- [ ] Locally deleting a key from a `meta/<lang>.json` and pushing should fail this step