### PR TITLE
fix(web): clamp tool card title and description in grid

### DIFF
--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -268,7 +268,7 @@ function ToolsDirectorySearch({
                       />
                       {locale.name}
                     </h3>
-                    <p className="text-sm leading-relaxed text-muted-foreground">
+                    <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
                       {locale.description}
                     </p>
                   </div>

--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -266,7 +266,7 @@ function ToolsDirectorySearch({
                         icon={entry.icon}
                         className="size-4 shrink-0 text-muted-foreground"
                       />
-                      {locale.name}
+                      <span className="min-w-0 truncate">{locale.name}</span>
                     </h3>
                     <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
                       {locale.description}


### PR DESCRIPTION
## Summary
- Long tool descriptions stretched cards on the home page and `/tools` grid; clamping to two lines with overflow ellipsis keeps every card the same height.
- Long tool names had the same effect; wrapping `locale.name` in `<span class="min-w-0 truncate">` truncates to a single line with `…` while keeping the icon visible (already `shrink-0`).

## Test plan
- [x] CI green (typecheck, lint, depcruise, tests, build)
- [x] Deploy preview verified: HTML carries `line-clamp-2` + `min-w-0 truncate`, CSS bundle ships the matching rules.
- [x] Card heights are uniform across the grid regardless of name/description length.

🤖 Generated with [Claude Code](https://claude.com/claude-code)