### PR TITLE
fix(tool): tighten cron mode segmented control

### DIFF
--- a/tools/cron-expression-generator/client.test.tsx
+++ b/tools/cron-expression-generator/client.test.tsx
@@ -71,6 +71,21 @@ describe("CronExpressionGeneratorClient", () => {
     expect(screen.getAllByRole("row").length).toBeGreaterThan(1)
   })
 
+  test("renders mode choices as a connected segmented control", () => {
+    renderClient()
+
+    const minuteCard = getCard(messages.fields.labels.minute)
+    const everyMode = minuteCard.getByRole("radio", {
+      name: messages.fields.every,
+    })
+    const modeGroup = everyMode.parentElement
+
+    expect(modeGroup?.className).not.toContain("gap-2")
+    expect(modeGroup?.className).not.toContain("flex-wrap")
+    expect(everyMode.className).toContain("basis-0")
+    expect(everyMode.querySelector("span")?.className).toContain("truncate")
+  })
+
   test("copies the generated expression", async () => {
     renderClient()
 

--- a/tools/cron-expression-generator/components/cron-field-card.tsx
+++ b/tools/cron-expression-generator/components/cron-field-card.tsx
@@ -115,7 +115,7 @@ function CronFieldCard({
               type="single"
               variant="outline"
               value={normalized.mode}
-              className="flex w-full flex-wrap gap-2"
+              className="w-full"
               onValueChange={(value) => {
                 if (MODE_VALUES.includes(value as CronFieldMode)) {
                   updateField({ mode: value as CronFieldMode })
@@ -127,9 +127,11 @@ function CronFieldCard({
                   key={mode}
                   value={mode}
                   aria-label={messages.fields[mode]}
-                  className="flex-1 sm:flex-none"
+                  className="min-w-0 flex-1 basis-0 overflow-hidden"
                 >
-                  {messages.fields[mode]}
+                  <span className="min-w-0 truncate">
+                    {messages.fields[mode]}
+                  </span>
                 </ToggleGroupItem>
               ))}
             </ToggleGroup>


### PR DESCRIPTION
## Summary
- remove the manual gap/wrap from the cron expression generator mode toggle group
- keep the mode choices as one connected segmented control with equal-width, truncating items
- add a regression test for the mode control layout classes

## Validation
- pnpm exec vitest run tools/cron-expression-generator/client.test.tsx
- pnpm format:check
- pnpm lint
- pnpm typecheck
- pnpm build
- Playwright visual check against Astro preview at desktop and 390px width: mode group computed gap 0px and adjacent item deltas 0

Note: this PR is intentionally left unmerged per request.