### PR TITLE
ci: add gitleaks secret scan workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,30 @@
+name: Gitleaks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev/astro-rewrite-base
+  workflow_dispatch:
+
+concurrency:
+  group: gitleaks-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gitleaks:
+    name: Secret scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/gitleaks.yml` — runs `gitleaks/gitleaks-action@v2` on every PR and on pushes to `dev/astro-rewrite-base`.
- Purpose: catch accidentally committed credentials (API tokens, private keys, etc.) before they reach the protected branch. This is the CI tier of the two-tier scheme (pre-commit hook can come later as a separate change).
- `fetch-depth: 0` so gitleaks can see full history on push events; minimal permissions (`contents: read`, `pull-requests: read`); concurrency group cancels superseded runs, matching `staging.yml` style.

## Notes
- **License**: `gitleaks-action@v2` is free for public repos and personal-account private repos. If `InBrowserApp/InBrowserApp` is an **org-owned private** repo, a `GITLEAKS_LICENSE` secret is required — this repo appears public, so no action needed. If the scan step ever errors with a license message, that's why.
- **Action pinning**: uses `@v2` for consistency with other workflows in this repo. Pinning third-party actions to commit SHAs (managed by Renovate) is a separate supply-chain hardening item.
- **If gitleaks finds something pre-existing**: the job will fail on the first PR after merge. Triage by either rotating the leaked secret (preferred — history rewrite is rarely worth it on public repos) and adding a narrow allowlist entry in a new `.gitleaks.toml`, or by fixing the source.

## Test plan
- [ ] `Gitleaks / Secret scan` check appears on this PR and passes (no secrets present).
- [ ] Optional smoke test: push a commit that adds a dummy string matching a gitleaks rule (e.g. `AKIAIOSFODNN7EXAMPLE`) to confirm the check fails, then revert.
- [ ] After merge, confirm the workflow runs on the push to `dev/astro-rewrite-base`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)