### PR TITLE
fix(web): restore single-column tools grid on mobile

### DIFF
--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -249,7 +249,7 @@ function ToolsDirectorySearch({
           </p>
         </div>
       ) : (
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {rankedEntries.map(({ entry }) => {
             const locale = resolveLocale(entry, language)
 


### PR DESCRIPTION
## What

Re-add the `grid-cols-1` class to the home page tools grid so it stays a single column on mobile.

## Why

This is a regression. PR #927 originally added `grid-cols-1` to fix horizontal overflow on mobile (an implicit auto track grows to the longest tool description's max-content width, since `line-clamp` limits height not intrinsic width, blowing the column past the viewport).

PR #933 (the language-suggestion banner, commit `c20f5af5`) inadvertently reverted that one-line change during rebase, dropping `grid-cols-1` and reintroducing the mobile card-width / horizontal-overflow issue.

```diff
-<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
```

This restores the #927 fix. No behavior change on `sm`/`lg` breakpoints.

https://claude.ai/code/session_014VsFu3dU7ooMzF1GgiRmgr

---
_Generated by [Claude Code](https://claude.ai/code/session_014VsFu3dU7ooMzF1GgiRmgr)_