### PR TITLE
docs: refresh repo docs for shipped v2.0.0 product

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,22 +4,22 @@ This file provides guidance to coding agents working in this repository.
 
 ## What this repo is
 
-The current working branch, `dev/astro-rewrite-base`, is the multilingual
-`Astro + React + shadcn/ui` rewrite of InBrowser.App. The legacy Vue 3 / Vite
-implementation still lives on `main` and remains the source of truth for older
-assets, copy, and tool ports until the rewrite reaches parity.
-
-When you need to port something from the legacy app, fetch it with
-`git show origin/main:<path>` instead of checking out `main`.
+InBrowser.App is the multilingual `Astro + React + shadcn/ui` application that
+hosts ~200 browser-only utilities at [inbrowser.app](https://inbrowser.app).
+`main` is the live product — shipped as v2.0.0 in #919. The legacy Vue 3 / Vite
+implementation is preserved on the `legacy/vue` branch; reach for it only when
+porting an asset or piece of copy that has not already made it across, and
+prefer `git show origin/legacy/vue:<path>` over checking the branch out.
 
 ## Working set
 
 - Treat the repo root as the source of truth.
 - Ignore generated or disposable directories unless the task explicitly targets
-  them: `apps/web/dist`, `apps/web/.astro`, `.turbo`, `coverage`,
-  `node_modules`.
+  them: `apps/web/dist`, `apps/web/.astro`, `coverage`, `node_modules`.
 - `packages/tool-registry/src/generated/*` is different: those generated files
-  are committed and should be updated when manifests or locales change.
+  are committed and should be updated when manifests or locales change. CI
+  fails if a fresh `pnpm tool-registry:generate` produces a diff under that
+  directory.
 - `.claude/worktrees/*` contains side worktrees and mirrors. Do not edit them
   unless the user explicitly asks you to work inside one of them.
 
@@ -47,12 +47,6 @@ Run a single test file or pattern from the repo root:
 pnpm exec vitest run path/to/file.test.ts
 pnpm exec vitest run -t "regex on test name"
 pnpm exec vitest
-```
-
-Deploy the Astro app to staging:
-
-```bash
-pnpm --filter web deploy:staging
 ```
 
 If `astro build` fails with `Cannot find module '<...>/dist/renderers.mjs'`,
@@ -159,13 +153,17 @@ When adding a new tool:
 1. Create `tools/<slug>/` with the required files.
 2. Run `pnpm tool-registry:generate`.
 3. If the generator reports that `packages/tool-registry/package.json` was out
-   of sync, run `pnpm install` and rerun `pnpm tool-registry:generate`.
+   of sync, it has already rewritten the `@tool/*` dependency block to match
+   the discovered tools — run `pnpm install` and rerun
+   `pnpm tool-registry:generate`.
 4. Commit both `packages/tool-registry/package.json` and
    `packages/tool-registry/src/generated/*` when they change.
 
 Do not hand-edit the `@tool/*` dependency list in
-`packages/tool-registry/package.json` unless you are also updating the
-generator. The generator now syncs those entries from the discovered tools.
+`packages/tool-registry/package.json`. The generator
+(`syncRegistryPackageDependencies` in
+`packages/tool-registry/src/generate/io.ts`) is the source of truth and will
+overwrite manual edits on the next run.
 
 ## i18n
 
@@ -179,6 +177,8 @@ generator. The generator now syncs those entries from the discovered tools.
 - Tool markdown content usually lives in `sections/<section>/<lang>.md`.
 - Native language names for the language picker live in
   `packages/ui/src/components/app/language-switcher.tsx`, not in message files.
+- The sitemap emits an `x-default` hreflang for multilingual entries
+  (`apps/web/src/lib/sitemap-serialize.ts`; see #910).
 
 Important repo-wide rule: `tests/i18n-consistency.test.ts` walks the entire repo
 and treats every directory containing `en.json` or `en.md` as a locale family.
@@ -224,17 +224,36 @@ Lint and formatting:
 - The web app is built from source packages directly via Astro aliases; there is
   no separate package compilation step.
 
+## CI, hosting, and releases
+
+Workflows live in `.github/workflows/`:
+
+- `ci.yml` — `code-check` (lint, format, registry-up-to-date check, typecheck,
+  test+coverage, depcruise, knip), `build-web` (astro build + htmltest on the
+  built HTML), and the deploy jobs below. Runs on PRs, on push to `main`, and on
+  release publish.
+- `pr-title.yml` — enforces Conventional Commits on PR titles.
+- `release-please.yml` — opens release PRs and publishes GitHub releases.
+- `actionlint.yml` — lints workflow YAML when `.github/workflows/**` changes.
+
+Cloudflare Workers (static assets via the Workers Sites model). There is no
+separate `staging` environment in `apps/web/wrangler.jsonc`; previews are
+Workers Versions:
+
+- **Same-repo PRs and pushes to `main`** — `deploy-staging` runs
+  `wrangler versions upload --tag <ref>` against the
+  `cloudflare-workers-staging` environment, exposing the version through the
+  job's `deployment-url`.
+- **Release publish** — `deploy-production` runs `wrangler deploy` against
+  production, and `upload-release-asset` attaches the built `apps/web/dist` as
+  a `.tar.zstd` archive on the GitHub release (#924).
+
 ## Git and PR conventions
 
 - Use Conventional Commits for commit messages.
 - PR titles must also follow Conventional Commits; CI checks this.
-- For rewrite work, the usual PR base branch is `dev/astro-rewrite-base`.
-  Do not target `main` unless the user explicitly asks for it, because `main`
-  is still the legacy Vue application.
-- Cloudflare staging preview and deploy workflows live in
-  `.github/workflows/staging.yml`.
-- Pull requests from branches in this repo get a preview deployment alias of
-  the form `pr-<number>-inbrowserapp-web-astro-staging.rwv.workers.dev`.
+- The PR base branch is `main`. Do not target `legacy/vue` unless the user
+  explicitly asks for it.
 
 ## Environment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What this repo is
 
-The `dev/astro-rewrite-base` branch (current) is the **multilingual Astro + React + shadcn/ui rewrite** of InBrowser.App. The previous Vue 3 / Vite implementation still lives on `main` and is the source of truth for assets, copy, and tool ports until the rewrite reaches parity.
-
-When porting something from `main`, fetch it via `git show origin/main:<path>` rather than checking out the branch.
+InBrowser.App is a multilingual **Astro + React + shadcn/ui** application that hosts ~200 browser-only utilities. `main` is the live product (shipped as v2.0.0 in PR #919). The legacy Vue 3 / Vite implementation lives on the `legacy/vue` branch — fetch from it via `git show origin/legacy/vue:<path>` rather than checking the branch out, and only when you need to port an asset or copy that has not already made it across.
 
 ## Common commands
 
 ```bash
 pnpm dev                  # tool-registry:generate + astro dev (apps/web)
 pnpm build                # tool-registry:generate + astro build
-pnpm tool-registry:generate  # regenerate packages/tool-registry/src/generated/* — required after adding a tool or a tool locale
+pnpm tool-registry:generate  # regenerate packages/tool-registry/src/generated/*
 pnpm test                 # vitest run (silent)
 pnpm test:coverage        # with v8 coverage and threshold enforcement
-pnpm typecheck            # tool-registry:generate + per-workspace astro check / tsc
+pnpm typecheck            # tool-registry:generate + root tsc + per-app astro check
 pnpm lint                 # oxlint
 pnpm lint:fix             # oxlint --fix
 pnpm format               # oxfmt
@@ -33,12 +31,6 @@ pnpm exec vitest run -t "matches a regex on test name"
 pnpm exec vitest                          # watch mode
 ```
 
-Deploy the web app to staging from `apps/web`:
-
-```bash
-pnpm --filter web deploy:staging          # wrangler deploy --env staging
-```
-
 If `astro build` fails with `Cannot find module '<...>/dist/renderers.mjs'`, the dist cache is stale — `rm -rf apps/web/dist apps/web/.astro` and rebuild. This happens easily when builds run from different cwds.
 
 ## Architecture
@@ -52,6 +44,7 @@ packages/tool-sdk     # framework-agnostic tool contract: defineTool(), types, l
 packages/tool-registry# manifest discovery + codegen (registry, search-index, static-paths, page-loaders). Source-only.
 packages/lib/<domain> # promoted, framework-free domain libs (only when reuse is justified).
 tools/<slug>/         # self-contained workspace packages, scoped @tool/<slug>.
+tests/                # repo-level tests (i18n consistency, sitemap serialization).
 ```
 
 Tools **are** workspace packages. Each `tools/<slug>/` has its own `package.json` with `name: "@tool/<slug>"` (must equal dirname — the registry generator validates). Per-tool runtime deps live in the tool's own `package.json`; `react`, `react-dom`, and `astro` are peer-deps satisfied by `apps/web`. Shared deps come through `@workspace/tool-sdk` and `@workspace/ui`.
@@ -64,7 +57,7 @@ Tools **are** workspace packages. Each `tools/<slug>/` has its own `package.json
 - `packages/ui` → presentation only. No imports from `apps/web`, `tools/*`, or `tool-registry`.
 - `packages/tool-sdk` → framework-agnostic. No imports from app shell, UI, registry, or tools.
 - `packages/tool-registry` → may depend on `tool-sdk` and on `@tool/*` packages, **but only `src/generated/` may directly import from `@tool/*`**. The rest of the registry source stays clean.
-- `tools/*` → may depend on `@workspace/ui`, `@workspace/tool-sdk`, `packages/lib/*`. Must NOT import from `apps/web` or `tool-registry`.
+- `tools/*` → may depend on `@workspace/ui`, `@workspace/tool-sdk`, `packages/lib/*`. Must NOT import from `apps/web` or `tool-registry`. Must NOT import third-party UI packages like `lucide-react` or `@radix-ui/*` directly — go through `@workspace/ui` (icons live at `@workspace/ui/icons`).
 
 Default to **tool-local** code. Promote into `packages/lib/*` only when the code is used by ≥3 tools (or is correctness-sensitive), framework-free, and has a clean domain boundary.
 
@@ -78,7 +71,7 @@ tools/<slug>/
   meta/en.json         # required base locale; meta/<lang>.json adds locales
 ```
 
-Tools do **not** ship a `tsconfig.json`. The root `tsconfig.json` includes `tools/**` and is what `pnpm typecheck` runs against (a single `tsc --noEmit` for everything except `apps/web`, which has its own `astro check`).
+Tools do **not** ship a `tsconfig.json`. The root `tsconfig.json` includes `tools/**` and is what `pnpm typecheck` runs against (a single `tsc --noEmit` for everything except `apps/web`, which has its own `astro check`). Tools also do **not** define their own `lint`, `format`, or `typecheck` scripts.
 
 Optional, all tool-local: `client.tsx`, `messages/<lang>.json`, `sections/intro/<lang>.md`, `components/`, `core/`, `workers/`, `tests/`.
 
@@ -87,23 +80,22 @@ The registry generator (`packages/tool-registry/src/generate.ts`) discovers tool
 - `registry.ts`, `search-index.ts`, `static-paths.ts` — data.
 - `page-loaders.ts` — a `Record<slug, () => Promise<{ default: AstroComponentFactory }>>` of explicit `import("@tool/<slug>/page")` calls. The app shell uses this map; **there is no `import.meta.glob` of tools anywhere**.
 
-Adding a new tool requires:
+The generator also **auto-syncs** the `@tool/*` block of `packages/tool-registry/package.json` to match the discovered tools (see `syncRegistryPackageDependencies` in `packages/tool-registry/src/generate/io.ts`). Adding a new tool flow:
 
-1. Creating the tool directory + files (see `tools/README.md`).
-2. Adding `"@tool/<slug>": "workspace:*"` to `packages/tool-registry/package.json` dependencies.
-3. `pnpm install` (materialises the symlink at `packages/tool-registry/node_modules/@tool/<slug>`).
-4. `pnpm tool-registry:generate`.
+1. Create the tool directory + files (see `tools/README.md`).
+2. Run `pnpm tool-registry:generate`. If the generator reports that the registry's `package.json` was out of sync, it has already rewritten it — just run `pnpm install` and re-run the generator. CI fails on a non-deduped lockfile and on uncommitted diffs under `packages/tool-registry/src/generated`, so both the package.json and the generated files must be committed.
 
-Adding/removing a locale on an existing tool: just `pnpm tool-registry:generate`. Both flows are run automatically by `pnpm build` so day-to-day you don't think about it — but if you forget to `pnpm install` after adding a new tool, the generator fails with a clear "ensure @tool/<slug> is in tool-registry deps and run pnpm install" error.
+Adding/removing a locale on an existing tool: just `pnpm tool-registry:generate`. Both flows run automatically as part of `pnpm build`, `pnpm dev`, and `pnpm typecheck`.
 
 ### i18n model
 
 - Site languages: defined as `SUPPORTED_SITE_LANGUAGES` in `apps/web/src/lib/site.ts`. Default is `en`. RTL set lives in the same file (`RTL_SITE_LANGUAGES` + `getSiteLanguageDirection`), wired into `<html dir>` in `apps/web/src/layouts/main.astro`.
 - **Site copy** (app shell strings — nav, footer, home page, language picker labels, shared layout text): `apps/web/src/messages/<lang>.json`, loaded by `apps/web/src/lib/site-messages.ts` via `import.meta.glob`. Falls back to `en`.
 - **Tool copy** (per-tool strings — tool title/description in `meta/<lang>.json`, plus the tool's own UI labels in `messages/<lang>.json`): lives inside each `tools/<slug>/`. `packages/tool-sdk/src/resolve-locale.ts` handles fallback chain → requested → `en` → first available.
+- `tests/i18n-consistency.test.ts` walks the repo and treats every directory containing `en.json` or `en.md` as a locale family. For each family: every file must exist for every supported language, JSON files must keep the same key structure as `en.json`, and markdown files must keep the same heading outline as `en.md`.
 - When translating either site copy or tool copy into all supported languages, fan out via the `i18n-translator` subagent (`.claude/agents/i18n-translator.md`) — spawn one instance per target language and run them in parallel. Do not translate multiple languages sequentially in the main conversation, and do not use a generic agent for this.
 - Native language names live in **the language picker component** (`packages/ui/src/components/app/language-switcher.tsx`), not in message catalogs. Don't duplicate them.
-- Routing: `/<lang>/...` for non-default languages; default (`en`) is bare. Generated by `createNonDefaultLanguageStaticPaths()` in `site.ts`.
+- Routing: `/<lang>/...` for non-default languages; default (`en`) is bare. Generated by `createNonDefaultLanguageStaticPaths()` in `site.ts`. The sitemap emits an `x-default` hreflang for multilingual entries (#910).
 
 ### Testing
 
@@ -117,20 +109,24 @@ Test files use `*.test.ts` / `*.test.tsx`. DOM tests use `happy-dom`. Don't mock
 
 ### Build pipeline notes
 
-- `pnpm build` always runs `tool-registry:generate` first. The generator imports each tool's manifest by package name (`@tool/<slug>/manifest`) and reads `meta/<lang>.json` from disk, then writes 4 files into `packages/tool-registry/src/generated/`. Those generated files **are committed** — diffs there are expected when adding tools or locales.
+- `pnpm build`, `pnpm dev`, and `pnpm typecheck` all run `tool-registry:generate` first. The generator imports each tool's manifest by package name (`@tool/<slug>/manifest`) and reads `meta/<lang>.json` from disk, then writes 4 files into `packages/tool-registry/src/generated/`. Those generated files **are committed** — diffs there are expected when adding tools or locales, and CI fails if the working tree diverges from a fresh generator run.
 - Astro aliases for `@workspace/*` resolve directly to package `src/` (see `apps/web/astro.config.mjs`). There is no per-package build step.
 - Cache headers for static assets live in `apps/web/public/_headers`. Fingerprinted `_astro/*` is `immutable`; brand icons use `stale-while-revalidate`.
 
-### Hosting
+### Hosting and CI
 
-Cloudflare Workers (static assets via the Workers Sites model). Two preview URL flavors are produced for the `staging` env (which has `preview_urls: true` in `apps/web/wrangler.jsonc`):
+Cloudflare Workers (static assets via the Workers Sites model). `.github/workflows/ci.yml` runs:
 
-- **Per-PR alias** — `https://pr-<num>-inbrowserapp-web-astro-staging.rwv.workers.dev`. Stable for the life of the PR; the `Deploy Preview` check posts it on each PR.
-- **Per-version hash URL** — `https://<version-hash>-inbrowserapp-web-astro-staging.rwv.workers.dev`. One per uploaded Worker version, immutable. Use this when you need to point at a specific build (e.g. bisecting, sharing a frozen snapshot) instead of the moving PR alias.
+- **PRs (same-repo)** — `code-check` + `build-web`, then `wrangler versions upload` against the `cloudflare-workers-staging` environment. Each PR push uploads a new Worker version tagged with the ref, exposed through the deploy job's `deployment-url` output.
+- **Push to `main`** — same flow as PRs; uploads a Workers Version of the latest commit.
+- **GitHub release (`release: published`)** — runs `wrangler deploy` against the production environment, plus uploads the built `apps/web/dist` as a `.tar.zstd` asset on the release (#924). release-please opens the chore release PR (anchored on legacy 1.5.0; the Astro rewrite shipped as 2.0.0 in #921, #923).
+
+There is no longer a separate `staging` env in `apps/web/wrangler.jsonc` — previews are Workers Versions, production is the default env. The `actionlint` workflow lints `.github/workflows/**` on PRs that touch them.
 
 ## Conventions
 
-- Commits: Conventional Commits, enforced by commitlint via Husky. **PR titles must also follow Conventional Commits** — they're used as the squash-merge commit subject and are checked in CI.
-- Formatter / linter: `oxfmt` and `oxlint`. Don't introduce Prettier or ESLint.
-- Package manager: `pnpm@9.15.9`. Node `>=20`.
-- TypeScript everywhere. Astro components use the `.astro` extension; React islands are `.tsx` and run with `client:*` directives in Astro.
+- Commits: Conventional Commits, enforced by commitlint via Husky. **PR titles must also follow Conventional Commits** — they're used as the squash-merge commit subject and are checked in CI by `.github/workflows/pr-title.yml`.
+- Formatter / linter: `oxfmt` and `oxlint`. Don't introduce Prettier or ESLint. Formatting is semicolon-free, 2-space indent, 80-column. `oxlint` enforces `max-lines: 300` for normal source files (tests and `src/generated/*` exempt).
+- Package manager: `pnpm@10.33.0`. Node `>=20`.
+- TypeScript everywhere, strict across the workspace. Astro components use the `.astro` extension; React islands are `.tsx` and run with `client:*` directives in Astro.
+- The `@/*` path alias maps to `apps/web/src/*` only — don't use it from packages or tools.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,44 @@
-# InBrowserApp Astro Rewrite
+# InBrowser.App
 
-This branch hosts the multilingual `Astro + React + shadcn/ui` rewrite for InBrowserApp.
+Browser-only developer and everyday utilities. Every tool runs entirely in the visitor's browser — no uploads, no servers, no tracking. Live at [inbrowser.app](https://inbrowser.app).
+
+Built with Astro, React, and shadcn/ui. Shipped to production as v2.0.0; `main` is the live product. The legacy Vue 3 / Vite implementation is preserved on the `legacy/vue` branch.
 
 ## Workspace shape
 
-- `apps/web`: the only web application. Owns Astro routes, layouts, SEO, and deploy config.
-- `packages/ui`: the shared design system. This is the only place that owns `shadcn/ui` source.
-- `packages/tool-sdk`: the framework-agnostic contract for tools.
-- `packages/tool-registry`: manifest scanning and generated registries/search indexes.
-- `packages/lib/*`: pure TypeScript domain libraries promoted out of tools when reuse is justified.
-- `tools/*`: self-contained tool directories. Tools are not workspace packages.
+- `apps/web` — the only deployable. Astro routes, layouts, SEO, and Cloudflare Worker config.
+- `packages/ui` — shared design system. The only owner of `shadcn/ui` source and `components.json`.
+- `packages/tool-sdk` — framework-agnostic tool contract: `defineTool()`, types, locale resolution, validation.
+- `packages/tool-registry` — manifest discovery + codegen (registry, search index, static paths, page loaders).
+- `packages/lib/<domain>` — promoted, framework-free domain libraries.
+- `tools/<slug>` — self-contained workspace packages, scoped `@tool/<slug>`. Each tool is its own private workspace package with its own runtime deps.
 
 ## Architectural rules
 
-- Default to tool-local code. Shared code must earn its way into `packages/lib/*`.
-- `tools/*` may depend on `packages/ui`, `packages/tool-sdk`, and `packages/lib/*`, but not on `apps/web`.
-- `packages/ui` must stay presentation-focused and must not import app shell code or tool implementations.
-- `packages/tool-sdk` must stay framework-agnostic.
-- `packages/tool-registry` is the only package allowed to generate imports that point at tools.
-- Internal packages are source-only. The app is the only deployable build artifact.
+- Default to tool-local code. Shared code must earn its way into `packages/lib/*` (≥3 callers or correctness-sensitive).
+- `tools/*` may depend on `@workspace/ui`, `@workspace/tool-sdk`, and `packages/lib/*`, but not on `apps/web` or `@workspace/tool-registry`.
+- `packages/ui` is presentation-only; no imports from `apps/web`, `tools/*`, or `tool-registry`.
+- `packages/tool-sdk` is framework-agnostic.
+- `packages/tool-registry` is the only package allowed to generate imports that point at `@tool/*`, and only from `src/generated/`.
+- All external dependency versions live in the `catalog:` block of `pnpm-workspace.yaml`; package manifests reference them as `"catalog:"`.
 
 See [docs/architecture/workspace-boundaries.md](./docs/architecture/workspace-boundaries.md) for the full boundary contract.
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dev          # tool-registry:generate + astro dev (apps/web)
+```
+
+Node `>=20`, `pnpm@10.33.0`.
 
 ## Working with shadcn/ui
 
 `packages/ui` owns the shared `components.json`. Add or update shadcn components from there rather than from the app shell.
+
+## Contributing
+
+- Conventional Commits, enforced by commitlint via Husky. PR titles are checked in CI and become the squash-merge subject.
+- Linter and formatter are `oxlint` and `oxfmt`. Don't introduce ESLint or Prettier.
+- See [CLAUDE.md](./CLAUDE.md) and [AGENTS.md](./AGENTS.md) for agent-facing guidance.

--- a/docs/architecture/workspace-boundaries.md
+++ b/docs/architecture/workspace-boundaries.md
@@ -1,6 +1,8 @@
 # Workspace Boundaries
 
-Issue [#316](https://github.com/InBrowserApp/InBrowserApp/issues/316) established the rewrite workspace layout. The current rewrite narrows those boundaries further around a smaller tool contract. As of `refactor: promote tools/* to workspace packages`, each leaf tool is also a private workspace package scoped under `@tool/<slug>`, so per-tool runtime dependencies live in the tool's own `package.json` instead of being phantom-resolved through the root.
+This document is the source of truth for what each top-level directory owns and what it is allowed to import from. The boundaries are enforced by `.dependency-cruiser.json`; the wording here is the rationale.
+
+Each leaf tool is a private workspace package scoped under `@tool/<slug>`, so per-tool runtime dependencies live in the tool's own `package.json` instead of being phantom-resolved through the root. The original constraints were set in issue [#316](https://github.com/InBrowserApp/InBrowserApp/issues/316).
 
 ## Top-level layout
 

--- a/packages/tool-registry/README.md
+++ b/packages/tool-registry/README.md
@@ -1,20 +1,23 @@
 # `@workspace/tool-registry`
 
-`packages/tool-registry` turns `tools/*/manifest.ts` files into generated platform data.
+`packages/tool-registry` turns `tools/*` workspace packages into generated platform data that the app shell consumes.
 
 ## Responsibilities
 
-- scans `tools/*/manifest.ts`
+- globs `tools/*/package.json`, validates `name === "@tool/" + dirname`, and dynamically imports each manifest via `await import("@tool/<slug>/manifest")` (no filesystem-path imports of tool source)
 - validates manifest shape and slug uniqueness
-- requires a fixed `index.astro` entrypoint per tool
-- loads and validates `meta/*.json`
+- loads and validates `meta/<lang>.json`
 - writes generated outputs into `src/generated/`
+- auto-syncs the `@tool/*` block of its own `package.json` to match the discovered tools (see `syncRegistryPackageDependencies` in `src/generate/io.ts`); manual edits to that block are overwritten on the next run
 
 ## Generated outputs
 
-- `registry.ts`: generated tool registry keyed by slug
-- `static-paths.ts`: language-aware static path entries
-- `search-index.ts`: localized search records based on tool metadata
+- `registry.ts` — generated tool registry keyed by slug
+- `static-paths.ts` — language-aware static path entries
+- `search-index.ts` — localized search records based on tool metadata
+- `page-loaders.ts` — `Record<slug, () => Promise<{ default: AstroComponentFactory }>>` of explicit `import("@tool/<slug>/page")` calls. The app shell uses this map; there is no `import.meta.glob` of tools anywhere in `apps/web`.
+
+The generator only writes a file when its contents change (`writeFileIfChanged`), so a no-op run produces no diff.
 
 ## Usage
 
@@ -24,4 +27,4 @@ Run the generator from the repo root:
 pnpm tool-registry:generate
 ```
 
-Root `build`, `typecheck`, and `dev` commands run the generator first so the generated source stays in sync with tool manifests and localized meta files.
+Root `build`, `typecheck`, and `dev` all run the generator first, so the generated source stays in sync with tool manifests and localized meta files on the day-to-day hot path. CI re-runs the generator and fails on any diff under `src/generated/` or in this package's `package.json` `@tool/*` block.

--- a/packages/tool-sdk/README.md
+++ b/packages/tool-sdk/README.md
@@ -1,6 +1,6 @@
 # `@workspace/tool-sdk`
 
-`packages/tool-sdk` owns the minimal, framework-agnostic tool contract for the Astro rewrite.
+`packages/tool-sdk` owns the minimal, framework-agnostic contract that every `@tool/*` package implements. It is what lets the app shell, the registry generator, and the tools share a vocabulary without leaking UI or routing concerns into the tool authoring surface.
 
 ## Responsibilities
 

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,6 +1,6 @@
 # `@workspace/ui`
 
-`packages/ui` is the single UI entrypoint for the Astro rewrite.
+`packages/ui` is the single UI entrypoint for `apps/web` and every `@tool/*`. Anything UI-shaped is imported from here, never directly from `shadcn`, `lucide-react`, or `@radix-ui/*`.
 
 ## Responsibilities
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -72,6 +72,8 @@ Tools may depend on `@workspace/tool-sdk`, `@workspace/ui`, and `packages/lib/*`
      }
    }
    ```
-3. Add `"@tool/<slug>": "workspace:*"` to `packages/tool-registry/package.json` dependencies (the registry needs this dep edge so its generated `page-loaders.ts` can import the tool).
-4. Run `pnpm install` to materialize the workspace symlinks.
-5. Run `pnpm tool-registry:generate` to refresh the generated registry, static paths, search index, and page loaders.
+3. Run `pnpm tool-registry:generate`. The generator auto-syncs the `@tool/*` block of `packages/tool-registry/package.json` to match the discovered tools (see `syncRegistryPackageDependencies` in `packages/tool-registry/src/generate/io.ts`), so do **not** hand-edit that block — it will be overwritten on the next run.
+4. If the generator reports that the registry's `package.json` was out of sync, it has already rewritten it. Run `pnpm install` to materialize the workspace symlink for the new `@tool/<slug>`, then re-run `pnpm tool-registry:generate`. The second run refreshes `src/generated/{registry,static-paths,search-index,page-loaders}.ts`.
+5. Commit both `packages/tool-registry/package.json` (if it changed) and any updates under `packages/tool-registry/src/generated/`.
+
+`pnpm build`, `pnpm dev`, and `pnpm typecheck` all run `pnpm tool-registry:generate` first, so the generator is on the day-to-day hot path — if you forget to commit the generated diffs, CI fails the "Verify generated tool registry is up to date" step.


### PR DESCRIPTION
## Summary

The Astro rewrite shipped on `main` as v2.0.0 (#919), but the top-level docs still framed the repo as an in-flight rewrite branch and described the pre-ship workflows. This refresh aligns the docs with the current code.

- **`README.md`** — rewrite as a product README (live at inbrowser.app), drop "this branch hosts the rewrite" framing, link to the boundary doc.
- **`CLAUDE.md` / `AGENTS.md`** — `main` is the live product; legacy lives on `legacy/vue`. Update pnpm to `10.33.0`. Replace the manual edit of `packages/tool-registry/package.json` with the generator's auto-sync flow (`syncRegistryPackageDependencies` in `packages/tool-registry/src/generate/io.ts`). Rewrite the hosting section to match `ci.yml`: previews are Workers Versions, production deploys on release, no separate `staging` env in `wrangler.jsonc`.
- **`tools/README.md`** — simplify "adding a new tool" to the auto-sync flow; warn against hand-editing the `@tool/*` dep block.
- **`docs/architecture/workspace-boundaries.md`** — drop the "current rewrite" framing; keep #316 as historical context.
- **`packages/{ui,tool-sdk,tool-registry}/README.md`** — drop "the Astro rewrite" framing; add the missing `page-loaders.ts` output and the dep auto-sync responsibility to the registry README.

Docs-only — no code changes. The stale `apps/web` `deploy:staging` npm script (which references the removed `--env staging`) is intentionally left for a follow-up.

## Test plan

- [ ] CI green (lint, format, registry-up-to-date, typecheck, test+coverage, depcruise, knip, build-web).
- [ ] Spot-check rendered Markdown on the PR (headings, code fences, links).
- [ ] Confirm no remaining references to `pnpm@9.x`, `dev/astro-rewrite-base`, `--env staging`, or "Astro rewrite" framing in repo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)