### PR TITLE
chore: drop redundant per-package lint/format scripts

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,10 +9,6 @@
     "preview": "astro preview",
     "astro": "astro",
     "deploy:staging": "wrangler deploy --env staging",
-    "lint": "oxlint .",
-    "lint:fix": "oxlint --fix .",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check .",
     "typecheck": "astro check"
   },
   "dependencies": {

--- a/packages/tool-registry/package.json
+++ b/packages/tool-registry/package.json
@@ -4,11 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "generate": "tsx src/generate.ts && pnpm exec oxfmt src/generated/*.ts",
-    "lint": "oxlint .",
-    "lint:fix": "oxlint --fix .",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check ."
+    "generate": "tsx src/generate.ts && pnpm exec oxfmt src/generated/*.ts"
   },
   "dependencies": {
     "@tool/base64-encoder-decoder": "workspace:*",

--- a/packages/tool-sdk/package.json
+++ b/packages/tool-sdk/package.json
@@ -3,12 +3,6 @@
   "version": "0.0.0",
   "type": "module",
   "private": true,
-  "scripts": {
-    "lint": "oxlint .",
-    "lint:fix": "oxlint --fix .",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check ."
-  },
   "dependencies": {
     "zod": "catalog:"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,12 +3,6 @@
   "version": "0.0.0",
   "type": "module",
   "private": true,
-  "scripts": {
-    "lint": "oxlint .",
-    "lint:fix": "oxlint --fix .",
-    "format": "oxfmt .",
-    "format:check": "oxfmt --check ."
-  },
   "dependencies": {
     "class-variance-authority": "catalog:",
     "clsx": "catalog:",


### PR DESCRIPTION
## Summary
- Remove `lint`, `lint:fix`, `format`, `format:check` from `apps/web`, `packages/tool-sdk`, `packages/tool-registry`, and `packages/ui` `package.json` files. They were dead code: CI calls the root scripts only, and lint-staged invokes the binaries directly. Same logic that put `typescript` at root-only in #368 — `oxlint`/`oxfmt` are workspace-wide CLI tools, not per-package concerns.
- `apps/web` keeps its `typecheck` script (`astro check`) because that one is unique to the app and called by the root `typecheck` script.

## Test plan
- [x] `pnpm lint`, `pnpm format:check`, `pnpm typecheck` all green locally
- [ ] CI Code Check passes