### PR TITLE
feat(sitemap): emit x-default hreflang for multilingual entries

### DIFF
--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -11,6 +11,7 @@ import {
   DEFAULT_SITE_LANGUAGE,
   SUPPORTED_SITE_LANGUAGES,
 } from "./src/lib/site.ts"
+import { addXDefaultHreflang } from "./src/lib/sitemap-serialize.ts"
 
 // https://astro.build/config
 export default defineConfig({
@@ -46,6 +47,7 @@ export default defineConfig({
           SUPPORTED_SITE_LANGUAGES.map((locale) => [locale, locale])
         ),
       },
+      serialize: addXDefaultHreflang,
     }),
   ],
   prefetch: {

--- a/apps/web/src/lib/sitemap-serialize.test.ts
+++ b/apps/web/src/lib/sitemap-serialize.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest"
+
+import type { SitemapItem } from "@astrojs/sitemap"
+
+import { addXDefaultHreflang } from "./sitemap-serialize"
+
+describe("addXDefaultHreflang", () => {
+  test("appends x-default pointing to the default-locale variant", () => {
+    const item: SitemapItem = {
+      url: "https://inbrowser.app/zh-CN/tools/foo",
+      links: [
+        { url: "https://inbrowser.app/tools/foo", lang: "en" },
+        { url: "https://inbrowser.app/zh-CN/tools/foo", lang: "zh-CN" },
+      ],
+    }
+
+    const result = addXDefaultHreflang(item)
+
+    expect(result.links).toEqual([
+      { url: "https://inbrowser.app/tools/foo", lang: "en" },
+      { url: "https://inbrowser.app/zh-CN/tools/foo", lang: "zh-CN" },
+      { url: "https://inbrowser.app/tools/foo", lang: "x-default" },
+    ])
+  })
+
+  test("returns the same item when no links are present", () => {
+    const item: SitemapItem = {
+      url: "https://inbrowser.app/standalone",
+    }
+
+    expect(addXDefaultHreflang(item)).toBe(item)
+  })
+
+  test("returns the same item when no default-locale variant exists", () => {
+    const item: SitemapItem = {
+      url: "https://inbrowser.app/zh-CN/tools/foo",
+      links: [
+        { url: "https://inbrowser.app/zh-CN/tools/foo", lang: "zh-CN" },
+        { url: "https://inbrowser.app/ja/tools/foo", lang: "ja" },
+      ],
+    }
+
+    expect(addXDefaultHreflang(item)).toBe(item)
+  })
+
+  test("is idempotent when x-default is already present", () => {
+    const item: SitemapItem = {
+      url: "https://inbrowser.app/tools/foo",
+      links: [
+        { url: "https://inbrowser.app/tools/foo", lang: "en" },
+        { url: "https://inbrowser.app/tools/foo", lang: "x-default" },
+      ],
+    }
+
+    expect(addXDefaultHreflang(item)).toBe(item)
+  })
+})

--- a/apps/web/src/lib/sitemap-serialize.ts
+++ b/apps/web/src/lib/sitemap-serialize.ts
@@ -1,0 +1,31 @@
+import type { SitemapItem } from "@astrojs/sitemap"
+
+import { DEFAULT_SITE_LANGUAGE } from "./site"
+
+const X_DEFAULT_HREFLANG = "x-default"
+
+// @astrojs/sitemap (v3.x) does not emit an `x-default` hreflang on its own.
+// Google recommends one for multilingual sites so crawlers know which
+// localized variant to surface when no other locale matches the user.
+function addXDefaultHreflang(item: SitemapItem): SitemapItem {
+  const { links } = item
+  if (!links || links.length === 0) {
+    return item
+  }
+
+  if (links.some((link) => link.lang === X_DEFAULT_HREFLANG)) {
+    return item
+  }
+
+  const defaultLink = links.find((link) => link.lang === DEFAULT_SITE_LANGUAGE)
+  if (!defaultLink) {
+    return item
+  }
+
+  return {
+    ...item,
+    links: [...links, { url: defaultLink.url, lang: X_DEFAULT_HREFLANG }],
+  }
+}
+
+export { addXDefaultHreflang }

--- a/tests/sitemap-serialize.test.ts
+++ b/tests/sitemap-serialize.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest"
 
 import type { SitemapItem } from "@astrojs/sitemap"
 
-import { addXDefaultHreflang } from "./sitemap-serialize"
+import { addXDefaultHreflang } from "../apps/web/src/lib/sitemap-serialize"
 
 describe("addXDefaultHreflang", () => {
   test("appends x-default pointing to the default-locale variant", () => {

--- a/tests/sitemap-serialize.test.ts
+++ b/tests/sitemap-serialize.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "vitest"
 
-import type { SitemapItem } from "@astrojs/sitemap"
-
 import { addXDefaultHreflang } from "../apps/web/src/lib/sitemap-serialize"
+
+type SitemapItem = Parameters<typeof addXDefaultHreflang>[0]
 
 describe("addXDefaultHreflang", () => {
   test("appends x-default pointing to the default-locale variant", () => {


### PR DESCRIPTION
## Summary

- Hook `@astrojs/sitemap`'s `serialize()` to append an `x-default` `<xhtml:link>` to every cross-linked entry, pointing at the default-locale (no-prefix) URL.
- Extract the logic to `apps/web/src/lib/sitemap-serialize.ts` so it can be unit-tested in isolation.
- Add a small vitest covering append, no-links, no-default-locale, and idempotency.

## Why

`@astrojs/sitemap` v3.x correctly emits per-locale `hreflang` siblings for every prerendered route, but it does not add an `x-default` link. Google [recommends](https://developers.google.com/search/docs/specialized/international/localized-versions#xdefault) one for multilingual sites so crawlers know which variant to surface when no other locale matches the user.

The codebase already emits a per-page `<link rel="alternate" hreflang="x-default">` from `getAlternateLinks()` in [site.ts](apps/web/src/lib/site.ts). This change keeps the sitemap consistent with that head metadata.

## Test plan

- [ ] CI: lint, format, typecheck, vitest all pass
- [ ] CI: astro build succeeds
- [ ] Inspect generated `dist/sitemap-0.xml` on staging — every `<url>` with `<xhtml:link>` siblings now also has one with `hreflang="x-default"` whose `href` matches the default-locale (no language prefix) URL
- [ ] Spot-check that an entry whose `availableLanguages` excludes `en` (if any) is unaffected (no x-default appended — verified by unit test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)