### PR TITLE
ci: split test from code-check and report coverage per event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,21 +51,50 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
-      - name: Test
-        run: pnpm test:coverage
-
-      - name: Coverage report
-        if: github.event_name == 'pull_request'
-        uses: davelosert/vitest-coverage-report-action@v2
-        with:
-          json-summary-path: coverage/coverage-summary.json
-          json-final-path: coverage/coverage-final.json
-
       - name: Dep boundaries
         run: pnpm depcruise
 
       - name: Knip
         run: pnpm knip
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          cache: true
+          run_install: true
+
+      - name: Run tests (changed + coverage)
+        if: github.event_name == 'pull_request'
+        run: pnpm vitest run --changed "origin/${{ github.base_ref }}" --coverage
+
+      - name: Run tests (full + coverage)
+        if: github.event_name != 'pull_request'
+        run: pnpm test:coverage
+
+      - name: Report coverage
+        if: ${{ !cancelled() && (github.event_name == 'pull_request' || github.event_name == 'push') }}
+        uses: davelosert/vitest-coverage-report-action@v2
+        with:
+          comment-on: ${{ github.event_name == 'pull_request' && 'pr' || 'commit' }}
+          json-summary-path: ./coverage/coverage-summary.json
+          json-final-path: ./coverage/coverage-final.json
 
   build-web:
     name: Build Web
@@ -109,6 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - code-check
+      - test
       - build-web
     if: github.event_name == 'release'
     permissions:
@@ -133,6 +162,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - code-check
+      - test
       - build-web
     if: github.event_name == 'release'
     permissions:
@@ -174,7 +204,6 @@ jobs:
     name: Upload Workers Version
     runs-on: ubuntu-latest
     needs:
-      - code-check
       - build-web
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default getViteConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json-summary", "json"],
+      reportOnFailure: true,
       include: ["packages/tool-sdk/src/**/*.ts", "tools/**/*.{ts,tsx}"],
       exclude: ["**/*.test.{ts,tsx}", "**/manifest.ts"],
       thresholds: {


### PR DESCRIPTION
## Summary

- Split the monolithic `code-check` job into `code-check` + `test` so the two run in parallel and have clearly separated responsibilities.
- On PRs, the test job runs `pnpm vitest run --changed "origin/<base>" --coverage` for fast diff-scoped feedback; on push to `main` / release, it runs the full `pnpm test:coverage` suite.
- Coverage is reported via [`davelosert/vitest-coverage-report-action@v2`](https://github.com/davelosert/vitest-coverage-report-action) — commenting on the PR for PR events and on the commit for push events. Uses `if: !cancelled()` so the report still posts when tests fail, and `coverage.reportOnFailure: true` in `vitest.config.ts` so the JSON files exist for the action to read.
- Gates:
  - `deploy-production`, `upload-release-asset` now `needs: [code-check, test, build-web]` — releases must pass tests.
  - `deploy-staging` keeps a minimal `needs: [build-web]` so PR preview deploys are not blocked by code-check / test.

## Notes on `--changed` + coverage thresholds

Repo is on Vitest v4, which dropped `coverage.all` and defaults to "only files imported by the running tests." That means per-glob thresholds in [vitest.config.ts](vitest.config.ts) only apply to files actually touched by the diff on PRs — full thresholds still enforce on push to `main` where the entire suite runs.

## Test plan

- [ ] CI runs both `code-check` and `test` in parallel on this PR.
- [ ] `test` job uses the `--changed` path (look for "Run tests (changed + coverage)" in logs).
- [ ] davelosert action posts a coverage comment on this PR.
- [ ] Staging deploy fires once `build-web` finishes, independent of `code-check` / `test`.
- [ ] After merge to `main`, the push run uses `pnpm test:coverage` (full) and posts coverage on the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)