### PR TITLE
fix(tool): make AES encrypted JSON sticky

### DIFF
--- a/tools/aes-encryptor/client.tsx
+++ b/tools/aes-encryptor/client.tsx
@@ -213,13 +213,15 @@ function AesEncryptorClient({ messages }: AesEncryptorClientProps) {
           onReset={handleReset}
         />
       </div>
-      <ResultCard
-        downloadFileName={downloadFileName}
-        downloadUrl={downloadUrl}
-        error={error}
-        messages={messages}
-        resultJson={resultJson}
-      />
+      <div className="min-w-0 self-start xl:sticky xl:top-6">
+        <ResultCard
+          downloadFileName={downloadFileName}
+          downloadUrl={downloadUrl}
+          error={error}
+          messages={messages}
+          resultJson={resultJson}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Makes the AES Encryptor `Encrypted JSON` result card sticky on `xl` viewports.
- Matches the existing wide-screen sticky panel pattern used by tools such as `css-box-shadow-generator`.
- Keeps mobile/tablet layouts in normal document flow so the result card does not trap small screens.

## Validation

- `pnpm exec vitest run tools/aes-encryptor/core/aes-encryptor.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- Production preview browser check: desktop computed `position: sticky`, `top: 24px`; mobile computed `position: static`.

## Notes

No i18n, manifest, dependency, or generated registry changes are needed for this layout-only follow-up.