### PR TITLE
feat(ui): add tool migration primitives

### DIFF
--- a/packages/ui/src/components/tool/tool-page-shell.tsx
+++ b/packages/ui/src/components/tool/tool-page-shell.tsx
@@ -21,7 +21,7 @@ function ToolPageShell({
       className={cn("flex flex-col gap-[var(--spacing-section-y)]", className)}
     >
       <header className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
-        <div className="space-y-2">
+        <div className="flex flex-col gap-2">
           <h1 className="font-heading text-3xl leading-none tracking-[var(--tracking-display)] text-balance sm:text-4xl">
             {title}
           </h1>

--- a/packages/ui/src/components/ui/empty.tsx
+++ b/packages/ui/src/components/ui/empty.tsx
@@ -1,0 +1,105 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentProps } from "react"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+function Empty({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex w-full min-w-0 flex-1 flex-col items-center justify-center gap-4 rounded-xl border-dashed p-6 text-center text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn("flex max-w-sm flex-col items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "size-8 rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-4",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-media"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn(
+        "font-heading text-sm font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-2.5 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+}

--- a/packages/ui/src/components/ui/field.tsx
+++ b/packages/ui/src/components/ui/field.tsx
@@ -1,0 +1,234 @@
+"use client"
+
+import { useMemo, type ComponentProps, type ReactNode } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { Label } from "@workspace/ui/components/ui/label"
+import { Separator } from "@workspace/ui/components/ui/separator"
+import { cn } from "@workspace/ui/lib/utils"
+
+function FieldSet({ className, ...props }: ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-4 has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-1.5 font-medium data-[variant=label]:text-sm data-[variant=legend]:text-base",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-5 data-[slot=checkbox-group]:gap-3 *:data-[slot=field-group]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-2 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: "flex-col *:w-full [&>.sr-only]:w-auto",
+        horizontal:
+          "flex-row items-center has-[>[data-slot=field-content]]:items-start *:data-[slot=field-label]:flex-auto has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        responsive:
+          "flex-col *:w-full @md/field-group:flex-row @md/field-group:items-center @md/field-group:*:w-auto @md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:*:data-[slot=field-label]:flex-auto [&>.sr-only]:w-auto @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-0.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({ className, ...props }: ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50 has-data-checked:border-primary/30 has-data-checked:bg-primary/5 has-[>[data-slot=field]]:rounded-lg has-[>[data-slot=field]]:border *:data-[slot=field]:p-2.5 dark:has-data-checked:border-primary/20 dark:has-data-checked:bg-primary/10",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-left text-sm leading-normal font-normal text-muted-foreground group-data-[orientation=horizontal]/field:text-balance [[data-variant=legend]+&]:-mt-1.5",
+        "last:mt-0 nth-last-2:-mt-1",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: ComponentProps<"div"> & {
+  children?: ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={Boolean(children)}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children ? (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors.length === 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map((error, index) =>
+          error?.message ? <li key={index}>{error.message}</li> : null
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldTitle,
+}

--- a/packages/ui/src/components/ui/input-group.tsx
+++ b/packages/ui/src/components/ui/input-group.tsx
@@ -1,0 +1,157 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentProps } from "react"
+
+import { Button } from "@workspace/ui/components/ui/button"
+import { Input } from "@workspace/ui/components/ui/input"
+import { Textarea } from "@workspace/ui/components/ui/textarea"
+import { cn } from "@workspace/ui/lib/utils"
+
+function InputGroup({ className, ...props }: ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
+        "inline-end":
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
+        "block-start":
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
+        "block-end":
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onMouseDown={(event) => {
+        if ((event.target as HTMLElement).closest("button")) {
+          return
+        }
+
+        event.preventDefault()
+        event.currentTarget.parentElement
+          ?.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+            "input, textarea"
+          )
+          ?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({ className, ...props }: ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+}

--- a/packages/ui/src/components/ui/toggle-group.tsx
+++ b/packages/ui/src/components/ui/toggle-group.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import {
+  createContext,
+  useContext,
+  type CSSProperties,
+  type ComponentProps,
+} from "react"
+import { type VariantProps } from "class-variance-authority"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { toggleVariants } from "@workspace/ui/components/ui/toggle"
+import { cn } from "@workspace/ui/lib/utils"
+
+type ToggleGroupContextValue = VariantProps<typeof toggleVariants> & {
+  spacing?: number
+  orientation?: "horizontal" | "vertical"
+}
+
+const ToggleGroupContext = createContext<ToggleGroupContextValue>({
+  size: "default",
+  variant: "default",
+  spacing: 0,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 0,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ComponentProps<typeof ToggleGroupPrimitive.Root> &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive.Root
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={
+        {
+          "--toggle-group-gap": `${spacing}px`,
+        } as CSSProperties
+      }
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[var(--toggle-group-gap)] rounded-lg data-[orientation=vertical]:flex-col data-[orientation=vertical]:items-stretch",
+        className
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider
+        value={{ variant, size, spacing, orientation }}
+      >
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: ComponentProps<typeof ToggleGroupPrimitive.Item> &
+  VariantProps<typeof toggleVariants>) {
+  const context = useContext(ToggleGroupContext)
+
+  return (
+    <ToggleGroupPrimitive.Item
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:first:rounded-l-lg group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:first:rounded-t-lg group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:last:rounded-r-lg group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:last:rounded-b-lg group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-[orientation=horizontal]/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-[orientation=vertical]/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </ToggleGroupPrimitive.Item>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/packages/ui/src/components/ui/toggle.tsx
+++ b/packages/ui/src/components/ui/toggle.tsx
@@ -1,0 +1,45 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentProps } from "react"
+import { Toggle as TogglePrimitive } from "radix-ui"
+
+import { cn } from "@workspace/ui/lib/utils"
+
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-lg text-sm font-medium whitespace-nowrap transition-all outline-none hover:bg-muted hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-muted data-[state=on]:bg-muted dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-muted",
+      },
+      size: {
+        default:
+          "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-7 min-w-7 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+        lg: "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: ComponentProps<typeof TogglePrimitive.Root> &
+  VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive.Root
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/tools/image-resizer/client/options-card.tsx
+++ b/tools/image-resizer/client/options-card.tsx
@@ -9,8 +9,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@workspace/ui/components/ui/card"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+} from "@workspace/ui/components/ui/field"
 import { Input } from "@workspace/ui/components/ui/input"
-import { Label } from "@workspace/ui/components/ui/label"
 import {
   Select,
   SelectContent,
@@ -81,162 +88,175 @@ export function OptionsCard({
         <CardTitle>{messages.optionsTitle}</CardTitle>
         <CardDescription>{messages.optionsDescription}</CardDescription>
       </CardHeader>
-      <CardContent className="flex flex-1 flex-col gap-5">
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
-          <div className="space-y-2">
-            <Label htmlFor={`${inputId}-width`}>{messages.widthLabel}</Label>
-            <Input
-              id={`${inputId}-width`}
-              type="number"
-              min={1}
-              value={options.width}
-              onChange={(event) => {
-                updateWidth(Math.max(1, Number(event.target.value) || 1))
-              }}
-            />
+      <CardContent className="flex flex-1 flex-col">
+        <FieldGroup>
+          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
+            <Field>
+              <FieldLabel htmlFor={`${inputId}-width`}>
+                {messages.widthLabel}
+              </FieldLabel>
+              <Input
+                id={`${inputId}-width`}
+                type="number"
+                min={1}
+                value={options.width}
+                onChange={(event) => {
+                  updateWidth(Math.max(1, Number(event.target.value) || 1))
+                }}
+              />
+            </Field>
+
+            <Field>
+              <FieldLabel htmlFor={`${inputId}-height`}>
+                {messages.heightLabel}
+              </FieldLabel>
+              <Input
+                id={`${inputId}-height`}
+                type="number"
+                min={1}
+                value={options.height}
+                onChange={(event) => {
+                  updateHeight(Math.max(1, Number(event.target.value) || 1))
+                }}
+              />
+            </Field>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor={`${inputId}-height`}>{messages.heightLabel}</Label>
-            <Input
-              id={`${inputId}-height`}
-              type="number"
-              min={1}
-              value={options.height}
-              onChange={(event) => {
-                updateHeight(Math.max(1, Number(event.target.value) || 1))
-              }}
-            />
-          </div>
-        </div>
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
+            <Field>
+              <FieldLabel>{messages.algorithmLabel}</FieldLabel>
+              <Select
+                value={options.algorithm}
+                onValueChange={(value) => {
+                  setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    algorithm: value as ResizeAlgorithm,
+                  }))
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {
+                      algorithmOptions.find(
+                        (o) => o.value === options.algorithm
+                      )?.label
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>{messages.algorithmLabel}</SelectLabel>
+                    {algorithmOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
 
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-1">
-          <div className="flex flex-col gap-2">
-            <Label>{messages.algorithmLabel}</Label>
-            <Select
-              value={options.algorithm}
-              onValueChange={(value) => {
+            <Field>
+              <FieldLabel>{messages.formatLabel}</FieldLabel>
+              <Select
+                value={options.outputFormat}
+                onValueChange={(value) => {
+                  setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    outputFormat: value as ResizeOutputFormat,
+                  }))
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue>
+                    {
+                      formatOptions.find(
+                        (o) => o.value === options.outputFormat
+                      )?.label
+                    }
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>{messages.formatLabel}</SelectLabel>
+                    {formatOptions.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+          </div>
+
+          <Field>
+            <div className="flex items-center justify-between gap-3">
+              <FieldTitle>{messages.qualityLabel}</FieldTitle>
+              <span className="font-mono text-sm text-muted-foreground">
+                {options.quality}
+              </span>
+            </div>
+            <Slider
+              aria-label={messages.qualityLabel}
+              min={1}
+              max={100}
+              value={[options.quality]}
+              onValueChange={([value]) => {
+                if (value === undefined) return
                 setOptions((currentOptions) => ({
                   ...currentOptions,
-                  algorithm: value as ResizeAlgorithm,
+                  quality: value,
                 }))
               }}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue>
-                  {
-                    algorithmOptions.find((o) => o.value === options.algorithm)
-                      ?.label
-                  }
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>{messages.algorithmLabel}</SelectLabel>
-                  {algorithmOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
+            />
+            <FieldDescription>{messages.qualityDescription}</FieldDescription>
+          </Field>
 
-          <div className="flex flex-col gap-2">
-            <Label>{messages.formatLabel}</Label>
-            <Select
-              value={options.outputFormat}
-              onValueChange={(value) => {
+          <Field orientation="horizontal">
+            <FieldContent>
+              <FieldLabel htmlFor={`${inputId}-keep-aspect-ratio`}>
+                {messages.keepAspectRatioLabel}
+              </FieldLabel>
+              <FieldDescription>
+                {messages.keepAspectRatioDescription}
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              id={`${inputId}-keep-aspect-ratio`}
+              checked={options.keepAspectRatio}
+              onCheckedChange={(checked) => {
                 setOptions((currentOptions) => ({
                   ...currentOptions,
-                  outputFormat: value as ResizeOutputFormat,
+                  keepAspectRatio: checked,
                 }))
               }}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue>
-                  {
-                    formatOptions.find((o) => o.value === options.outputFormat)
-                      ?.label
-                  }
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>{messages.formatLabel}</SelectLabel>
-                  {formatOptions.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectGroup>
-              </SelectContent>
-            </Select>
-          </div>
-        </div>
+              aria-label={messages.keepAspectRatioLabel}
+            />
+          </Field>
 
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <Label>{messages.qualityLabel}</Label>
-            <span className="font-mono text-sm text-muted-foreground">
-              {options.quality}
-            </span>
-          </div>
-          <Slider
-            min={1}
-            max={100}
-            value={[options.quality]}
-            onValueChange={([value]) => {
-              if (value === undefined) return
-              setOptions((currentOptions) => ({
-                ...currentOptions,
-                quality: value,
-              }))
-            }}
-          />
-          <p className="text-sm leading-6 text-muted-foreground">
-            {messages.qualityDescription}
-          </p>
-        </div>
-
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <Label>{messages.keepAspectRatioLabel}</Label>
-            <p className="text-sm leading-6 text-muted-foreground">
-              {messages.keepAspectRatioDescription}
-            </p>
-          </div>
-          <Switch
-            checked={options.keepAspectRatio}
-            onCheckedChange={(checked) => {
-              setOptions((currentOptions) => ({
-                ...currentOptions,
-                keepAspectRatio: checked,
-              }))
-            }}
-            aria-label={messages.keepAspectRatioLabel}
-          />
-        </div>
-
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-1">
-            <Label>{messages.allowUpscaleLabel}</Label>
-            <p className="text-sm leading-6 text-muted-foreground">
-              {messages.allowUpscaleDescription}
-            </p>
-          </div>
-          <Switch
-            checked={options.allowUpscale}
-            onCheckedChange={(checked) => {
-              setOptions((currentOptions) => ({
-                ...currentOptions,
-                allowUpscale: checked,
-              }))
-            }}
-            aria-label={messages.allowUpscaleLabel}
-          />
-        </div>
+          <Field orientation="horizontal">
+            <FieldContent>
+              <FieldLabel htmlFor={`${inputId}-allow-upscale`}>
+                {messages.allowUpscaleLabel}
+              </FieldLabel>
+              <FieldDescription>
+                {messages.allowUpscaleDescription}
+              </FieldDescription>
+            </FieldContent>
+            <Switch
+              id={`${inputId}-allow-upscale`}
+              checked={options.allowUpscale}
+              onCheckedChange={(checked) => {
+                setOptions((currentOptions) => ({
+                  ...currentOptions,
+                  allowUpscale: checked,
+                }))
+              }}
+              aria-label={messages.allowUpscaleLabel}
+            />
+          </Field>
+        </FieldGroup>
       </CardContent>
       <CardFooter className="justify-between gap-3">
         <Button type="button" variant="ghost" size="sm" onClick={onReset}>

--- a/tools/image-resizer/client/result-card.tsx
+++ b/tools/image-resizer/client/result-card.tsx
@@ -1,11 +1,6 @@
 import { Badge } from "@workspace/ui/components/ui/badge"
 import { Button } from "@workspace/ui/components/ui/button"
 import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@workspace/ui/components/ui/alert"
-import {
   Card,
   CardContent,
   CardDescription,
@@ -13,6 +8,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@workspace/ui/components/ui/card"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/ui/empty"
 import { Download, ImageUp } from "@workspace/ui/icons"
 
 import type { ImageDimensions, ResizeResult } from "../core/resize-image"
@@ -44,7 +46,7 @@ export function ResultCard({
         {result && resultPreviewUrl && sourcePreviewUrl && sourceDimensions ? (
           <>
             <div className="grid gap-4 lg:grid-cols-2">
-              <div className="space-y-3">
+              <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-foreground">
                     {messages.originalLabel}
@@ -62,7 +64,7 @@ export function ResultCard({
                 </div>
               </div>
 
-              <div className="space-y-3">
+              <div className="flex flex-col gap-3">
                 <div className="flex items-center gap-2">
                   <span className="text-sm font-medium text-foreground">
                     {messages.outputLabel}
@@ -89,13 +91,17 @@ export function ResultCard({
             </div>
           </>
         ) : (
-          <Alert>
-            <ImageUp />
-            <AlertTitle>{messages.emptyResultTitle}</AlertTitle>
-            <AlertDescription>
-              {messages.emptyResultDescription}
-            </AlertDescription>
-          </Alert>
+          <Empty className="border border-dashed border-border/80 bg-muted/20">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <ImageUp />
+              </EmptyMedia>
+              <EmptyTitle>{messages.emptyResultTitle}</EmptyTitle>
+              <EmptyDescription>
+                {messages.emptyResultDescription}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
         )}
       </CardContent>
       {result && resultPreviewUrl ? (

--- a/tools/image-resizer/client/upload-card.tsx
+++ b/tools/image-resizer/client/upload-card.tsx
@@ -6,6 +6,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@workspace/ui/components/ui/card"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/ui/empty"
 import { ImageUp } from "@workspace/ui/icons"
 
 import type { ImageDimensions } from "../core/resize-image"
@@ -66,17 +73,18 @@ export function UploadCard({
         ) : (
           <label
             htmlFor={inputId}
-            className="flex flex-1 cursor-pointer flex-col items-center justify-center rounded-xl border border-dashed border-border/80 bg-muted/30 px-6 py-8 text-center transition-colors hover:border-foreground/20 hover:bg-muted/45"
+            aria-label={messages.chooseImageLabel}
+            className="block cursor-pointer"
           >
-            <ImageUp className="size-6 text-muted-foreground" />
-            <div className="mt-4 space-y-1">
-              <p className="font-medium text-foreground">
-                {messages.chooseImageLabel}
-              </p>
-              <p className="text-sm leading-6 text-muted-foreground">
-                {messages.uploadHint}
-              </p>
-            </div>
+            <Empty className="border border-dashed border-border/80 bg-muted/30 transition-colors hover:border-foreground/20 hover:bg-muted/45">
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <ImageUp />
+                </EmptyMedia>
+                <EmptyTitle>{messages.chooseImageLabel}</EmptyTitle>
+                <EmptyDescription>{messages.uploadHint}</EmptyDescription>
+              </EmptyHeader>
+            </Empty>
           </label>
         )}
         <input

--- a/tools/json-schema-validator/client.tsx
+++ b/tools/json-schema-validator/client.tsx
@@ -17,7 +17,14 @@ import {
   CardHeader,
   CardTitle,
 } from "@workspace/ui/components/ui/card"
-import { Label } from "@workspace/ui/components/ui/label"
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+} from "@workspace/ui/components/ui/field"
 import { Switch } from "@workspace/ui/components/ui/switch"
 import { Textarea } from "@workspace/ui/components/ui/textarea"
 import { FileJson2, RefreshCcw } from "@workspace/ui/icons"
@@ -192,46 +199,54 @@ function JsonSchemaValidatorClient({
             <CardTitle>{messages.optionsTitle}</CardTitle>
             <CardDescription>{messages.optionsDescription}</CardDescription>
           </CardHeader>
-          <CardContent className="flex flex-1 flex-col gap-5">
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <Label>{messages.validateFormatsLabel}</Label>
-                <p className="text-sm leading-6 text-muted-foreground">
-                  {messages.validateFormatsDescription}
-                </p>
-              </div>
-              <Switch
-                checked={validateFormats}
-                onCheckedChange={setValidateFormats}
-                aria-label={messages.validateFormatsLabel}
-              />
-            </div>
+          <CardContent className="flex flex-1 flex-col">
+            <FieldGroup>
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <FieldLabel htmlFor="validate-formats">
+                    {messages.validateFormatsLabel}
+                  </FieldLabel>
+                  <FieldDescription>
+                    {messages.validateFormatsDescription}
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="validate-formats"
+                  checked={validateFormats}
+                  onCheckedChange={setValidateFormats}
+                  aria-label={messages.validateFormatsLabel}
+                />
+              </Field>
 
-            <div className="flex items-start justify-between gap-4">
-              <div className="space-y-1">
-                <Label>{messages.allErrorsLabel}</Label>
-                <p className="text-sm leading-6 text-muted-foreground">
-                  {messages.allErrorsDescription}
-                </p>
-              </div>
-              <Switch
-                checked={allErrors}
-                onCheckedChange={setAllErrors}
-                aria-label={messages.allErrorsLabel}
-              />
-            </div>
+              <Field orientation="horizontal">
+                <FieldContent>
+                  <FieldLabel htmlFor="all-errors">
+                    {messages.allErrorsLabel}
+                  </FieldLabel>
+                  <FieldDescription>
+                    {messages.allErrorsDescription}
+                  </FieldDescription>
+                </FieldContent>
+                <Switch
+                  id="all-errors"
+                  checked={allErrors}
+                  onCheckedChange={setAllErrors}
+                  aria-label={messages.allErrorsLabel}
+                />
+              </Field>
 
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-foreground">
-                {messages.draftLabel}
-              </span>
-              <Badge variant="outline" className="font-mono">
-                {validation.state === "validated" ||
-                validation.state === "schema-error"
-                  ? validation.detectedDraft
-                  : "2020-12"}
-              </Badge>
-            </div>
+              <Field>
+                <div className="flex items-center gap-2">
+                  <FieldTitle>{messages.draftLabel}</FieldTitle>
+                  <Badge variant="outline" className="font-mono">
+                    {validation.state === "validated" ||
+                    validation.state === "schema-error"
+                      ? validation.detectedDraft
+                      : "2020-12"}
+                  </Badge>
+                </div>
+              </Field>
+            </FieldGroup>
           </CardContent>
           <CardFooter className="justify-between gap-3">
             <Button


### PR DESCRIPTION
## Summary
- add shared `@workspace/ui` primitives for migration-heavy tool UIs: `field`, `input-group`, `empty`, `toggle`, and `toggle-group`
- refactor the current migrated tool samples to use the shared baseline where it matters most
- normalize tool-page header spacing to the same gap-based pattern used elsewhere in the rewrite

## Why
Batch migration will drift quickly if each tool rebuilds form semantics, empty states, and simple option layouts by hand. This PR establishes a shared baseline before more leaf-tool migrations land.

This is foundation work for #379. It does not close a leaf migration issue.

## Impact
- gives formatter/converter/validator tools a stronger default form skeleton
- reduces repeated ad hoc spacing and label markup in migrated tools
- makes later leaf PRs smaller because they can compose shared primitives instead of recreating structure

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run packages/ui/src/components/tool/tool-page-shell.test.tsx tools/image-resizer/client.test.tsx tools/json-schema-validator/client.test.tsx`
- `pnpm exec oxlint packages/ui/src/components/tool/tool-page-shell.tsx packages/ui/src/components/ui/empty.tsx packages/ui/src/components/ui/field.tsx packages/ui/src/components/ui/input-group.tsx packages/ui/src/components/ui/toggle.tsx packages/ui/src/components/ui/toggle-group.tsx tools/image-resizer/client/options-card.tsx tools/image-resizer/client/result-card.tsx tools/image-resizer/client/upload-card.tsx tools/json-schema-validator/client.tsx`
