### PR TITLE
feat(web): use @astrojs/sitemap and add robots.txt

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -4,6 +4,12 @@ import tailwindcss from "@tailwindcss/vite"
 import { defineConfig } from "astro/config"
 import mdx from "@astrojs/mdx"
 import react from "@astrojs/react"
+import sitemap from "@astrojs/sitemap"
+
+import {
+  DEFAULT_SITE_LANGUAGE,
+  SUPPORTED_SITE_LANGUAGES,
+} from "./src/lib/site.ts"
 
 // https://astro.build/config
 export default defineConfig({
@@ -11,7 +17,18 @@ export default defineConfig({
   vite: {
     plugins: [tailwindcss()],
   },
-  integrations: [mdx(), react()],
+  integrations: [
+    mdx(),
+    react(),
+    sitemap({
+      i18n: {
+        defaultLocale: DEFAULT_SITE_LANGUAGE,
+        locales: Object.fromEntries(
+          SUPPORTED_SITE_LANGUAGES.map((locale) => [locale, locale])
+        ),
+      },
+    }),
+  ],
   prefetch: {
     prefetchAll: true,
     defaultStrategy: "hover",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@astrojs/mdx": "catalog:",
     "@astrojs/react": "catalog:",
+    "@astrojs/sitemap": "catalog:",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@workspace/tool-registry": "workspace:*",

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://inbrowser.app/sitemap-index.xml

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -1,15 +1,10 @@
-import { toolStaticPaths } from "@workspace/tool-registry"
-
 import type { SiteLanguage } from "./site"
 import type { AlternateLink } from "./site"
 
 import {
-  DEFAULT_SITE_LANGUAGE,
   SUPPORTED_SITE_LANGUAGES,
   getAlternateLinks,
   getCanonicalUrl,
-  isSupportedSiteLanguage,
-  resolveLocalizedAssetLanguage,
 } from "./site"
 
 type PageSeo = Readonly<{
@@ -17,11 +12,6 @@ type PageSeo = Readonly<{
   description: string
   canonicalUrl: string
   alternateLinks: readonly AlternateLink[]
-}>
-
-type SitemapEntry = Readonly<{
-  loc: string
-  alternates: readonly AlternateLink[]
 }>
 
 function createPageSeo(options: {
@@ -42,79 +32,4 @@ function createPageSeo(options: {
   } as const satisfies PageSeo
 }
 
-function getSitemapEntries() {
-  const entries: SitemapEntry[] = [
-    {
-      alternates: getAlternateLinks("/", SUPPORTED_SITE_LANGUAGES),
-      loc: getCanonicalUrl("/", DEFAULT_SITE_LANGUAGE),
-    },
-    {
-      alternates: getAlternateLinks("/tools", SUPPORTED_SITE_LANGUAGES),
-      loc: getCanonicalUrl("/tools", DEFAULT_SITE_LANGUAGE),
-    },
-  ]
-
-  const toolLanguagesBySlug = new Map<string, SiteLanguage[]>()
-
-  for (const { language, slug } of toolStaticPaths) {
-    if (!isSupportedSiteLanguage(language)) {
-      continue
-    }
-
-    const existingLanguages = toolLanguagesBySlug.get(slug) ?? []
-
-    if (!existingLanguages.includes(language)) {
-      existingLanguages.push(language)
-      existingLanguages.sort((left, right) => left.localeCompare(right))
-      toolLanguagesBySlug.set(slug, existingLanguages)
-    }
-  }
-
-  for (const [slug, languages] of toolLanguagesBySlug.entries()) {
-    const canonicalLanguage = resolveLocalizedAssetLanguage(
-      DEFAULT_SITE_LANGUAGE,
-      languages,
-      DEFAULT_SITE_LANGUAGE
-    )
-
-    entries.push({
-      alternates: getAlternateLinks(`/tools/${slug}`, languages),
-      loc: getCanonicalUrl(`/tools/${slug}`, canonicalLanguage),
-    })
-  }
-
-  return entries
-}
-
-function escapeXml(value: string) {
-  return value
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&apos;")
-}
-
-function buildSitemapXml(entries: readonly SitemapEntry[]) {
-  const urls = entries
-    .map(
-      (entry) => `<url>
-  <loc>${escapeXml(entry.loc)}</loc>
-${entry.alternates
-  .map(
-    (alternate) =>
-      `  <xhtml:link rel="alternate" hreflang="${escapeXml(alternate.hrefLang)}" href="${escapeXml(alternate.href)}" />`
-  )
-  .join("\n")}
-</url>`
-    )
-    .join("\n")
-
-  return `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-${urls}
-</urlset>
-`
-}
-
-export { buildSitemapXml, createPageSeo, getSitemapEntries }
+export { createPageSeo }

--- a/apps/web/src/pages/sitemap.xml.ts
+++ b/apps/web/src/pages/sitemap.xml.ts
@@ -1,8 +1,0 @@
-import { buildSitemapXml, getSitemapEntries } from "@/lib/seo"
-export async function GET() {
-  return new Response(buildSitemapXml(getSitemapEntries()), {
-    headers: {
-      "Content-Type": "application/xml; charset=utf-8",
-    },
-  })
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@astrojs/react':
       specifier: ^4.4.2
       version: 4.4.2
+    '@astrojs/sitemap':
+      specifier: ^3.7.2
+      version: 3.7.2
     '@commitlint/cli':
       specifier: ^20.5.0
       version: 20.5.0
@@ -167,6 +170,9 @@ importers:
       '@astrojs/react':
         specifier: 'catalog:'
         version: 4.4.2(@types/node@25.5.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tsx@4.21.0)(yaml@2.8.3)
+      '@astrojs/sitemap':
+        specifier: 'catalog:'
+        version: 3.7.2
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -417,6 +423,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/sitemap@3.7.2':
+    resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -3042,6 +3051,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@24.12.2':
+    resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
+
   '@types/node@25.5.2':
     resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
 
@@ -3052,6 +3064,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/sax@1.2.7':
+    resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
@@ -3222,6 +3237,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -5234,6 +5252,11 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  sitemap@9.0.1:
+    resolution: {integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==}
+    engines: {node: '>=20.19.5', npm: '>=10.8.2'}
+    hasBin: true
+
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -5274,6 +5297,9 @@ packages:
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
     engines: {node: '>=18'}
+
+  stream-replace-string@2.0.0:
+    resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
@@ -5479,6 +5505,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -6117,6 +6146,12 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  '@astrojs/sitemap@3.7.2':
+    dependencies:
+      sitemap: 9.0.1
+      stream-replace-string: 2.0.0
+      zod: 4.3.6
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -8339,6 +8374,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@24.12.2':
+    dependencies:
+      undici-types: 7.16.0
+
   '@types/node@25.5.2':
     dependencies:
       undici-types: 7.18.2
@@ -8350,6 +8389,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/sax@1.2.7':
+    dependencies:
+      '@types/node': 25.5.2
 
   '@types/statuses@2.0.6': {}
 
@@ -8547,6 +8590,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  arg@5.0.2: {}
 
   argparse@2.0.1: {}
 
@@ -11304,6 +11349,13 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  sitemap@9.0.1:
+    dependencies:
+      '@types/node': 24.12.2
+      '@types/sax': 1.2.7
+      arg: 5.0.2
+      sax: 1.6.0
+
   slice-ansi@7.1.2:
     dependencies:
       ansi-styles: 6.2.3
@@ -11331,6 +11383,8 @@ snapshots:
   std-env@4.0.0: {}
 
   stdin-discarder@0.2.2: {}
+
+  stream-replace-string@2.0.0: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -11511,6 +11565,8 @@ snapshots:
   unbash@2.2.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici-types@7.16.0: {}
 
   undici-types@7.18.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ catalog:
   "@astrojs/check": ^0.9.8
   "@astrojs/mdx": ^4.3.14
   "@astrojs/react": ^4.4.2
+  "@astrojs/sitemap": ^3.7.2
   "@commitlint/cli": ^20.5.0
   "@commitlint/config-conventional": ^20.5.0
   "@tailwindcss/vite": ^4.1.18


### PR DESCRIPTION
## Summary
- Replace the hand-rolled `apps/web/src/pages/sitemap.xml.ts` (and the `buildSitemapXml` / `getSitemapEntries` helpers in `lib/seo.ts`) with the official `@astrojs/sitemap` integration.
- Wire the integration's `i18n` option from `DEFAULT_SITE_LANGUAGE` / `SUPPORTED_SITE_LANGUAGES` in `apps/web/src/lib/site.ts` so language config stays single-source. `astro.config.mjs` imports the `.ts` directly (Vite handles loading).
- Add `apps/web/public/robots.txt` pointing crawlers at `/sitemap-index.xml`.

Build now emits `/sitemap-index.xml` + `/sitemap-0.xml` with 115 URLs (5 path families × 23 locales) and reciprocal `hreflang` alternates per URL.

### Known regression vs the old custom sitemap
The previous hand-written sitemap emitted an `x-default` `hreflang`. `@astrojs/sitemap` does not by default; can be added later via a `serialize` hook if desired.

## Test plan
- [x] `pnpm build` — sitemap-index.xml + sitemap-0.xml emitted, robots.txt copied through
- [x] `pnpm typecheck` — clean
- [ ] `pnpm lint` — pre-existing failure on `dev/astro-rewrite-base` (max-lines override glob doesn't exclude `packages/tool-registry/src/generated/**`); unrelated to this PR
- [ ] Manually verify `/sitemap-index.xml`, `/sitemap-0.xml`, and `/robots.txt` on the deploy preview