### PR TITLE
ci: rename staging workflow to ci and target main

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,7 +7,7 @@ on:
       - ".github/actions/**"
   push:
     branches:
-      - dev/astro-rewrite-base
+      - main
     paths:
       - ".github/workflows/**"
       - ".github/actions/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,14 @@
-name: Staging
+name: CI
 
 on:
   pull_request:
   push:
     branches:
-      - dev/astro-rewrite-base
+      - main
   workflow_dispatch:
 
 concurrency:
-  group: staging-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -108,7 +108,7 @@ jobs:
     needs:
       - code-check
       - build-web
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev/astro-rewrite-base'
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
     environment:


### PR DESCRIPTION
## Summary
- Rename `.github/workflows/staging.yml` → `ci.yml` (workflow `name:` is now `CI`).
- Switch the push trigger from `dev/astro-rewrite-base` to `main` so pushes to `main` actually run CI again after the Astro rewrite cutover.
- Switch the `deploy-staging` job guard from `refs/heads/dev/astro-rewrite-base` to `refs/heads/main` so the deploy fires from `main`.
- Update `actionlint.yml` push branch in the same way.

## Why
After the Astro rewrite was cut over to `main`, the existing workflow only fired on `dev/astro-rewrite-base`, so pushes to `main` produced no CI runs.

## Test plan
- [ ] CI run on this PR succeeds (`Code Check`, `Build Web`, `Deploy Preview`)
- [ ] After merge, push-to-`main` triggers a CI run and `Deploy Staging` deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)