### PR TITLE
fix(web): prevent iOS Safari zoom on directory search focus

### DIFF
--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -193,7 +193,7 @@ function ToolsDirectorySearch({
           <Input
             ref={inputRef}
             aria-label={messages.searchLabel}
-            className="h-11 pl-10 text-sm"
+            className="h-11 pl-10 text-base md:text-sm"
             placeholder={messages.searchPlaceholder}
             defaultValue={query}
             onCompositionStart={() => {


### PR DESCRIPTION
## Problem

On mobile iOS Safari, tapping the tools-directory search box zooms the page in. This is the classic iOS auto-zoom: Safari zooms whenever a focused input has an effective `font-size` below 16px.

## Root cause

`apps/web/src/components/pages/tools-directory-search.tsx` applied an unconditional `text-sm` (14px) to the search `<Input>`:

```tsx
className="h-11 pl-10 text-sm"
```

The shared `Input` primitive (`packages/ui/src/components/ui/input.tsx`) is already iOS-safe — it renders `text-base` (16px) by default and only downshifts to `text-sm` at the `md:` breakpoint and up, where iOS zoom doesn't apply. The directory search's override re-introduced 14px on mobile, triggering the zoom.

The viewport meta tag (`width=device-width`, no `maximum-scale`) intentionally keeps pinch-zoom enabled for accessibility, so the fix belongs on the font-size side, not the viewport.

## Fix

```tsx
className="h-11 pl-10 text-base md:text-sm"
```

Keeps 16px on mobile (no auto-zoom) while preserving the 14px desktop appearance, matching the shared `Input` default.

## Notes

The other tool search boxes (mime-type-lookup, port-number-lookup, http-status-code-lookup, html-color-names) use the shared `Input` without a font-size override, so they were already safe and are untouched.

https://claude.ai/code/session_01Ei5x7zwA16KJhzejpKaMC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ei5x7zwA16KJhzejpKaMC9)_