### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,32 @@
+name: Actionlint
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - dev/astro-rewrite-base
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+concurrency:
+  group: actionlint-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: Lint workflows
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color


### PR DESCRIPTION
## Summary
- Add `.github/workflows/actionlint.yml`. Runs `rhysd/actionlint` (via the official Docker image) on every change to `.github/workflows/**` or `.github/actions/**`. Catches broken `${{ }}` expressions, unknown contexts, missing inputs, and shellcheck issues inside `run:` blocks before the workflow fails at runtime.
- Path-filtered: only triggers when workflow files change, so it doesn't add noise to unrelated PRs.

## Test plan
- [ ] This PR's own actionlint job passes (the new workflow file is itself the input)
- [ ] Editing a workflow on a follow-up PR with a deliberately broken expression should fail this check