### PR TITLE
ci: use lts/* node and let pnpm/action-setup own caching

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -21,19 +21,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: pnpm
+          node-version: lts/*
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
+          run_install: true
 
       - name: Lint
         run: pnpm lint
@@ -69,19 +66,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: pnpm
+          node-version: lts/*
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
+          run_install: true
 
       - name: Build
         run: pnpm build
@@ -107,19 +101,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: pnpm
+          node-version: lts/*
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
+          run_install: true
 
       - name: Download web artifact
         uses: actions/download-artifact@v4
@@ -151,19 +142,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20
-          cache: pnpm
+          node-version: lts/*
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
+          run_install: true
 
       - name: Download web artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
- Pin every CI job to `node-version: lts/*` instead of a hardcoded `20`, so a new LTS bump propagates automatically.
- Bump `pnpm/action-setup` from v4 to v5 and let it own the pnpm-store cache (`cache: true`) and the install step (`run_install: true`).
- Reorder steps so `setup-node` runs first (it no longer needs pnpm on PATH for the cache key) and drop the now-redundant `Install dependencies` step from all four jobs.

## Test plan
- [ ] CI Code Check / Build Web / Deploy Preview all green on this PR
- [ ] Cache hit rate visible in the pnpm install step on the second run