### PR TITLE
ci: upload web dist as .tar.zstd to release assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,30 @@ jobs:
           name: web-dist
           path: apps/web/dist
 
+  upload-release-asset:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    needs:
+      - code-check
+      - build-web
+    if: github.event_name == 'release'
+    permissions:
+      contents: write
+    steps:
+      - name: Download web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist
+
+      - name: Create tar.zstd archive
+        run: tar --zstd -cf "web-dist-${{ github.event.release.tag_name }}.tar.zstd" -C apps/web/dist .
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "web-dist-${{ github.event.release.tag_name }}.tar.zstd" --repo "${{ github.repository }}" --clobber
+
   deploy-production:
     name: Deploy Production
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- On `release: published`, pack `apps/web/dist` as `web-dist-<tag>.tar.zstd` (GNU `tar --zstd`) and attach it to the GitHub release via `gh release upload --clobber`.
- New `upload-release-asset` job gated on `code-check` + `build-web` (mirrors `deploy-production`), scoped `contents: write`.

## Test plan
- [ ] Cut a test release tag and confirm the `.tar.zstd` asset appears on the release page.
- [ ] Re-run the workflow on the same release and confirm `--clobber` keeps it idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)