### PR TITLE
fix: use relative paths in pre-commit lint-staged

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm exec lint-staged
+pnpm exec lint-staged --relative


### PR DESCRIPTION
## Summary
- switch the Husky `pre-commit` hook to `lint-staged --relative`
- keep `packages/tool-registry/src/generated/**` linted while making the existing `max-lines` override match hook execution more reliably
- avoid broadening `oxlint` ignore patterns for generated registry files

## Root Cause
The repository already disables `max-lines` for `packages/tool-registry/src/generated/**` in `.oxlintrc.json`, but the pre-commit flow was invoking `lint-staged` without `--relative`. Passing repo-relative file paths makes the hook behavior line up with the repo's glob-based override rules and reduces path-matching ambiguity in staged-file lint runs.

## Impact
Generated registry files still go through normal linting in pre-commit, but they are less likely to be treated like ordinary source for `max-lines` enforcement.

## Validation
- `PATH=/home/hzc/code/inbrowserapp/inbrowser-app/node_modules/.bin:$PATH oxlint packages/tool-registry/src/generated/*.ts`
- `sh -n .husky/pre-commit`
- manual staged-file reproduction of `lint-staged --relative` against `packages/tool-registry/src/generated/search-index.ts`