### PR TITLE
ci: check built HTML for broken internal links with htmltest

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -83,6 +83,11 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check internal links in built HTML
+        uses: wjdp/htmltest-action@master
+        with:
+          config: .htmltest.yml
+
       - name: Upload web artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -1,0 +1,10 @@
+DirectoryPath: apps/web/dist
+CheckExternal: false
+CheckInternal: true
+CheckInternalHash: true
+CheckImages: true
+CheckScripts: true
+CheckLinks: true
+IgnoreInternalEmptyHash: true
+IgnoreEmptyHref: true
+EnforceHTTPS: false

--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -7,4 +7,5 @@ CheckScripts: true
 CheckLinks: true
 IgnoreInternalEmptyHash: true
 IgnoreEmptyHref: true
+IgnoreDirectoryMissingTrailingSlash: true
 EnforceHTTPS: false


### PR DESCRIPTION
## Summary
- Add `.htmltest.yml` configured for **internal-only** checks: `<a>`, `<img>`, `<script>`, `<link>`, and anchor (`#id`) targets in `apps/web/dist`. External links are off so the gate is fully deterministic and never flakes.
- Wire `wjdp/htmltest-action` into the existing `Build Web` job, right after `pnpm build` and before the artifact upload. No new workflow file, no extra build cost.

This catches the cases that source-markdown link checking can't see, because most of our internal links live in Astro-generated routes (language switcher, alternate links, nav, canonical URLs, mdx anchors) — not in handwritten markdown.

## Test plan
- [ ] CI Build Web step "Check internal links in built HTML" passes
- [ ] Future PR that deletes a tool without updating nav links should fail this step