### PR TITLE
ci: deploy main directly to cloudflare workers production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,8 @@ jobs:
           name: web-dist
           path: apps/web/dist
 
-  deploy-staging:
-    name: Deploy Staging
+  deploy-production:
+    name: Deploy Production
     runs-on: ubuntu-latest
     needs:
       - code-check
@@ -112,7 +112,7 @@ jobs:
     permissions:
       contents: read
     environment:
-      name: cloudflare-workers-staging
+      name: cloudflare-workers
       url: ${{ steps.deploy.outputs.deployment-url }}
     steps:
       - name: Checkout
@@ -135,14 +135,14 @@ jobs:
           name: web-dist
           path: apps/web/dist
 
-      - name: Deploy to Cloudflare Workers staging
+      - name: Deploy to Cloudflare Workers production
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           workingDirectory: apps/web
-          environment: staging
+          command: deploy
 
   deploy-preview:
     name: Deploy Preview


### PR DESCRIPTION
## Summary
- Replace `deploy-staging` (which deployed `main` to the staging worker) with `deploy-production`, deploying `main` directly to the production Cloudflare Workers env (`cloudflare-workers`).
- Use `wrangler deploy` against the default env in `apps/web/wrangler.jsonc` (worker `inbrowserapp-web-astro`), which is what `https://inbrowser.app/` resolves to.
- `deploy-preview` (PR → staging worker via `versions upload --preview-alias`) is unchanged.

Also updated the `cloudflare-workers` environment's deployment branch policy from `v*.*.*` tags to `main` branch (out-of-band, via API) so the new push-to-main trigger isn't blocked.

## Why
After the Astro rewrite cutover, no workflow ever deployed to the production worker, so `https://inbrowser.app/` was still serving the legacy Vue worker. With the release-based flow dropped in favor of "main is latest", push-to-main needs to publish straight to production.

## Test plan
- [ ] PR checks pass (Code Check, Build Web, Deploy Preview)
- [ ] After merge, push-to-main fires `Deploy Production`, which deploys to the `inbrowserapp-web-astro` worker
- [ ] `https://inbrowser.app/` serves the Astro rewrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)