### PR TITLE
fix(ui): use checkboxes for tool option flags

### DIFF
--- a/tools/csv-to-json-converter/client.test.tsx
+++ b/tools/csv-to-json-converter/client.test.tsx
@@ -167,7 +167,7 @@ describe("CsvToJsonConverterClient", () => {
       target: { value: "Ada;36" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.noHeaderLabel,
       })
     )
@@ -178,7 +178,7 @@ describe("CsvToJsonConverterClient", () => {
       target: { value: ";" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.checkTypeLabel,
       })
     )
@@ -235,7 +235,7 @@ describe("CsvToJsonConverterClient", () => {
       target: { value: "name,age\nAda,36" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.checkTypeLabel,
       })
     )

--- a/tools/csv-to-json-converter/components/option-controls.tsx
+++ b/tools/csv-to-json-converter/components/option-controls.tsx
@@ -1,3 +1,4 @@
+import { Checkbox } from "@workspace/ui/components/ui/checkbox"
 import {
   Field,
   FieldContent,
@@ -14,11 +15,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@workspace/ui/components/ui/select"
-import { Switch } from "@workspace/ui/components/ui/switch"
 
 import type { SkipEmptyLinesMode } from "../core/convert-csv-to-json"
 
-type SwitchFieldProps = Readonly<{
+type CheckboxFieldProps = Readonly<{
   id: string
   label: string
   checked: boolean
@@ -45,23 +45,24 @@ type SelectFieldProps = Readonly<{
   onValueChange: (value: SkipEmptyLinesMode) => void
 }>
 
-function SwitchField({
+function CheckboxField({
   id,
   label,
   checked,
   onCheckedChange,
-}: SwitchFieldProps) {
+}: CheckboxFieldProps) {
   return (
     <Field orientation="horizontal">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(nextChecked) => {
+          onCheckedChange(Boolean(nextChecked))
+        }}
+      />
       <FieldContent>
         <FieldLabel htmlFor={id}>{label}</FieldLabel>
       </FieldContent>
-      <Switch
-        id={id}
-        checked={checked}
-        onCheckedChange={onCheckedChange}
-        aria-label={label}
-      />
     </Field>
   )
 }
@@ -133,4 +134,4 @@ function SkipEmptyLinesField({
   )
 }
 
-export { SkipEmptyLinesField, SwitchField, TextField }
+export { CheckboxField, SkipEmptyLinesField, TextField }

--- a/tools/csv-to-json-converter/components/options-card.tsx
+++ b/tools/csv-to-json-converter/components/options-card.tsx
@@ -16,7 +16,11 @@ import {
   type CsvToJsonOptions,
   type SkipEmptyLinesMode,
 } from "../core/convert-csv-to-json"
-import { SkipEmptyLinesField, SwitchField, TextField } from "./option-controls"
+import {
+  CheckboxField,
+  SkipEmptyLinesField,
+  TextField,
+} from "./option-controls"
 
 type OptionsCardProps = Readonly<{
   messages: CsvToJsonConverterMessages
@@ -62,7 +66,7 @@ function OptionsCard({ messages, options, setOptions }: OptionsCardProps) {
       <CardContent className="flex flex-col gap-6">
         <FieldGroup>
           <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-4">
-            <SwitchField
+            <CheckboxField
               id="csv-no-header"
               label={messages.noHeaderLabel}
               checked={options.noHeader}
@@ -139,7 +143,7 @@ function OptionsCard({ messages, options, setOptions }: OptionsCardProps) {
           </div>
 
           <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
-            <SwitchField
+            <CheckboxField
               id="csv-trim"
               label={messages.trimLabel}
               checked={options.trim}
@@ -147,7 +151,7 @@ function OptionsCard({ messages, options, setOptions }: OptionsCardProps) {
                 updateOption("trim", checked)
               }}
             />
-            <SwitchField
+            <CheckboxField
               id="csv-check-type"
               label={messages.checkTypeLabel}
               checked={options.checkType}
@@ -155,7 +159,7 @@ function OptionsCard({ messages, options, setOptions }: OptionsCardProps) {
                 updateOption("checkType", checked)
               }}
             />
-            <SwitchField
+            <CheckboxField
               id="csv-fast-mode"
               label={messages.fastModeLabel}
               checked={options.fastMode}

--- a/tools/image-resizer/client.test.tsx
+++ b/tools/image-resizer/client.test.tsx
@@ -356,10 +356,10 @@ describe("ImageResizerClient", () => {
     expect(aspectSwitch.getAttribute("data-state")).toBe("checked")
   })
 
-  test("toggling allow upscale switch", () => {
+  test("toggling allow upscale checkbox", () => {
     render(<ImageResizerClient messages={messages} />)
 
-    const upscaleSwitch = screen.getByRole("switch", {
+    const upscaleSwitch = screen.getByRole("checkbox", {
       name: "Allow upscale",
     })
 
@@ -392,7 +392,7 @@ describe("ImageResizerClient", () => {
     const widthInput = screen.getByLabelText("Width") as HTMLInputElement
     fireEvent.change(widthInput, { target: { value: "400" } })
 
-    const upscaleSwitch = screen.getByRole("switch", {
+    const upscaleSwitch = screen.getByRole("checkbox", {
       name: "Allow upscale",
     })
     fireEvent.click(upscaleSwitch)
@@ -906,7 +906,7 @@ describe("ImageResizerClient", () => {
     })
     expect(aspectSwitch.getAttribute("data-state")).toBe("unchecked")
 
-    const upscaleSwitch = screen.getByRole("switch", {
+    const upscaleSwitch = screen.getByRole("checkbox", {
       name: "Allow upscale",
     })
     expect(upscaleSwitch.getAttribute("data-state")).toBe("checked")

--- a/tools/image-resizer/client/options-card.tsx
+++ b/tools/image-resizer/client/options-card.tsx
@@ -9,6 +9,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@workspace/ui/components/ui/card"
+import { Checkbox } from "@workspace/ui/components/ui/checkbox"
 import {
   Field,
   FieldContent,
@@ -236,6 +237,16 @@ export function OptionsCard({
           </Field>
 
           <Field orientation="horizontal">
+            <Checkbox
+              id={`${inputId}-allow-upscale`}
+              checked={options.allowUpscale}
+              onCheckedChange={(checked) => {
+                setOptions((currentOptions) => ({
+                  ...currentOptions,
+                  allowUpscale: Boolean(checked),
+                }))
+              }}
+            />
             <FieldContent>
               <FieldLabel htmlFor={`${inputId}-allow-upscale`}>
                 {messages.allowUpscaleLabel}
@@ -244,17 +255,6 @@ export function OptionsCard({
                 {messages.allowUpscaleDescription}
               </FieldDescription>
             </FieldContent>
-            <Switch
-              id={`${inputId}-allow-upscale`}
-              checked={options.allowUpscale}
-              onCheckedChange={(checked) => {
-                setOptions((currentOptions) => ({
-                  ...currentOptions,
-                  allowUpscale: checked,
-                }))
-              }}
-              aria-label={messages.allowUpscaleLabel}
-            />
           </Field>
         </FieldGroup>
       </CardContent>

--- a/tools/json-schema-validator/client.test.tsx
+++ b/tools/json-schema-validator/client.test.tsx
@@ -221,13 +221,13 @@ describe("JsonSchemaValidatorClient", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
       // Toggle validateFormats off
-      const validateFormatsSwitch = screen.getByRole("switch", {
+      const validateFormatsSwitch = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       fireEvent.click(validateFormatsSwitch)
 
       // Toggle allErrors off
-      const allErrorsSwitch = screen.getByRole("switch", {
+      const allErrorsSwitch = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       fireEvent.click(allErrorsSwitch)
@@ -457,20 +457,20 @@ describe("JsonSchemaValidatorClient", () => {
     })
   })
 
-  describe("options: toggle switches", () => {
-    test("validateFormats switch starts checked", () => {
+  describe("options: checkboxes", () => {
+    test("validateFormats checkbox starts checked", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("checked")
     })
 
-    test("allErrors switch starts checked", () => {
+    test("allErrors checkbox starts checked", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("checked")
@@ -491,7 +491,7 @@ describe("JsonSchemaValidatorClient", () => {
       expect(screen.getByText(messages.invalidTitle)).toBeTruthy()
 
       // Turn off format validation
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       fireEvent.click(switchEl)
@@ -502,10 +502,10 @@ describe("JsonSchemaValidatorClient", () => {
       expect(screen.getByText(messages.validTitle)).toBeTruthy()
     })
 
-    test("toggling allErrors switch changes its state", () => {
+    test("toggling allErrors checkbox changes its state", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("checked")
@@ -544,7 +544,7 @@ describe("JsonSchemaValidatorClient", () => {
     test("saves validateFormats to localStorage on toggle", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       fireEvent.click(switchEl)
@@ -557,7 +557,7 @@ describe("JsonSchemaValidatorClient", () => {
     test("saves allErrors to localStorage on toggle", () => {
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       fireEvent.click(switchEl)
@@ -588,7 +588,7 @@ describe("JsonSchemaValidatorClient", () => {
 
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("unchecked")
@@ -599,7 +599,7 @@ describe("JsonSchemaValidatorClient", () => {
 
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("unchecked")
@@ -610,7 +610,7 @@ describe("JsonSchemaValidatorClient", () => {
 
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.validateFormatsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("checked")
@@ -621,7 +621,7 @@ describe("JsonSchemaValidatorClient", () => {
 
       render(<JsonSchemaValidatorClient messages={messages} />)
 
-      const switchEl = screen.getByRole("switch", {
+      const switchEl = screen.getByRole("checkbox", {
         name: messages.allErrorsLabel,
       })
       expect(switchEl.getAttribute("data-state")).toBe("checked")

--- a/tools/json-schema-validator/client.tsx
+++ b/tools/json-schema-validator/client.tsx
@@ -9,6 +9,7 @@ import {
 import { ToolCopyButton } from "@workspace/ui/components/tool/tool-copy-button"
 import { Badge } from "@workspace/ui/components/ui/badge"
 import { Button } from "@workspace/ui/components/ui/button"
+import { Checkbox } from "@workspace/ui/components/ui/checkbox"
 import {
   Card,
   CardContent,
@@ -25,7 +26,6 @@ import {
   FieldLabel,
   FieldTitle,
 } from "@workspace/ui/components/ui/field"
-import { Switch } from "@workspace/ui/components/ui/switch"
 import { Textarea } from "@workspace/ui/components/ui/textarea"
 import { FileJson2, RefreshCcw } from "@workspace/ui/icons"
 
@@ -202,6 +202,13 @@ function JsonSchemaValidatorClient({
           <CardContent className="flex flex-1 flex-col">
             <FieldGroup>
               <Field orientation="horizontal">
+                <Checkbox
+                  id="validate-formats"
+                  checked={validateFormats}
+                  onCheckedChange={(checked) => {
+                    setValidateFormats(Boolean(checked))
+                  }}
+                />
                 <FieldContent>
                   <FieldLabel htmlFor="validate-formats">
                     {messages.validateFormatsLabel}
@@ -210,15 +217,16 @@ function JsonSchemaValidatorClient({
                     {messages.validateFormatsDescription}
                   </FieldDescription>
                 </FieldContent>
-                <Switch
-                  id="validate-formats"
-                  checked={validateFormats}
-                  onCheckedChange={setValidateFormats}
-                  aria-label={messages.validateFormatsLabel}
-                />
               </Field>
 
               <Field orientation="horizontal">
+                <Checkbox
+                  id="all-errors"
+                  checked={allErrors}
+                  onCheckedChange={(checked) => {
+                    setAllErrors(Boolean(checked))
+                  }}
+                />
                 <FieldContent>
                   <FieldLabel htmlFor="all-errors">
                     {messages.allErrorsLabel}
@@ -227,12 +235,6 @@ function JsonSchemaValidatorClient({
                     {messages.allErrorsDescription}
                   </FieldDescription>
                 </FieldContent>
-                <Switch
-                  id="all-errors"
-                  checked={allErrors}
-                  onCheckedChange={setAllErrors}
-                  aria-label={messages.allErrorsLabel}
-                />
               </Field>
 
               <Field>

--- a/tools/json-to-xml-converter/client.test.tsx
+++ b/tools/json-to-xml-converter/client.test.tsx
@@ -176,7 +176,7 @@ describe("JsonToXmlConverterClient", () => {
       target: { value: "0" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.includeDeclarationLabel,
       })
     )

--- a/tools/json-to-xml-converter/components/options-card.tsx
+++ b/tools/json-to-xml-converter/components/options-card.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, SetStateAction } from "react"
 
+import { Checkbox } from "@workspace/ui/components/ui/checkbox"
 import {
   Card,
   CardContent,
@@ -16,7 +17,6 @@ import {
   FieldLabel,
 } from "@workspace/ui/components/ui/field"
 import { Input } from "@workspace/ui/components/ui/input"
-import { Switch } from "@workspace/ui/components/ui/switch"
 
 import {
   clampIndentSize,
@@ -135,6 +135,16 @@ function OptionsCard({
 
           <div className="grid gap-4 lg:grid-cols-2">
             <Field orientation="horizontal">
+              <Checkbox
+                id={includeDeclarationId}
+                checked={options.includeXmlDeclaration}
+                onCheckedChange={(checked) => {
+                  setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    includeXmlDeclaration: Boolean(checked),
+                  }))
+                }}
+              />
               <FieldContent>
                 <FieldLabel htmlFor={includeDeclarationId}>
                   {messages.includeDeclarationLabel}
@@ -143,20 +153,19 @@ function OptionsCard({
                   {messages.includeDeclarationDescription}
                 </FieldDescription>
               </FieldContent>
-              <Switch
-                id={includeDeclarationId}
-                checked={options.includeXmlDeclaration}
-                onCheckedChange={(checked) => {
-                  setOptions((currentOptions) => ({
-                    ...currentOptions,
-                    includeXmlDeclaration: checked,
-                  }))
-                }}
-                aria-label={messages.includeDeclarationLabel}
-              />
             </Field>
 
             <Field orientation="horizontal">
+              <Checkbox
+                id={expandEmptyElementsId}
+                checked={options.fullTagEmptyElement}
+                onCheckedChange={(checked) => {
+                  setOptions((currentOptions) => ({
+                    ...currentOptions,
+                    fullTagEmptyElement: Boolean(checked),
+                  }))
+                }}
+              />
               <FieldContent>
                 <FieldLabel htmlFor={expandEmptyElementsId}>
                   {messages.expandEmptyElementsLabel}
@@ -165,17 +174,6 @@ function OptionsCard({
                   {messages.expandEmptyElementsDescription}
                 </FieldDescription>
               </FieldContent>
-              <Switch
-                id={expandEmptyElementsId}
-                checked={options.fullTagEmptyElement}
-                onCheckedChange={(checked) => {
-                  setOptions((currentOptions) => ({
-                    ...currentOptions,
-                    fullTagEmptyElement: checked,
-                  }))
-                }}
-                aria-label={messages.expandEmptyElementsLabel}
-              />
             </Field>
           </div>
         </FieldGroup>

--- a/tools/xml-to-json-converter/client.test.tsx
+++ b/tools/xml-to-json-converter/client.test.tsx
@@ -148,12 +148,12 @@ describe("XmlToJsonConverterClient", () => {
       target: { value: "0" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.ignoreDeclarationLabel,
       })
     )
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.ignoreAttributesLabel,
       })
     )
@@ -212,7 +212,7 @@ describe("XmlToJsonConverterClient", () => {
       target: { value: "<root><persisted>true</persisted></root>" },
     })
     fireEvent.click(
-      screen.getByRole("switch", {
+      screen.getByRole("checkbox", {
         name: messages.ignoreDeclarationLabel,
       })
     )

--- a/tools/xml-to-json-converter/components/options-card.tsx
+++ b/tools/xml-to-json-converter/components/options-card.tsx
@@ -1,5 +1,6 @@
 import { useId, type Dispatch, type SetStateAction } from "react"
 
+import { Checkbox } from "@workspace/ui/components/ui/checkbox"
 import {
   Card,
   CardContent,
@@ -15,7 +16,6 @@ import {
   FieldLabel,
 } from "@workspace/ui/components/ui/field"
 import { Input } from "@workspace/ui/components/ui/input"
-import { Switch } from "@workspace/ui/components/ui/switch"
 
 import type { XmlToJsonConverterMessages } from "../client/types"
 import {
@@ -136,23 +136,22 @@ function OptionsCard({ messages, options, setOptions }: OptionsCardProps) {
                   orientation="horizontal"
                   data-disabled={isDisabled || undefined}
                 >
-                  <FieldContent>
-                    <FieldLabel htmlFor={optionId}>
-                      {toggleOption.label}
-                    </FieldLabel>
-                  </FieldContent>
-                  <Switch
+                  <Checkbox
                     id={optionId}
                     checked={options[toggleOption.key]}
                     disabled={isDisabled}
                     onCheckedChange={(checked) => {
                       setOptions((currentOptions) => ({
                         ...currentOptions,
-                        [toggleOption.key]: checked,
+                        [toggleOption.key]: Boolean(checked),
                       }))
                     }}
-                    aria-label={toggleOption.label}
                   />
+                  <FieldContent>
+                    <FieldLabel htmlFor={optionId}>
+                      {toggleOption.label}
+                    </FieldLabel>
+                  </FieldContent>
                 </Field>
               )
             })}


### PR DESCRIPTION
## Summary
- replace option-style switches with checkboxes across migrated conversion and validation tools
- keep `image-resizer` aspect-ratio control as a switch because it behaves like a live interaction mode
- update affected tests to assert checkbox roles where appropriate

## Validation
- pnpm exec vitest run tools/csv-to-json-converter/client.test.tsx tools/json-to-xml-converter/client.test.tsx tools/xml-to-json-converter/client.test.tsx tools/json-schema-validator/client.test.tsx tools/image-resizer/client.test.tsx
- pnpm exec tsc --noEmit
- pnpm exec oxlint tools/csv-to-json-converter/components/option-controls.tsx tools/csv-to-json-converter/components/options-card.tsx tools/json-to-xml-converter/components/options-card.tsx tools/xml-to-json-converter/components/options-card.tsx tools/json-schema-validator/client.tsx tools/image-resizer/client/options-card.tsx tools/csv-to-json-converter/client.test.tsx tools/json-to-xml-converter/client.test.tsx tools/xml-to-json-converter/client.test.tsx tools/json-schema-validator/client.test.tsx tools/image-resizer/client.test.tsx