### PR TITLE
ci: run Build Web in parallel with Code Check

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -69,8 +69,6 @@ jobs:
   build-web:
     name: Build Web
     runs-on: ubuntu-latest
-    needs:
-      - code-check
     permissions:
       contents: read
     steps:
@@ -106,6 +104,7 @@ jobs:
     name: Deploy Staging
     runs-on: ubuntu-latest
     needs:
+      - code-check
       - build-web
     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev/astro-rewrite-base'
     permissions:
@@ -147,6 +146,7 @@ jobs:
     name: Deploy Preview
     runs-on: ubuntu-latest
     needs:
+      - code-check
       - build-web
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:


### PR DESCRIPTION
## Summary
- `build-web` no longer `needs: code-check` — they run in parallel, cutting PR wall-clock roughly in half.
- `deploy-staging` and `deploy-preview` now `needs: [code-check, build-web]`, so a failing check still blocks deploys.

## Test plan
- [ ] This PR's own checks pass (Code Check + Build Web start at the same time)
- [ ] Deploy Preview still runs after both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)