### PR TITLE
ci: automerge non-major deps and run Renovate daily

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,7 @@
   },
   "packageRules": [
     {
-      "description": "Automerge non-major devDependency updates once CI passes",
-      "matchDepTypes": ["devDependencies"],
+      "description": "Automerge all non-major updates once CI passes",
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     },

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommits"],
   "timezone": "Etc/UTC",
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 6am"],
   "rangeStrategy": "bump",
   "postUpdateOptions": ["pnpmDedupe"],
   "lockFileMaintenance": {


### PR DESCRIPTION
## What

Two tweaks to the Renovate config (`renovate.json`):

1. **Automerge all non-major updates** — every `minor`/`patch` update now automerges once CI passes, for both runtime and dev dependencies (was `devDependencies`-only).
2. **Run daily instead of weekly** — `schedule` changed from Monday-only to `before 6am` daily. With automerge handling the noise, daily means faster patch/security uptake. Lock file maintenance stays weekly.

Major updates and security PRs still require manual review (security PRs are still raised immediately, bypassing the schedule).

## Activation reminder
Automerge only actually merges if the repo has **Settings → Allow auto-merge** enabled and `main` branch protection lists CI as required checks; otherwise Renovate marks the PR for automerge but waits.

https://claude.ai/code/session_01KEnqEtvh4URaoXjnXoFAUe