### PR TITLE
fix(web): constrain tools grid to single column on mobile

### DIFF
--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -249,7 +249,7 @@ function ToolsDirectorySearch({
           </p>
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {rankedEntries.map(({ entry }) => {
             const locale = resolveLocale(entry, language)
 


### PR DESCRIPTION
## Problem

On the index (home) page, the tools list overflows horizontally on mobile, making cards wider than the viewport.

The grid in `apps/web/src/components/pages/tools-directory-search.tsx` only declared responsive columns from the `sm` breakpoint up:

```jsx
<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
```

Below `sm` (640px) the grid has no explicit column definition, so it falls back to a **single implicit `auto`-sized column**. An `auto` grid track grows to its content's *max-content* width. The card description `<p className="line-clamp-2 …">` has no width constraint — `line-clamp-2` caps height, not intrinsic width — so its max-content is the full description on a single line. That intrinsic width blows the column past the viewport and causes horizontal overflow on mobile.

Tailwind's `grid-cols-N` utilities use `minmax(0, 1fr)` (min of `0`) precisely to prevent this blowout, but that guard only existed for `sm:`/`lg:` — the mobile default was the one breakpoint missing it.

## Fix

Add an explicit `grid-cols-1` so the mobile breakpoint also uses `minmax(0, 1fr)`, clamping the column to the container width like the larger breakpoints:

```jsx
<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
```

One-line, presentation-only change. `pnpm lint` and `pnpm format:check` pass.

https://claude.ai/code/session_018TGhJpLFNYKty3nyfNxjsn

---
_Generated by [Claude Code](https://claude.ai/code/session_018TGhJpLFNYKty3nyfNxjsn)_