### PR TITLE
fix(ui): correct systemic and per-tool card padding issues

### DIFF
--- a/packages/ui/src/components/tool/tool-panel-card.test.tsx
+++ b/packages/ui/src/components/tool/tool-panel-card.test.tsx
@@ -23,6 +23,17 @@ describe("ToolPanelCard", () => {
     expect(card?.className).toContain("py-0")
   })
 
+  test("restores top padding on a header child", () => {
+    render(
+      <ToolPanelCard>
+        <div>body</div>
+      </ToolPanelCard>
+    )
+
+    const card = screen.getByText("body").closest("[data-slot='card']")
+    expect(card?.className).toContain("[&>[data-slot=card-header]]:pt-4")
+  })
+
   test("adds flex content defaults", () => {
     render(
       <ToolPanelCard>

--- a/packages/ui/src/components/tool/tool-panel-card.tsx
+++ b/packages/ui/src/components/tool/tool-panel-card.tsx
@@ -8,7 +8,13 @@ function ToolPanelCard({
   ...props
 }: React.ComponentProps<typeof Card>) {
   return (
-    <Card className={cn("h-full min-h-0 gap-0 py-0", className)} {...props} />
+    <Card
+      className={cn(
+        "h-full min-h-0 gap-0 py-0 [&>[data-slot=card-header]]:pt-4",
+        className
+      )}
+      {...props}
+    />
   )
 }
 

--- a/packages/ui/src/components/tool/tool-panel-card.tsx
+++ b/packages/ui/src/components/tool/tool-panel-card.tsx
@@ -10,7 +10,7 @@ function ToolPanelCard({
   return (
     <Card
       className={cn(
-        "h-full min-h-0 gap-0 py-0 [&>[data-slot=card-header]]:pt-4",
+        "h-full min-h-0 gap-0 py-0 [&>[data-slot=card-header]]:pt-4 data-[size=sm]:[&>[data-slot=card-header]]:pt-3",
         className
       )}
       {...props}

--- a/tools/barcode-reader/client/camera-card.tsx
+++ b/tools/barcode-reader/client/camera-card.tsx
@@ -108,7 +108,7 @@ function CameraCard({
         <CardTitle>{messages.cameraTitle}</CardTitle>
         <CardDescription>{messages.cameraDescription}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-4">
+      <ToolPanelCardContent className="gap-4 py-4">
         <div className="relative aspect-square w-full overflow-hidden rounded-xl border bg-muted">
           <video
             ref={videoRef}

--- a/tools/color-contrast-checker/client/preview-card.tsx
+++ b/tools/color-contrast-checker/client/preview-card.tsx
@@ -26,7 +26,7 @@ export function PreviewCard({ messages, previewStyle }: PreviewCardProps) {
           {messages.normalTextLabel} / {messages.largeTextLabel}
         </CardDescription>
       </CardHeader>
-      <ToolPanelCardContent>
+      <ToolPanelCardContent className="py-4">
         <div
           className="grid gap-5 rounded-xl border p-5 shadow-xs"
           style={previewStyle}

--- a/tools/color-converter/client/options-card.tsx
+++ b/tools/color-converter/client/options-card.tsx
@@ -47,7 +47,7 @@ export function OptionsCard({
         <CardTitle>{messages.optionsTitle}</CardTitle>
         <CardDescription>{messages.meta.description}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-6">
+      <ToolPanelCardContent className="gap-6 py-4">
         <div className="flex items-center gap-4 rounded-xl border bg-muted/20 p-4">
           <div
             aria-hidden="true"

--- a/tools/color-converter/client/preview-card.tsx
+++ b/tools/color-converter/client/preview-card.tsx
@@ -45,7 +45,7 @@ export function PreviewCard({
         <CardTitle>{messages.previewTitle}</CardTitle>
         <CardDescription>{messages.meta.description}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-6">
+      <ToolPanelCardContent className="gap-6 py-4">
         <div
           className="rounded-2xl border p-4"
           style={{

--- a/tools/color-picker/client/results-card.tsx
+++ b/tools/color-picker/client/results-card.tsx
@@ -79,7 +79,7 @@ function ResultsCard({
           </div>
         </CardAction>
       </CardHeader>
-      <ToolPanelCardContent className="gap-5">
+      <ToolPanelCardContent className="gap-5 py-4">
         <div className="flex flex-wrap items-center gap-4 rounded-xl border bg-muted/20 p-4">
           <div
             className="size-16 rounded-2xl border shadow-inner"

--- a/tools/cron-expression-parser/components/cron-results-card.tsx
+++ b/tools/cron-expression-parser/components/cron-results-card.tsx
@@ -124,7 +124,7 @@ function CronResultsCard({
           </Badge>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-6 p-6">
+      <CardContent className="flex flex-col gap-6 p-4">
         {validation.state === "empty" ? (
           <Empty className="rounded-none border-0 py-10">
             <EmptyHeader>

--- a/tools/css-box-shadow-generator/components/preview-card.tsx
+++ b/tools/css-box-shadow-generator/components/preview-card.tsx
@@ -62,7 +62,7 @@ function PreviewCard({
           </Button>
         </CardAction>
       </CardHeader>
-      <ToolPanelCardContent className="min-w-0 gap-3">
+      <ToolPanelCardContent className="min-w-0 gap-3 py-3">
         <div
           className={cn(
             "grid min-h-48 place-items-center overflow-hidden rounded-lg border p-3 transition-colors sm:min-h-56 sm:p-4",

--- a/tools/gif-to-apng-converter/client/result-preview-card.tsx
+++ b/tools/gif-to-apng-converter/client/result-preview-card.tsx
@@ -31,7 +31,7 @@ function ResultPreviewCard({
   )}`
 
   return (
-    <Card className="gap-0 overflow-hidden">
+    <Card className="gap-0 overflow-hidden py-0">
       <CardContent className="flex flex-col gap-4 p-4 pb-3">
         <div className="flex min-h-44 items-center justify-center rounded-lg border bg-[linear-gradient(135deg,rgba(161,161,170,0.10),rgba(228,228,231,0.22))] p-3">
           {previewUrl ? (

--- a/tools/gitignore-generator/components/preview-card.tsx
+++ b/tools/gitignore-generator/components/preview-card.tsx
@@ -29,11 +29,11 @@ function PreviewCard({
 }: PreviewCardProps) {
   return (
     <ToolPanelCard>
-      <CardHeader className="border-b">
+      <CardHeader className="border-b pt-4">
         <CardTitle>{messages.resultLabel}</CardTitle>
         <CardDescription>{messages.resultDescription}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent>
+      <ToolPanelCardContent className="py-4">
         <ScrollArea className="h-[28rem] overflow-hidden rounded-lg border border-input bg-transparent sm:h-[32rem]">
           <HighlightedGitignore
             ariaLabel={messages.resultLabel}

--- a/tools/gitignore-generator/components/preview-card.tsx
+++ b/tools/gitignore-generator/components/preview-card.tsx
@@ -29,7 +29,7 @@ function PreviewCard({
 }: PreviewCardProps) {
   return (
     <ToolPanelCard>
-      <CardHeader className="border-b pt-4">
+      <CardHeader className="border-b">
         <CardTitle>{messages.resultLabel}</CardTitle>
         <CardDescription>{messages.resultDescription}</CardDescription>
       </CardHeader>

--- a/tools/image-to-avif-converter/client/result-preview-card.tsx
+++ b/tools/image-to-avif-converter/client/result-preview-card.tsx
@@ -18,7 +18,7 @@ function ResultPreviewCard({ messages, result }: ResultPreviewCardProps) {
   const previewUrl = useObjectUrl(result.blob)
 
   return (
-    <Card className="gap-0 overflow-hidden">
+    <Card className="gap-0 overflow-hidden py-0">
       <CardContent className="flex flex-col gap-4 p-4 pb-3">
         <div className="flex min-h-44 items-center justify-center rounded-lg border bg-[linear-gradient(135deg,rgba(161,161,170,0.10),rgba(228,228,231,0.22))] p-3">
           {previewUrl ? (

--- a/tools/image-to-webp-converter/client/result-preview-card.tsx
+++ b/tools/image-to-webp-converter/client/result-preview-card.tsx
@@ -18,7 +18,7 @@ function ResultPreviewCard({ messages, result }: ResultPreviewCardProps) {
   const previewUrl = useObjectUrl(result.blob)
 
   return (
-    <Card className="gap-0 overflow-hidden">
+    <Card className="gap-0 overflow-hidden py-0">
       <CardContent className="flex flex-col gap-4 p-4 pb-3">
         <div className="flex min-h-44 items-center justify-center rounded-lg border bg-[linear-gradient(135deg,rgba(161,161,170,0.10),rgba(228,228,231,0.22))] p-3">
           {previewUrl ? (

--- a/tools/password-strength-checker/components/password-results-card.tsx
+++ b/tools/password-strength-checker/components/password-results-card.tsx
@@ -52,7 +52,7 @@ function PasswordResultsCard({ analysis, messages }: PasswordResultsCardProps) {
         <CardTitle>{messages.resultTitle}</CardTitle>
         <CardDescription>{description}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-4">
+      <ToolPanelCardContent className="gap-4 py-4">
         {analysis ? (
           <>
             <section className="rounded-xl border border-border/70 bg-muted/20 p-4">

--- a/tools/qr-code-reader/client/camera-card.tsx
+++ b/tools/qr-code-reader/client/camera-card.tsx
@@ -102,7 +102,7 @@ function CameraCard({
         <CardTitle>{messages.cameraTitle}</CardTitle>
         <CardDescription>{messages.cameraDescription}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-4">
+      <ToolPanelCardContent className="gap-4 py-4">
         <div className="relative aspect-square w-full overflow-hidden rounded-xl border bg-muted">
           <video
             ref={videoRef}

--- a/tools/random-number-generator/components/results-card.tsx
+++ b/tools/random-number-generator/components/results-card.tsx
@@ -43,7 +43,7 @@ function ResultsCard({
         <CardTitle>{messages.resultsTitle}</CardTitle>
         <CardDescription>{messages.resultsDescription}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-5">
+      <ToolPanelCardContent className="gap-5 py-4">
         <button
           type="button"
           className="flex min-h-52 w-full flex-1 items-center justify-center rounded-xl border border-dashed border-border bg-muted/20 px-4 py-6 text-center transition-colors hover:border-primary/40 hover:bg-muted/40 disabled:cursor-default disabled:hover:border-border disabled:hover:bg-muted/20"

--- a/tools/random-password-generator/components/results-card.tsx
+++ b/tools/random-password-generator/components/results-card.tsx
@@ -58,7 +58,7 @@ function ResultsCard({
         <CardTitle>{messages.resultsTitle}</CardTitle>
         <CardDescription>{messages.resultsDescription}</CardDescription>
       </CardHeader>
-      <ToolPanelCardContent className="gap-5">
+      <ToolPanelCardContent className="gap-5 py-4">
         <div
           aria-label={messages.resultsTitle}
           className="flex min-h-56 w-full flex-1 items-center justify-center rounded-2xl border border-dashed border-border bg-linear-to-br from-muted/10 via-background to-muted/25 px-5 py-6 text-center"

--- a/tools/uuid-max-generator/client.tsx
+++ b/tools/uuid-max-generator/client.tsx
@@ -86,7 +86,7 @@ function UuidMaxGeneratorClient({ messages }: UuidMaxGeneratorClientProps) {
             <Badge variant="secondary">{messages.stableValue}</Badge>
           </div>
         </CardHeader>
-        <ToolPanelCardContent className="gap-4">
+        <ToolPanelCardContent className="gap-4 py-4">
           <div className="rounded-md border bg-muted/20 p-4">
             <div className="mb-2 text-sm font-medium">
               {messages.canonicalLabel}

--- a/tools/uuid-nil-generator/client.tsx
+++ b/tools/uuid-nil-generator/client.tsx
@@ -87,7 +87,7 @@ function UuidNilGeneratorClient({ messages }: UuidNilGeneratorClientProps) {
             <Badge variant="secondary">{messages.stableValue}</Badge>
           </div>
         </CardHeader>
-        <ToolPanelCardContent className="gap-4">
+        <ToolPanelCardContent className="gap-4 py-4">
           <div className="rounded-md border bg-muted/20 p-4">
             <div className="mb-2 text-sm font-medium">
               {messages.canonicalLabel}


### PR DESCRIPTION
## Card spacing review

A careful pass over card padding/margins across all ~214 tools. The shared shadcn `Card` supplies vertical rhythm (`py-4` + `gap-4`); `CardHeader`/`CardContent` only add horizontal padding and rely on the card's `py-4` for top/bottom space. `ToolPanelCard` deliberately resets that to `gap-0 py-0` so a full-bleed child can own its padding — correct for headerless/full-bleed panels, but it silently removes the padding from any `CardHeader`/framed box placed inside. That reset is the root of most issues found.

### Fixed

**1. Systemic — header flush against the top edge (root-cause fix).** `ToolPanelCard` is `gap-0 py-0` and `CardHeader` has no top padding of its own, so **~181 card headers across ~89 tools** rendered with their title jammed against the card's rounded top edge. Only ~22 panels escaped it by manually adding header padding. Fixed at the source in `tool-panel-card.tsx`, size-aware so small cards stay symmetric:

```tsx
"… gap-0 py-0 [&>[data-slot=card-header]]:pt-4 data-[size=sm]:[&>[data-slot=card-header]]:pt-3"
```

One rule, fixes all ~89 tools (16px on default cards / 12px on `size=sm`, each symmetric with the `border-b`'s `pb-4`/`pb-3`). Panels that already set their own header padding are unaffected; `markdown-previewer`'s header goes 20→16px, which makes it symmetric.

**2. Doubled vertical padding — image converter result preview cards (3 tools).** `gif-to-apng`, `image-to-webp`, `image-to-avif` kept the Card's `py-4` *and* added `p-4` content → 32px top. The sibling `gif-to-animated-webp` renders the same component correctly as a plain `<article>`. Fixed by adding `py-0` to the Card.

**3. Header/content edge misalignment — `cron-expression-parser`.** Header `px-4` (16) vs content `p-6` (24) misaligned the left edges. Aligned content to `p-4`.

**4. Framed box jammed against dividers/edges — 13 panels.** These panels show a single bordered display box (preview, swatch, viewfinder, value box, strength/result panel) that had 16px horizontal inset (content `px-4`) but **0px vertical**, so it sat flush against the header divider / card edge with an asymmetric inset. Added `py-4` (or `py-3` for the `size=sm` card) for a symmetric inset:

`gitignore-generator`, `color-contrast-checker`, `barcode-reader`, `qr-code-reader`, `color-converter` (options + preview), `color-picker`, `uuid-max-generator`, `uuid-nil-generator`, `password-strength-checker`, `random-number-generator`, `random-password-generator`, `css-box-shadow-generator` (sm).

### Reviewed and deliberately NOT changed

- **Content padding is intentionally heterogeneous** — `p-0` full-bleed (markdown preview iframe, `markdown-to-html` output, `reverse-ip`/`ip-info` tables), `p-5` (`pdf-splitter`), `p-6` (`radio-timecode`), `pb-3` (converter previews). It can't be normalized at the source without overriding these, and bottom-jamming is layout-dependent (`flex-1`). So content was fixed per-tool, only for clear framed-box cases above.
- **Textarea/input fills, conditional alerts, plain labeled fields, list/form content** sitting flush below a `border-b` header — established house style (the divider separates); left as-is. Where a tool mixes a framed-box card (padded) with a fields card (flush), the difference is content-driven and intentional, not an inconsistency.
- `gap-0` cards with `CardContent pt-4` (`device-information`, `my-ip-address`, `audio-recorder`) — intentional 16px gap below a divider.

### Verification
- `pnpm test` — **19,817 tests passing** (incl. a new ToolPanelCard test); affected-tool suites re-run green
- `pnpm typecheck` — 0 errors; Tailwind stacked variant has precedent in `card.tsx` and is verified by the CI build
- `oxlint` clean on all changed files

> Verified via tests, typecheck, and the gold-standard tools already hard-coding the same values — no rendered screenshot (no headless browser in this environment).

https://claude.ai/code/session_01F9kTvDMUxud2kcNGnBt766