### PR TITLE
ci: post vitest coverage report comment on every PR

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -51,6 +52,13 @@ jobs:
 
       - name: Test
         run: pnpm test:coverage
+
+      - name: Coverage report
+        if: github.event_name == 'pull_request'
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          json-summary-path: coverage/coverage-summary.json
+          json-final-path: coverage/coverage-final.json
 
       - name: Dep boundaries
         run: pnpm depcruise

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default getViteConfig({
     environment: "happy-dom",
     coverage: {
       provider: "v8",
+      reporter: ["text", "html", "json-summary", "json"],
       include: ["packages/tool-sdk/src/**/*.ts", "tools/**/*.{ts,tsx}"],
       exclude: ["**/*.test.{ts,tsx}", "**/manifest.ts"],
       thresholds: {


### PR DESCRIPTION
## Summary
- Add `json-summary` and `json` reporters to vitest's coverage config so we produce `coverage/coverage-summary.json` and `coverage/coverage-final.json` alongside the existing text + html outputs.
- Run `davelosert/vitest-coverage-report-action@v2` in the `Code Check` job on PR events. It reads the summary and posts a single rolling PR comment with current absolute coverage numbers per file, color-coded against the thresholds we already enforce in `vitest.config.ts`.
- Grant the job `pull-requests: write` so it can post the comment.
- This is intentionally the **no-delta** variant — no `main` artifact dance, no fork-PR edge cases. Coverage thresholds are already strictly enforced (#360); this PR just makes the numbers visible to reviewers.

## Test plan
- [x] `pnpm test:coverage` produces `coverage/coverage-summary.json` locally
- [ ] CI Code Check passes and the action posts a comment on this PR