### PR TITLE
chore(release): anchor release-please on legacy 1.5.0, ship Astro rewrite as 2.0.0

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -19,6 +19,7 @@
     ".playwright-cli/",
     "coverage/",
     "pnpm-lock.yaml",
-    ".pnpm-store/"
+    ".pnpm-store/",
+    "CHANGELOG.md"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,220 @@
+# Changelog
+
+## [1.5.0](https://github.com/InBrowserApp/InBrowserApp/compare/v1.4.0...v1.5.0) (2026-02-27)
+
+
+### Features
+
+* **hash:** add cityhash64 hash tool ([#218](https://github.com/InBrowserApp/InBrowserApp/issues/218)) ([737d639](https://github.com/InBrowserApp/InBrowserApp/commit/737d63916aeb4f1fc2467ecfe4f872d974ecf3f4))
+* **hash:** add CRC64 variants to CRC checksum calculator ([#261](https://github.com/InBrowserApp/InBrowserApp/issues/261)) ([add0f50](https://github.com/InBrowserApp/InBrowserApp/commit/add0f5025d376fda8e15adda9a0c11692d3b3f8b))
+* **hash:** add HighwayHash hash text or file tool ([#266](https://github.com/InBrowserApp/InBrowserApp/issues/266)) ([007421c](https://github.com/InBrowserApp/InBrowserApp/commit/007421c15179dcf57fd3b23bab11aa1b46e67a9a))
+* **hash:** add sha3 fips-202 hash tools ([#221](https://github.com/InBrowserApp/InBrowserApp/issues/221)) ([fc42436](https://github.com/InBrowserApp/InBrowserApp/commit/fc424362685ef8b387cb90abc625935d6903785b))
+* **hash:** add SipHash tools ([#246](https://github.com/InBrowserApp/InBrowserApp/issues/246)) ([c7b3bc0](https://github.com/InBrowserApp/InBrowserApp/commit/c7b3bc09674352c82bb57e6df9dcfb9523fc2140))
+* **hash:** add xxh3 64/128 hash tools ([#243](https://github.com/InBrowserApp/InBrowserApp/issues/243)) ([9c39c39](https://github.com/InBrowserApp/InBrowserApp/commit/9c39c39c69d132b69b806257a18dc2bda18bbc74))
+* **pdf:** add drag-sort PDF merger with preview ([#262](https://github.com/InBrowserApp/InBrowserApp/issues/262)) ([5cb40de](https://github.com/InBrowserApp/InBrowserApp/commit/5cb40dea1faf6da85e888af5ca5ba336279949e8))
+* **tools:** add Adler-32 hash text or file tool ([#259](https://github.com/InBrowserApp/InBrowserApp/issues/259)) ([75d711f](https://github.com/InBrowserApp/InBrowserApp/commit/75d711fae260f367163cfe98854301071f7ae206))
+* **tools:** add argon2 hash password generator and verifier ([#256](https://github.com/InBrowserApp/InBrowserApp/issues/256)) ([bdcb611](https://github.com/InBrowserApp/InBrowserApp/commit/bdcb611bf735c2d557e9fff3aabee84c2394ae4e))
+* **tools:** add audio recorder tool ([#220](https://github.com/InBrowserApp/InBrowserApp/issues/220)) ([242211d](https://github.com/InBrowserApp/InBrowserApp/commit/242211d5d31b35b96c636957be88393f4c84692f))
+* **tools:** add barcode reader tool ([#189](https://github.com/InBrowserApp/InBrowserApp/issues/189)) ([64e7c6e](https://github.com/InBrowserApp/InBrowserApp/commit/64e7c6e593ec007e6c312867f682d9290e93243e))
+* **tools:** add base16 encoder and decoder ([#192](https://github.com/InBrowserApp/InBrowserApp/issues/192)) ([8f7176e](https://github.com/InBrowserApp/InBrowserApp/commit/8f7176eab2a2184cbad04be94532c4a08f7bdc36))
+* **tools:** add base16 what is section ([#201](https://github.com/InBrowserApp/InBrowserApp/issues/201)) ([6cb8ff8](https://github.com/InBrowserApp/InBrowserApp/commit/6cb8ff8bc3e78a891ebdb6b878d17e565ab0eb01))
+* **tools:** add base32 encoder and decoder ([#182](https://github.com/InBrowserApp/InBrowserApp/issues/182)) ([9d95ae5](https://github.com/InBrowserApp/InBrowserApp/commit/9d95ae518cc7c3df9900738aeb09b4367b070ca6))
+* **tools:** add base58 encoder and decoder ([#230](https://github.com/InBrowserApp/InBrowserApp/issues/230)) ([6f78975](https://github.com/InBrowserApp/InBrowserApp/commit/6f78975853747d9753967337a9f8d0a8645a105a))
+* **tools:** add base85 encoder and decoder ([#237](https://github.com/InBrowserApp/InBrowserApp/issues/237)) ([a8f9b58](https://github.com/InBrowserApp/InBrowserApp/commit/a8f9b5893d3162a6d94ed485aa46bfb26e49c973))
+* **tools:** add blake3 hash tool ([#217](https://github.com/InBrowserApp/InBrowserApp/issues/217)) ([614fc17](https://github.com/InBrowserApp/InBrowserApp/commit/614fc17008103da4e3e41e3f890a3e701db74ef3))
+* **tools:** add camera tool ([#239](https://github.com/InBrowserApp/InBrowserApp/issues/239)) ([0318019](https://github.com/InBrowserApp/InBrowserApp/commit/03180192a796ef467ce45939fe7f984313381650))
+* **tools:** add chinese uppercase number converter ([#228](https://github.com/InBrowserApp/InBrowserApp/issues/228)) ([25132b1](https://github.com/InBrowserApp/InBrowserApp/commit/25132b112834cedcea027fd1d6b87cf34c8d8ba6))
+* **tools:** add code screenshot generator ([#216](https://github.com/InBrowserApp/InBrowserApp/issues/216)) ([5d16dfb](https://github.com/InBrowserApp/InBrowserApp/commit/5d16dfb04686a92d65ba5093926527be946cb708))
+* **tools:** add color contrast checker ([#202](https://github.com/InBrowserApp/InBrowserApp/issues/202)) ([99fb327](https://github.com/InBrowserApp/InBrowserApp/commit/99fb327b910fbe031cb7347f5242080b6cd381ab))
+* **tools:** add cookie parser ([#242](https://github.com/InBrowserApp/InBrowserApp/issues/242)) ([ebe766b](https://github.com/InBrowserApp/InBrowserApp/commit/ebe766b14ea3fdf4395fef25bd4e677be7b29909))
+* **tools:** add csr generator ([#203](https://github.com/InBrowserApp/InBrowserApp/issues/203)) ([5ee16d7](https://github.com/InBrowserApp/InBrowserApp/commit/5ee16d7a0b4bb1a3f5d03d25a5d466f413847b5f))
+* **tools:** add css box shadow generator ([#208](https://github.com/InBrowserApp/InBrowserApp/issues/208)) ([feba92c](https://github.com/InBrowserApp/InBrowserApp/commit/feba92c67acec275f2707adc8b6f97209314a908))
+* **tools:** add css gradient generator ([#200](https://github.com/InBrowserApp/InBrowserApp/issues/200)) ([c242ae4](https://github.com/InBrowserApp/InBrowserApp/commit/c242ae4943248405ba78704110b233ba2a499b19))
+* **tools:** add curl-fetch converter ([#183](https://github.com/InBrowserApp/InBrowserApp/issues/183)) ([51c6350](https://github.com/InBrowserApp/InBrowserApp/commit/51c6350348a2ffb69ff209dc2bd62316021bf991))
+* **tools:** add docker run to compose converter ([#195](https://github.com/InBrowserApp/InBrowserApp/issues/195)) ([fedd3ab](https://github.com/InBrowserApp/InBrowserApp/commit/fedd3ab1784328a3e53f8f0ec40b4e7078ad4f90))
+* **tools:** add email validator tool ([#185](https://github.com/InBrowserApp/InBrowserApp/issues/185)) ([14c321b](https://github.com/InBrowserApp/InBrowserApp/commit/14c321b423150a9c170dff10442563273ae3be62))
+* **tools:** add gif to animated webp converter ([#249](https://github.com/InBrowserApp/InBrowserApp/issues/249)) ([4390db5](https://github.com/InBrowserApp/InBrowserApp/commit/4390db5375a8156c38a4bed17bfbc1b4a3b5efde))
+* **tools:** add gif to apng converter ([#240](https://github.com/InBrowserApp/InBrowserApp/issues/240)) ([71a2c79](https://github.com/InBrowserApp/InBrowserApp/commit/71a2c792edb4d1f7bf27c394f43401a87c054bce))
+* **tools:** add image palette extractor ([#186](https://github.com/InBrowserApp/InBrowserApp/issues/186)) ([713a8ab](https://github.com/InBrowserApp/InBrowserApp/commit/713a8ab37d6875d3d1ef4f5546803d602d451358))
+* **tools:** add image resizer with multi-algorithm scaling ([#257](https://github.com/InBrowserApp/InBrowserApp/issues/257)) ([1e6d435](https://github.com/InBrowserApp/InBrowserApp/commit/1e6d435d382f5005b8e096f777b3ad259a218b60))
+* **tools:** add image to webp converter ([#233](https://github.com/InBrowserApp/InBrowserApp/issues/233)) ([e5db48a](https://github.com/InBrowserApp/InBrowserApp/commit/e5db48a8af36cb619f53329d4d1776aae9b8b1c9))
+* **tools:** add jwk pem converter ([#191](https://github.com/InBrowserApp/InBrowserApp/issues/191)) ([d19a153](https://github.com/InBrowserApp/InBrowserApp/commit/d19a1533f8f761f0a9e94b75f3125b31bf6033da))
+* **tools:** add local font book tool ([#224](https://github.com/InBrowserApp/InBrowserApp/issues/224)) ([32388a1](https://github.com/InBrowserApp/InBrowserApp/commit/32388a1a95b732af4766ea46ed8ef16bce0ae82a))
+* **tools:** add markdown previewer ([#199](https://github.com/InBrowserApp/InBrowserApp/issues/199)) ([63dcce7](https://github.com/InBrowserApp/InBrowserApp/commit/63dcce74b9069776961e94fc815a59aecf8d84e5))
+* **tools:** add md4 hash tool ([#247](https://github.com/InBrowserApp/InBrowserApp/issues/247)) ([7e8cc16](https://github.com/InBrowserApp/InBrowserApp/commit/7e8cc1648daa2cd5c7a731a5fe3ba752b21e28c1))
+* **tools:** add murmurhash3 hash tools ([#229](https://github.com/InBrowserApp/InBrowserApp/issues/229)) ([9ba64d4](https://github.com/InBrowserApp/InBrowserApp/commit/9ba64d43cc46ae38937b6247a3d6d586de06fee2))
+* **tools:** add pbkdf2 key derivation tool ([#245](https://github.com/InBrowserApp/InBrowserApp/issues/245)) ([ae8421a](https://github.com/InBrowserApp/InBrowserApp/commit/ae8421aa7ddf3016cb6c5c08ad30d6dd8dc9da78))
+* **tools:** add pdf info viewer ([8311a24](https://github.com/InBrowserApp/InBrowserApp/commit/8311a24549c95201e1503274a6c124b4cedc172a))
+* **tools:** add pdf-to-image-converter tool ([#263](https://github.com/InBrowserApp/InBrowserApp/issues/263)) ([104afcd](https://github.com/InBrowserApp/InBrowserApp/commit/104afcd71769e1fd97b00cb721dac1588c489e0f))
+* **tools:** add radio timecode tool ([#214](https://github.com/InBrowserApp/InBrowserApp/issues/214)) ([fcfc971](https://github.com/InBrowserApp/InBrowserApp/commit/fcfc971cea8449364a5e324b6d7714fc324fe7b5))
+* **tools:** add random number generator ([#207](https://github.com/InBrowserApp/InBrowserApp/issues/207)) ([bd7f774](https://github.com/InBrowserApp/InBrowserApp/commit/bd7f7746bed07de97ab471577d269666a6de37d0))
+* **tools:** add random number history ([#219](https://github.com/InBrowserApp/InBrowserApp/issues/219)) ([2240a8a](https://github.com/InBrowserApp/InBrowserApp/commit/2240a8a06991215ce392b6db580b188e7dfeaab6))
+* **tools:** add ripemd hash tools ([#232](https://github.com/InBrowserApp/InBrowserApp/issues/232)) ([5a7b2c7](https://github.com/InBrowserApp/InBrowserApp/commit/5a7b2c71e9bc6a1c1e2dfd68c55dac0912efa105))
+* **tools:** add robots.txt generator ([#184](https://github.com/InBrowserApp/InBrowserApp/issues/184)) ([0f5e328](https://github.com/InBrowserApp/InBrowserApp/commit/0f5e32846460d3b4018c45efd03298cf4e0236ed))
+* **tools:** add screen recorder tool ([c8bbe7f](https://github.com/InBrowserApp/InBrowserApp/commit/c8bbe7fe902eb61e9c782f5c42a0b2f056a5d0b4))
+* **tools:** add scrypt key derivation tool ([#258](https://github.com/InBrowserApp/InBrowserApp/issues/258)) ([3db5d1d](https://github.com/InBrowserApp/InBrowserApp/commit/3db5d1dcb5775c93205eb6b92267ea86f2ab8213))
+* **tools:** add sha224 hash tool ([#227](https://github.com/InBrowserApp/InBrowserApp/issues/227)) ([5b87a24](https://github.com/InBrowserApp/InBrowserApp/commit/5b87a24e10bb78ca962b06770714162dd9c7641a))
+* **tools:** add sha3-224 and sha3-384 hash tools ([#241](https://github.com/InBrowserApp/InBrowserApp/issues/241)) ([8dca610](https://github.com/InBrowserApp/InBrowserApp/commit/8dca610a684f549989bd59f60dc2eb71dd83a60d))
+* **tools:** add sha512-224/256 hash tools ([#238](https://github.com/InBrowserApp/InBrowserApp/issues/238)) ([91e500e](https://github.com/InBrowserApp/InBrowserApp/commit/91e500ef92abbac12673a21438b3ebd91d2a2d54))
+* **tools:** add shake hash tools ([#234](https://github.com/InBrowserApp/InBrowserApp/issues/234)) ([fde633b](https://github.com/InBrowserApp/InBrowserApp/commit/fde633be2c80e9dd8ac2f3683da0506c61886d54))
+* **tools:** add sitemap.xml generator ([#194](https://github.com/InBrowserApp/InBrowserApp/issues/194)) ([76c3a08](https://github.com/InBrowserApp/InBrowserApp/commit/76c3a08426a585e17ae985ca158a9c3d35419984))
+* **tools:** add sm3 hash tool ([#225](https://github.com/InBrowserApp/InBrowserApp/issues/225)) ([ed9c0de](https://github.com/InBrowserApp/InBrowserApp/commit/ed9c0de9b1a0cdcf1c8be55ae1b9c890549ce8b3))
+* **tools:** add sql formatter and linter tool ([#267](https://github.com/InBrowserApp/InBrowserApp/issues/267)) ([a0b5950](https://github.com/InBrowserApp/InBrowserApp/commit/a0b59505f434a7cc9f5700408abed791a5995077))
+* **tools:** add ssh public key fingerprint tool ([#187](https://github.com/InBrowserApp/InBrowserApp/issues/187)) ([43512af](https://github.com/InBrowserApp/InBrowserApp/commit/43512affd266d51604c8397aebf53494f85e743b))
+* **tools:** add VIN validator ([#223](https://github.com/InBrowserApp/InBrowserApp/issues/223)) ([c90302f](https://github.com/InBrowserApp/InBrowserApp/commit/c90302f10cb730869a6808161ec2b7592b2afc92))
+* **tools:** add whirlpool hash tool ([#236](https://github.com/InBrowserApp/InBrowserApp/issues/236)) ([eff4733](https://github.com/InBrowserApp/InBrowserApp/commit/eff4733a87fcc0525ff638a7deea86ec4d62c14e))
+* **web:** show tools count in heading ([#181](https://github.com/InBrowserApp/InBrowserApp/issues/181)) ([0d7592a](https://github.com/InBrowserApp/InBrowserApp/commit/0d7592a019a8572634b6928b2ff5f61c88df0f1f))
+
+
+### Bug Fixes
+
+* **timer:** simplify countdown controls ([70667e5](https://github.com/InBrowserApp/InBrowserApp/commit/70667e5c73e5049b83b8a8bce8ed83bc93bebb8e))
+* **tools:** improve audio recorder codecs ([d31a436](https://github.com/InBrowserApp/InBrowserApp/commit/d31a4362179188bcd91316fc6e2400c36bd31832))
+* **tools:** prefer mp4 aac codecs ([b4ca348](https://github.com/InBrowserApp/InBrowserApp/commit/b4ca34821623a8d5e9dc615e3e2c983c6dcdcb12))
+* **tools:** show csr subject inputs ([#206](https://github.com/InBrowserApp/InBrowserApp/issues/206)) ([31f9e51](https://github.com/InBrowserApp/InBrowserApp/commit/31f9e51a3ad1c52364ea4ce84cdbdfd637095d6f))
+
+## [1.4.0](https://github.com/InBrowserApp/InBrowserApp/compare/v1.3.0...v1.4.0) (2026-01-20)
+
+
+### Features
+
+* **time:** add stopwatch tool ([#158](https://github.com/InBrowserApp/InBrowserApp/issues/158)) ([7fdb874](https://github.com/InBrowserApp/InBrowserApp/commit/7fdb87438a5df50ca52a663e4185f3132f3cbf16))
+* **tools:** add BIC/SWIFT validator ([#148](https://github.com/InBrowserApp/InBrowserApp/issues/148)) ([581d400](https://github.com/InBrowserApp/InBrowserApp/commit/581d40037c2f455abe37a8ff0310af288aa55e19))
+* **tools:** add BIP39 mnemonic generator ([#139](https://github.com/InBrowserApp/InBrowserApp/issues/139)) ([67f4050](https://github.com/InBrowserApp/InBrowserApp/commit/67f40508eb64ae7dd7b55b96c60782006b640ef3))
+* **tools:** add business days calculator ([#155](https://github.com/InBrowserApp/InBrowserApp/issues/155)) ([9ce251c](https://github.com/InBrowserApp/InBrowserApp/commit/9ce251c3a2672d25a738873bcd6b1e179ef5b95b))
+* **tools:** add certificate public key parser ([#147](https://github.com/InBrowserApp/InBrowserApp/issues/147)) ([ca64b8f](https://github.com/InBrowserApp/InBrowserApp/commit/ca64b8fe6fe1ab6db631ede434cd8a7c7edcdfa3))
+* **tools:** add color picker tool ([#163](https://github.com/InBrowserApp/InBrowserApp/issues/163)) ([a1bbb5e](https://github.com/InBrowserApp/InBrowserApp/commit/a1bbb5e9a3f0878a4a1b6a80acf486dc95554152))
+* **tools:** add cuid2 generator ([d20d5a9](https://github.com/InBrowserApp/InBrowserApp/commit/d20d5a90cbdd0caf7625181982883374a4e47327))
+* **tools:** add EU VAT number validator ([#154](https://github.com/InBrowserApp/InBrowserApp/issues/154)) ([394e052](https://github.com/InBrowserApp/InBrowserApp/commit/394e05241d9c563149dcf89966abf40db4d25b75))
+* **tools:** add IBAN validator tool ([#144](https://github.com/InBrowserApp/InBrowserApp/issues/144)) ([f62e72d](https://github.com/InBrowserApp/InBrowserApp/commit/f62e72db7b78ed6acbcb959d499e0eeb15d3f46c))
+* **tools:** add iCal event generator ([#160](https://github.com/InBrowserApp/InBrowserApp/issues/160)) ([8295ec6](https://github.com/InBrowserApp/InBrowserApp/commit/8295ec62c73cad9a5b039f94842a0c8806011435))
+* **tools:** add image metadata cleaner ([#162](https://github.com/InBrowserApp/InBrowserApp/issues/162)) ([e3d68f8](https://github.com/InBrowserApp/InBrowserApp/commit/e3d68f8f881dc7e5453d80786e67e51eb1f560d2))
+* **tools:** add image-to-ico tool ([#174](https://github.com/InBrowserApp/InBrowserApp/issues/174)) ([ad289e5](https://github.com/InBrowserApp/InBrowserApp/commit/ad289e53fdeddaa43876d2e86f86b74051bc39f0))
+* **tools:** add ISBN validator tool ([#140](https://github.com/InBrowserApp/InBrowserApp/issues/140)) ([13f6c89](https://github.com/InBrowserApp/InBrowserApp/commit/13f6c89d7005bd57643962400e6a3b6b370c44a8))
+* **tools:** add json schema generator ([#168](https://github.com/InBrowserApp/InBrowserApp/issues/168)) ([a4c99ab](https://github.com/InBrowserApp/InBrowserApp/commit/a4c99ab02cdeaa8a5021c346796121ed6c0c532f))
+* **tools:** add json schema validator ([#141](https://github.com/InBrowserApp/InBrowserApp/issues/141)) ([6207590](https://github.com/InBrowserApp/InBrowserApp/commit/6207590d1efda8781b3c43adf2f0c93f0e492545))
+* **tools:** add JSONPath and JMESPath testers ([#161](https://github.com/InBrowserApp/InBrowserApp/issues/161)) ([e076824](https://github.com/InBrowserApp/InBrowserApp/commit/e076824bfca7027e54b67f567ca2aecaee8a6e15))
+* **tools:** add ksuid generator ([#159](https://github.com/InBrowserApp/InBrowserApp/issues/159)) ([37c18ae](https://github.com/InBrowserApp/InBrowserApp/commit/37c18ae8fbfcc4f4ce2e9ad7f52303ca7b06a67f))
+* **tools:** add nanoid generator ([#169](https://github.com/InBrowserApp/InBrowserApp/issues/169)) ([26acec8](https://github.com/InBrowserApp/InBrowserApp/commit/26acec836096b2789143e1821f5b0e90743b7be5))
+* **tools:** add OpenAPI to TypeScript converter ([#150](https://github.com/InBrowserApp/InBrowserApp/issues/150)) ([613b1d0](https://github.com/InBrowserApp/InBrowserApp/commit/613b1d06ca490d4156f6c2e5d510a72ac928b9bd))
+* **tools:** add password strength checker ([#153](https://github.com/InBrowserApp/InBrowserApp/issues/153)) ([38fc27f](https://github.com/InBrowserApp/InBrowserApp/commit/38fc27f02b620f9696bc447bef5cf999c2a4c955))
+* **tools:** add PGP key generator ([#173](https://github.com/InBrowserApp/InBrowserApp/issues/173)) ([779f072](https://github.com/InBrowserApp/InBrowserApp/commit/779f072343cfaa94ee6dbacc467a5e70a4cf1583))
+* **tools:** add Prettier code formatter ([#137](https://github.com/InBrowserApp/InBrowserApp/issues/137)) ([c159523](https://github.com/InBrowserApp/InBrowserApp/commit/c159523f4ec51c03bbbcc7c1b5fa42c2e315312c))
+* **tools:** add regex tester replacer ([#146](https://github.com/InBrowserApp/InBrowserApp/issues/146)) ([fe19203](https://github.com/InBrowserApp/InBrowserApp/commit/fe19203f03ddcc5396070c89521290623108f19f))
+* **tools:** add svg to image converter ([#164](https://github.com/InBrowserApp/InBrowserApp/issues/164)) ([6519730](https://github.com/InBrowserApp/InBrowserApp/commit/65197305506ffab35a2d5502aaa48a2e660f1844))
+* **tools:** add time difference calculator ([#145](https://github.com/InBrowserApp/InBrowserApp/issues/145)) ([ee06961](https://github.com/InBrowserApp/InBrowserApp/commit/ee06961d62d610cd8ccca5c80849ea372907ef64))
+* **tools:** add time zone converter ([#138](https://github.com/InBrowserApp/InBrowserApp/issues/138)) ([158c9ec](https://github.com/InBrowserApp/InBrowserApp/commit/158c9ecdb24880fdffef7287e0021177634195ff))
+* **tools:** add unicode invisible character checker ([#170](https://github.com/InBrowserApp/InBrowserApp/issues/170)) ([42bbbb2](https://github.com/InBrowserApp/InBrowserApp/commit/42bbbb2cd273177e2ed5bd8831b2e0190bd4651f))
+* **tools:** add user-agent parser ([#143](https://github.com/InBrowserApp/InBrowserApp/issues/143)) ([ffd4797](https://github.com/InBrowserApp/InBrowserApp/commit/ffd4797d61932092efa913688dc43b95af78c49c))
+* **tools:** use anchor download links ([#165](https://github.com/InBrowserApp/InBrowserApp/issues/165)) ([a506951](https://github.com/InBrowserApp/InBrowserApp/commit/a5069515c3718f14ce6b0bfd8fd948f403e53bc6))
+* **validator:** add PRC resident ID validator ([#171](https://github.com/InBrowserApp/InBrowserApp/issues/171)) ([a92cc5f](https://github.com/InBrowserApp/InBrowserApp/commit/a92cc5f8c311d846b30a4244e6f03707fad49a18))
+
+## [1.3.0](https://github.com/InBrowserApp/InBrowserApp/compare/v1.2.0...v1.3.0) (2026-01-09)
+
+
+### Features
+
+* **tools:** add HMAC Generator tool ([#134](https://github.com/InBrowserApp/InBrowserApp/issues/134)) ([fa25fe8](https://github.com/InBrowserApp/InBrowserApp/commit/fa25fe8dd20cc8fffa878bddb6f8f660332555e4))
+* **tools:** add HTML Color Names tool ([#133](https://github.com/InBrowserApp/InBrowserApp/issues/133)) ([de4cbfd](https://github.com/InBrowserApp/InBrowserApp/commit/de4cbfd6939a3cbcfdba6a72019e597815ba7156))
+* **tools:** add QR Code Reader tool ([#136](https://github.com/InBrowserApp/InBrowserApp/issues/136)) ([d44cc2e](https://github.com/InBrowserApp/InBrowserApp/commit/d44cc2e5a7152b1b6f9081c78f18e95f474408f2))
+* **tools:** add SSH Key Generator tool ([#124](https://github.com/InBrowserApp/InBrowserApp/issues/124)) ([6ae5f01](https://github.com/InBrowserApp/InBrowserApp/commit/6ae5f018367ef7a5a495723e949a7525847b664a))
+* **tools:** add SVG Optimizer tool ([#135](https://github.com/InBrowserApp/InBrowserApp/issues/135)) ([e7feef9](https://github.com/InBrowserApp/InBrowserApp/commit/e7feef93431b48caa062b76ee4212592383691e1))
+
+## [1.2.0](https://github.com/InBrowserApp/InBrowserApp/compare/v1.1.0...v1.2.0) (2026-01-07)
+
+
+### Features
+
+* **agents:** add pr-checks-watcher agent ([#103](https://github.com/InBrowserApp/InBrowserApp/issues/103)) ([59231b5](https://github.com/InBrowserApp/InBrowserApp/commit/59231b5b9511382a5986f6622670f574457c2a8f))
+* **agents:** add test-writer agent with project testing patterns ([#102](https://github.com/InBrowserApp/InBrowserApp/issues/102)) ([436bb80](https://github.com/InBrowserApp/InBrowserApp/commit/436bb80e86e7d29a032dabb736d5e5c4de0578ac))
+* **common:** add bug report button in tool default page layout ([#120](https://github.com/InBrowserApp/InBrowserApp/issues/120)) ([681064f](https://github.com/InBrowserApp/InBrowserApp/commit/681064f5de807e3c65bbacb10aedd17cddccbe0f))
+* **tools:** add .gitignore Generator tool ([#119](https://github.com/InBrowserApp/InBrowserApp/issues/119)) ([7a8486c](https://github.com/InBrowserApp/InBrowserApp/commit/7a8486c7d136acfe7e42e9a15ed030257ed2b7a3))
+* **tools:** add AES Encryptor and Decryptor tools ([#97](https://github.com/InBrowserApp/InBrowserApp/issues/97)) ([adef207](https://github.com/InBrowserApp/InBrowserApp/commit/adef207f0855263c22824ed57c2f012028184a51))
+* **tools:** add Credit Card Validator tool ([#113](https://github.com/InBrowserApp/InBrowserApp/issues/113)) ([99869e4](https://github.com/InBrowserApp/InBrowserApp/commit/99869e46259a5706c0d12740521023a4cdfb06a8))
+* **tools:** add Cron Expression Generator tool ([#112](https://github.com/InBrowserApp/InBrowserApp/issues/112)) ([ceda9f4](https://github.com/InBrowserApp/InBrowserApp/commit/ceda9f40aee32fdc21f7fccc883d06372bd82ed3))
+* **tools:** add Data URI converters ([#100](https://github.com/InBrowserApp/InBrowserApp/issues/100)) ([eb7bb05](https://github.com/InBrowserApp/InBrowserApp/commit/eb7bb058e37b31565269d42ac68cf3725fa31541))
+* **tools:** add EXIF Viewer tool ([#116](https://github.com/InBrowserApp/InBrowserApp/issues/116)) ([fe7d9d5](https://github.com/InBrowserApp/InBrowserApp/commit/fe7d9d5bc7f3f69c4414628b32674f4bd884d20a))
+* **tools:** add HTTP Status Code Lookup tool ([#105](https://github.com/InBrowserApp/InBrowserApp/issues/105)) ([c04fa23](https://github.com/InBrowserApp/InBrowserApp/commit/c04fa23b41b076f31857183aaa2bc3aa069532a7))
+* **tools:** add Lorem Ipsum Generator tool ([#104](https://github.com/InBrowserApp/InBrowserApp/issues/104)) ([a5719bd](https://github.com/InBrowserApp/InBrowserApp/commit/a5719bd3ba6661e0e90d8d93f1dfbe9649182e4b))
+* **tools:** add MIME Type Lookup tool ([#110](https://github.com/InBrowserApp/InBrowserApp/issues/110)) ([ba38faa](https://github.com/InBrowserApp/InBrowserApp/commit/ba38faab7dd2600602d1e0276697e0ec9cdcbbc6))
+* **tools:** add Placeholder Image Generator tool ([#115](https://github.com/InBrowserApp/InBrowserApp/issues/115)) ([833b217](https://github.com/InBrowserApp/InBrowserApp/commit/833b217cb6cb034f9b2763b61a1f411e8ee710b1))
+* **tools:** add port number lookup tool ([#99](https://github.com/InBrowserApp/InBrowserApp/issues/99)) ([313637d](https://github.com/InBrowserApp/InBrowserApp/commit/313637d9e6558218d16ac633e45b24c9642ce7e9))
+* **tools:** add slug generator tool ([#118](https://github.com/InBrowserApp/InBrowserApp/issues/118)) ([8c47ade](https://github.com/InBrowserApp/InBrowserApp/commit/8c47adef5290fbec30d833f6158db6f67bdc75cb))
+* **tools:** add Text Statistics tool ([#101](https://github.com/InBrowserApp/InBrowserApp/issues/101)) ([c9b9937](https://github.com/InBrowserApp/InBrowserApp/commit/c9b9937216fa56fa35152fd35e96cc18035ece12))
+
+
+### Bug Fixes
+
+* **agents:** handle blocking situations in pr-checks-watcher ([#117](https://github.com/InBrowserApp/InBrowserApp/issues/117)) ([c1d9122](https://github.com/InBrowserApp/InBrowserApp/commit/c1d9122c9b97b37296d122960b4aa35862b429e5))
+* **deps:** replace mime-types with mime for browser compatibility ([#114](https://github.com/InBrowserApp/InBrowserApp/issues/114)) ([7cf62fb](https://github.com/InBrowserApp/InBrowserApp/commit/7cf62fb904e470b5b0c9124b3806c26abebf7693))
+* **favicon:** use svgo/browser to fix Vite build warnings ([#111](https://github.com/InBrowserApp/InBrowserApp/issues/111)) ([261dae7](https://github.com/InBrowserApp/InBrowserApp/commit/261dae73dac1f41e6669e7cd9a2775cd47acd9b8))
+
+## [1.1.0](https://github.com/InBrowserApp/InBrowserApp/compare/v1.0.0...v1.1.0) (2026-01-05)
+
+
+### Features
+
+* **tools:** add ASCII Art Generator tool ([#92](https://github.com/InBrowserApp/InBrowserApp/issues/92)) ([1529425](https://github.com/InBrowserApp/InBrowserApp/commit/1529425047e17acb33cce62d2e938e9a376a7e8c))
+* **tools:** add Chmod Calculator tool ([#90](https://github.com/InBrowserApp/InBrowserApp/issues/90)) ([6a22227](https://github.com/InBrowserApp/InBrowserApp/commit/6a22227dff639c84de6a751f471273380b941c5c))
+* **tools:** add cron expression parser tool ([#78](https://github.com/InBrowserApp/InBrowserApp/issues/78)) ([42e4de5](https://github.com/InBrowserApp/InBrowserApp/commit/42e4de5e492a6413027f8cad157066bbf88382f0))
+* **tools:** add HTML Entity Encoder & Decoder tool ([#88](https://github.com/InBrowserApp/InBrowserApp/issues/88)) ([feab94b](https://github.com/InBrowserApp/InBrowserApp/commit/feab94b4269f9db7aed9f7b04bbcdcb8a07ae916))
+* **tools:** add Morse Code Converter tool ([#80](https://github.com/InBrowserApp/InBrowserApp/issues/80)) ([c3d77b6](https://github.com/InBrowserApp/InBrowserApp/commit/c3d77b6d50f42c4dae79b40cac44082380489db6))
+* **tools:** add ROT Cipher Encrypt & Decrypt tool ([#84](https://github.com/InBrowserApp/InBrowserApp/issues/84)) ([1a9c834](https://github.com/InBrowserApp/InBrowserApp/commit/1a9c834398dda432b47ca8f346ee2aee76925e70))
+* **tools:** add Unicode escape/unescape tool ([#75](https://github.com/InBrowserApp/InBrowserApp/issues/75)) ([4cac4de](https://github.com/InBrowserApp/InBrowserApp/commit/4cac4de2ee96bf23fe665f4b2eaf42621f5335b4))
+
+## 1.0.0 (2025-12-30)
+
+
+### Features
+
+* **airplane-mode:** implement airplane mode functionality ([70daeb0](https://github.com/InBrowserApp/InBrowserApp/commit/70daeb01dae59ddc29ba40f069a2a740a34123d4))
+* **csv-to-json-converter:** add localization for settings option in CSV to JSON converter ([fc2ec65](https://github.com/InBrowserApp/InBrowserApp/commit/fc2ec653fbd5e146b3f050d471b890cbb5125825))
+* migrate from old inbrowser.app projects ([6f25d8b](https://github.com/InBrowserApp/InBrowserApp/commit/6f25d8b559e1011a78f96e576b9507cb8a9b3a6c))
+* **qr-code-generator:** add multiple content type for qr code generator ([ece196f](https://github.com/InBrowserApp/InBrowserApp/commit/ece196fb2758dffe3ec4d5d5d21d1a46601abcd3))
+* **tools:** add barcode generator tool ([44675e1](https://github.com/InBrowserApp/InBrowserApp/commit/44675e1a0ab55e2a324f76556f2c0f2bfa6751ea))
+* **tools:** add Base64 encoder/decoder tool ([a70d806](https://github.com/InBrowserApp/InBrowserApp/commit/a70d80650f406b5175a96fee34df89891df58a2f))
+* **tools:** add basic auth decoder ([435769a](https://github.com/InBrowserApp/InBrowserApp/commit/435769a7a950e6fdc87dc67a14474b8b125fb82f))
+* **tools:** add basic auth generator ([0a812cc](https://github.com/InBrowserApp/InBrowserApp/commit/0a812ccf75e31f4667b133788b508ef31affa8c9))
+* **tools:** add Case Converter tool ([3bdea7c](https://github.com/InBrowserApp/InBrowserApp/commit/3bdea7ce1fda4ffc58e26e9ee3705d823beaf0ac))
+* **tools:** add Color Converter tool ([4c1032c](https://github.com/InBrowserApp/InBrowserApp/commit/4c1032c57881169436673668b4b12391cc522f06))
+* **tools:** add CSV to JSON converter tool ([4501783](https://github.com/InBrowserApp/InBrowserApp/commit/4501783188a62a9230e203873a1b89df24f2a213))
+* **tools:** add device information tool and update dependencies ([d71c09d](https://github.com/InBrowserApp/InBrowserApp/commit/d71c09d3a91cb130dfcc07924c876026029f8fe4))
+* **tools:** add HTML to Markdown converter tool and integrate into package ([ea8c4c2](https://github.com/InBrowserApp/InBrowserApp/commit/ea8c4c233a94c66794a698661e0b75def04d2d34))
+* **tools:** add JSON formatter tool ([#36](https://github.com/InBrowserApp/InBrowserApp/issues/36)) ([950057b](https://github.com/InBrowserApp/InBrowserApp/commit/950057b9dbfcec4edb62a1925b9429130ea8865f))
+* **tools:** add JSON to CSV converter tool ([96fc7c8](https://github.com/InBrowserApp/InBrowserApp/commit/96fc7c88bc0ffbd29fee9223419a79319ffc1ca5))
+* **tools:** add JSON to TOML converter tool ([192c94e](https://github.com/InBrowserApp/InBrowserApp/commit/192c94e1002eeeeaea39a66b26ff1a7bf577052b))
+* **tools:** add JSON to XML converter tool ([88919ca](https://github.com/InBrowserApp/InBrowserApp/commit/88919cae204764fe8660802f01b3bf6ac97edd6c))
+* **tools:** add JSON to YAML converter tool ([08bcf21](https://github.com/InBrowserApp/InBrowserApp/commit/08bcf218baba9837fcc68c8cd5bf4331f5ed637f))
+* **tools:** add jwt decoder and verifier ([cc76906](https://github.com/InBrowserApp/InBrowserApp/commit/cc76906f58388bfdd0a4d366e78fb0835526a38f))
+* **tools:** add jwt signer tool ([f726d04](https://github.com/InBrowserApp/InBrowserApp/commit/f726d04322b1b96f4c07ccb1268f741c81e1f4c1))
+* **tools:** add markdown to HTML converter tool and integrate into package ([c44aba8](https://github.com/InBrowserApp/InBrowserApp/commit/c44aba8d5042373e1075a5c1b7e162b768163886))
+* **tools:** add Number Base Converter tool ([354dda3](https://github.com/InBrowserApp/InBrowserApp/commit/354dda37ba48eefd0733cb2e6f3062c9633dbb30))
+* **tools:** add QR code generator tool ([9901d55](https://github.com/InBrowserApp/InBrowserApp/commit/9901d55801c8e81b7733ea2ecd178cbf93154628))
+* **tools:** add random password generator tool and integrate into package ([a8cc6b6](https://github.com/InBrowserApp/InBrowserApp/commit/a8cc6b675f3090ff697a63f84957457638bf1e91))
+* **tools:** add Roman numeral converter tool ([#38](https://github.com/InBrowserApp/InBrowserApp/issues/38)) ([4f30ecf](https://github.com/InBrowserApp/InBrowserApp/commit/4f30ecf7d752c81bb3ec5496c3a8c6c5d75ffc01))
+* **tools:** add Text Diff tool with Monaco Editor ([eec85d3](https://github.com/InBrowserApp/InBrowserApp/commit/eec85d3c5ead66e0e21dc0faddc5b2edda3d1e45))
+* **tools:** add TOML to JSON converter tool ([f20bf51](https://github.com/InBrowserApp/InBrowserApp/commit/f20bf51cfa5e827ce23cb682f9fe3fcdcb0f1879))
+* **tools:** add TOML to YAML and YAML to TOML converter tools ([45e2164](https://github.com/InBrowserApp/InBrowserApp/commit/45e216456e0a4003c67864a6065cdd138cc3b84a))
+* **tools:** add ULID generator tool ([316ccf0](https://github.com/InBrowserApp/InBrowserApp/commit/316ccf0a380e0b7271555229d77bec08ba4726e7))
+* **tools:** add Unix timestamp converter tool ([fc92ecf](https://github.com/InBrowserApp/InBrowserApp/commit/fc92ecf4dae4487f21a23121ae96daac0b538d6f))
+* **tools:** add url parser and builder which parse URLs into components and build URLs from individual components ([#22](https://github.com/InBrowserApp/InBrowserApp/issues/22)) ([d03a8fa](https://github.com/InBrowserApp/InBrowserApp/commit/d03a8fa15064202c69377025a4aaf8f31e0ac332))
+* **tools:** add XML to JSON converter tool ([dbf6adf](https://github.com/InBrowserApp/InBrowserApp/commit/dbf6adfee99bf82bf1f33afab5dbedd59f0553ea))
+* **tools:** add YAML to JSON converter tool ([387192d](https://github.com/InBrowserApp/InBrowserApp/commit/387192dd071e751ce535049d38e16ac3b9da00d5))
+* **web:** add sitemap generation ([583eb2e](https://github.com/InBrowserApp/InBrowserApp/commit/583eb2e50fb96a8f43a2a6409074458dc3e4a16e))
+* **web:** integrate Vite PWA plugin for web ([9a17b32](https://github.com/InBrowserApp/InBrowserApp/commit/9a17b3260448eda9f3fb04c3860d1014a23b4489))
+* **web:** update cloudflare pages `_headers` to include service worker with cache control settings ([867f7da](https://github.com/InBrowserApp/InBrowserApp/commit/867f7da8e53ce52476a1566429ca60c6a947576f))
+* **web:** update index.html with improved favicon support and title change ([085d905](https://github.com/InBrowserApp/InBrowserApp/commit/085d905e872bc8cac52f1393e0d29c4c9d89ee47))
+
+
+### Bug Fixes
+
+* **ci:** use correct workspace filter for playwright install ([b1624c9](https://github.com/InBrowserApp/InBrowserApp/commit/b1624c952c00b21cda631f94f88050b1f9e3c6a9))
+* **dependencies:** update package.json to use 'catalog:' specifier for Vue-related ([f2872e8](https://github.com/InBrowserApp/InBrowserApp/commit/f2872e801b51f934eb9554f753bf297e64c76512))
+* fix Component name should always be multi-word lint error ([5f7d86d](https://github.com/InBrowserApp/InBrowserApp/commit/5f7d86d598fe7095e9189f56ecea92589fc9b4c4))
+* **i18n:** complete all 25 language translations for Vue components ([48ca93d](https://github.com/InBrowserApp/InBrowserApp/commit/48ca93d093a6a2a59d4a1c9b8ef856c3cfd21a39))
+* **pwa:** correct mask icon asset ([#71](https://github.com/InBrowserApp/InBrowserApp/issues/71)) ([6bd3c0e](https://github.com/InBrowserApp/InBrowserApp/commit/6bd3c0e108e10f8691daa9d006cc80e7a9505067))
+* **pwa:** increase workbox max file size for Monaco Editor ([ff88ce7](https://github.com/InBrowserApp/InBrowserApp/commit/ff88ce7291b5f530d19fd027b1243d58678b0333))
+* **tools-grid:** update grid layout to screen responsive to avoid blink ([a9a526c](https://github.com/InBrowserApp/InBrowserApp/commit/a9a526cafe50a1b1267636f9cf416960a338ea56))
+* **tools:** enhance JWT decoder and verifier with multilingual support for various languages ([0d5ff46](https://github.com/InBrowserApp/InBrowserApp/commit/0d5ff46b98b7e5d3724e05133a408fdcfd828fc2))
+* **tools:** set textarea type for text input in QROptionsForm component ([6eb0029](https://github.com/InBrowserApp/InBrowserApp/commit/6eb0029b501f52bd99729085f8bca63543ad2717))
+* **tools:** update color format in barcode and QR code generators to use uppercase hex values ([56bcfa9](https://github.com/InBrowserApp/InBrowserApp/commit/56bcfa99b904e159b5a5a3c037a0c332c8603383))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inbrowser-app",
-  "version": "0.0.1",
+  "version": "1.5.0",
   "private": true,
   "scripts": {
     "build": "pnpm tool-registry:generate && pnpm --filter web build",


### PR DESCRIPTION
## Summary

Fixes the release-please [PR #920](https://github.com/InBrowserApp/InBrowserApp/pull/920), which currently proposes a fresh `1.0.0` and also fails `Format check` on the bot-generated `CHANGELOG.md`.

- Port `CHANGELOG.md` from the legacy `v1.5.0` tag so release-please has prior history to append to.
- Bump root `package.json` version `0.0.1` → `1.5.0` so the file mirrors the legacy line.
- Add `CHANGELOG.md` to the `.oxfmtrc.json` ignore list — release-please regenerates it on every run and we don't want `oxfmt --check` to fail.
- Add an empty commit with `Release-As: 2.0.0` so release-please bumps to `2.0.0` (matching the `feat!` in [#919](https://github.com/InBrowserApp/InBrowserApp/pull/919)) rather than falling back to a fresh `1.0.0` (the legacy `v1.5.0` tag's commit is unreachable from the post-cutover main, so release-please cannot anchor on it on its own).

## Dry-run

Verified locally against this branch with `release-please release-pr --dry-run`:

```
title: chore(main): release 2.0.0
✔ updating from 1.5.0 to 2.0.0
## 2.0.0 (2026-05-22)
### ⚠ BREAKING CHANGES
* ship Astro rewrite v2.0.0 via inbrowserapp-web (#919)
…
```

After this merges, release-please will close [#920](https://github.com/InBrowserApp/InBrowserApp/pull/920) and open a new release PR titled `chore(main): release 2.0.0`.

## Test plan

- [x] `pnpm format:check` passes locally (`CHANGELOG.md` ignored).
- [x] `release-please release-pr --dry-run` reports `1.5.0 → 2.0.0` and prepends a `## 2.0.0` section above the legacy `## [1.5.0]` entry.
- [ ] CI `Code Check` green on this PR.
- [ ] After merge, release-please opens a new release PR proposing `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)