### PR TITLE
ci: enforce pnpm dedupe --check in Code Check

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,6 +32,9 @@ jobs:
           cache: true
           run_install: true
 
+      - name: Verify pnpm lockfile is deduped
+        run: pnpm dedupe --check
+
       - name: Lint
         run: pnpm lint
 


### PR DESCRIPTION
## Summary
- Add `pnpm dedupe --check` as a Code Check step. The pnpm catalog (#367) keeps `package.json` versions in lockstep, but transitive dependencies can still leave the lockfile with duplicate resolutions; this check is the missing belt-and-suspenders that prevents the kind of situation that motivated the React dedupe in #355.

## Test plan
- [x] `pnpm dedupe --check` clean locally
- [ ] CI Code Check passes