### PR TITLE
ci: attest build provenance for release archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,8 @@ jobs:
     if: github.event_name == 'release'
     permissions:
       contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Download web artifact
         uses: actions/download-artifact@v4
@@ -169,6 +171,11 @@ jobs:
 
       - name: Create tar.zstd archive
         run: tar --zstd -cf "web-dist-${{ github.event.release.tag_name }}.tar.zstd" -C apps/web/dist .
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: web-dist-${{ github.event.release.tag_name }}.tar.zstd
 
       - name: Upload to release
         env:


### PR DESCRIPTION
## What

Generate a [SLSA build provenance](https://slsa.dev/) attestation for the `web-dist-<tag>.tar.zstd` archive that is uploaded to GitHub Releases, so the published artifact can be cryptographically verified back to the commit and workflow that built it.

## Changes

In the `upload-release-asset` job of `.github/workflows/ci.yml`:

- Add `id-token: write` and `attestations: write` permissions (kept existing `contents: write` for the release upload).
- Add an `actions/attest-build-provenance@v4` step right after the archive is created and before it's uploaded to the release.

```yaml
      - name: Attest build provenance
        uses: actions/attest-build-provenance@v4
        with:
          subject-path: web-dist-${{ github.event.release.tag_name }}.tar.zstd
```

## Notes

- Scoped to the `upload-release-asset` job only — PR / push / staging / production-deploy flows are untouched. The step only runs on `release: published` (the job already gates on `if: github.event_name == 'release'`).
- This is a **public** repo, so attestation uses the free Sigstore public-good instance — no extra secrets required.
- Consumers can verify a downloaded asset with:

  ```bash
  gh attestation verify web-dist-<tag>.tar.zstd --repo InBrowserApp/InBrowserApp
  ```

https://claude.ai/code/session_014wfwhPzPUxRNa2uVZm62ky

---
_Generated by [Claude Code](https://claude.ai/code/session_014wfwhPzPUxRNa2uVZm62ky)_