### PR TITLE
fix: relax ssh fingerprint tool layout

### DIFF
--- a/tools/ssh-public-key-fingerprint/client.tsx
+++ b/tools/ssh-public-key-fingerprint/client.tsx
@@ -123,7 +123,7 @@ function SshPublicKeyFingerprintClient({
   }
 
   return (
-    <div className="grid gap-6 xl:grid-cols-[minmax(0,30rem)_minmax(0,1fr)]">
+    <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
       <ToolPanelCard>
         <CardHeader className="border-b">
           <CardTitle>{messages.inputTitle}</CardTitle>

--- a/tools/ssh-public-key-fingerprint/components/fingerprint-results.tsx
+++ b/tools/ssh-public-key-fingerprint/components/fingerprint-results.tsx
@@ -75,7 +75,7 @@ function FingerprintResults({ messages, state }: FingerprintResultsProps) {
   }
 
   return (
-    <div className="grid gap-4 md:grid-cols-2">
+    <div className="grid gap-4">
       {state.entries.map((entry, index) => (
         <KeyFingerprintSection
           key={`${entry.fingerprints.sha256}-${index}`}


### PR DESCRIPTION
## Summary
- changes the SSH public key fingerprint tool body from an extra-wide two-column desktop layout to a centered single-column layout
- keeps parsed key result sections in one column so long fingerprints and comments have more horizontal room

## UI/UX Notes
- the tool is mostly long, monospace security text, so single-column desktop reads better than splitting input and results into narrow panes
- this trades some vertical length for less wrapping and better scanability on desktop
- mobile/tablet behavior remains naturally single-column

## Validation
- `pnpm exec vitest run tools/ssh-public-key-fingerprint/client.test.tsx`
- `pnpm lint`
