### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ npm-debug.log*
 # Misc
 .DS_Store
 *.pem
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
Claude Code creates worktrees under `.claude/worktrees/` which show up as untracked in `git status`. Add to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)