### PR TITLE
ci: isolate htmltest into a dedicated HTML Link Check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,16 +121,33 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=6144
         run: pnpm build
 
-      - name: Check internal links in built HTML
-        uses: wjdp/htmltest-action@master
-        with:
-          config: .htmltest.yml
-
       - name: Upload web artifact
         uses: actions/upload-artifact@v4
         with:
           name: web-dist
           path: apps/web/dist
+
+  html-check:
+    name: HTML Link Check
+    runs-on: ubuntu-latest
+    needs:
+      - build-web
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download web artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: web-dist
+          path: apps/web/dist
+
+      - name: Check internal links in built HTML
+        uses: wjdp/htmltest-action@master
+        with:
+          config: .htmltest.yml
 
   upload-release-asset:
     name: Upload Release Asset
@@ -139,6 +156,7 @@ jobs:
       - code-check
       - test
       - build-web
+      - html-check
     if: github.event_name == 'release'
     permissions:
       contents: write
@@ -164,6 +182,7 @@ jobs:
       - code-check
       - test
       - build-web
+      - html-check
     if: github.event_name == 'release'
     permissions:
       contents: read
@@ -205,6 +224,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-web
+      - html-check
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
       || (github.event_name == 'push' && github.ref == 'refs/heads/main')


### PR DESCRIPTION
## What

Moves the htmltest internal-link check out of the `build-web` job into its own dedicated `html-check` job (name: **HTML Link Check**).

## Why

Previously htmltest ran as a step inside `build-web`, between `pnpm build` and the artifact upload. That mixed two concerns: producing the artifact vs. verifying the built HTML. Splitting them gives:

- **Clear failure attribution** — a red "Build Web" no longer hides whether the build broke or just a link broke. Now you get separate ✅/❌ for build vs. link check.
- **Single-responsibility `build-web`** — it just builds and uploads the artifact.
- **Near-zero extra cost** — the new job needs no Node/pnpm; it only checks out (for `.htmltest.yml`), downloads the existing `web-dist` artifact, and runs the Docker-based htmltest action. No rebuild.

## Gating preserved

The old inline step blocked deploys via `build-web`. To keep that exact behavior, `html-check` is added to the `needs` of **all** downstream jobs — `upload-release-asset`, `deploy-production`, and `deploy-staging` — so a broken link still blocks every deploy path (staging previews, production release, and release asset upload).

## Notes

- `wjdp/htmltest-action` is a Docker action, so it never touched the build job's Node environment anyway — the real win here is clarity and attribution, not environment isolation.

https://claude.ai/code/session_01DuqyEwBuHddaTEoxhfEhcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01DuqyEwBuHddaTEoxhfEhcA)_