### PR TITLE
chore(lint): enable oxlint vitest and promise plugins

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,15 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["import", "react", "jsx-a11y", "typescript", "unicorn", "oxc"],
+  "plugins": [
+    "import",
+    "react",
+    "jsx-a11y",
+    "typescript",
+    "unicorn",
+    "oxc",
+    "vitest",
+    "promise"
+  ],
   "categories": {
     "correctness": "error"
   },
@@ -14,7 +23,23 @@
     {
       "files": ["**/*.test.ts", "**/*.test.tsx", "**/tests/**"],
       "rules": {
-        "max-lines": "off"
+        "max-lines": "off",
+        "vitest/require-mock-type-parameters": "off",
+        "vitest/no-conditional-expect": "off",
+        "vitest/valid-expect": "error",
+        "vitest/expect-expect": [
+          "error",
+          {
+            "assertFunctionNames": [
+              "expect*",
+              "screen.findBy*",
+              "screen.findAllBy*",
+              "screen.getBy*",
+              "screen.getAllBy*"
+            ]
+          }
+        ],
+        "vitest/require-to-throw-message": "error"
       }
     },
     {

--- a/tests/i18n-consistency.test.ts
+++ b/tests/i18n-consistency.test.ts
@@ -154,23 +154,20 @@ describe.each(families)("locale family $relDir/*.$ext", ({ dir, ext }) => {
     expect(missing).toEqual([])
   })
 
-  if (ext === "json") {
-    const enKeys = collectKeyPaths(loadJson(path.join(dir, "en.json")))
-    const others = filesInDir.filter((f) => f !== "en.json")
-    for (const file of others) {
-      test(`${file}: JSON key parity with en`, () => {
+  const enFile = `en.${ext}`
+  const parityKind = ext === "json" ? "JSON key" : "markdown heading structure"
+  const others = filesInDir.filter((f) => f !== enFile)
+  for (const file of others) {
+    test(`${file}: ${parityKind} parity with en`, () => {
+      if (ext === "json") {
+        const enKeys = collectKeyPaths(loadJson(path.join(dir, enFile)))
         const keys = collectKeyPaths(loadJson(path.join(dir, file)))
         expect(diffSets(enKeys, keys)).toEqual({ missing: [], extra: [] })
-      })
-    }
-  } else {
-    const enLevels = extractHeadingLevels(loadText(path.join(dir, "en.md")))
-    const others = filesInDir.filter((f) => f !== "en.md")
-    for (const file of others) {
-      test(`${file}: markdown heading structure parity with en`, () => {
+      } else {
+        const enLevels = extractHeadingLevels(loadText(path.join(dir, enFile)))
         const levels = extractHeadingLevels(loadText(path.join(dir, file)))
         expect(levels).toEqual(enLevels)
-      })
-    }
+      }
+    })
   }
 })

--- a/tools/aes-encryptor/core/aes-encryptor.test.ts
+++ b/tools/aes-encryptor/core/aes-encryptor.test.ts
@@ -231,7 +231,7 @@ describe("decryptAesEnvelope", () => {
 
     await expect(
       decryptAesEnvelope(tamperedEnvelope, { password: "secret" })
-    ).rejects.toThrow()
+    ).rejects.toThrow(/operation failed/i)
   })
 
   it("rejects malformed hexadecimal envelope fields", async () => {

--- a/tools/base64-encoder-decoder/core/base64.test.ts
+++ b/tools/base64-encoder-decoder/core/base64.test.ts
@@ -43,7 +43,7 @@ describe("decodeBase64", () => {
   })
 
   test("throws on invalid base64", () => {
-    expect(() => decodeBase64("!!!")).toThrow()
+    expect(() => decodeBase64("!!!")).toThrow("Invalid character")
   })
 })
 

--- a/tools/data-uri-to-file-converter/core/data-uri.test.ts
+++ b/tools/data-uri-to-file-converter/core/data-uri.test.ts
@@ -55,8 +55,12 @@ describe("parseDataUri", () => {
   })
 
   test("throws for malformed values", () => {
-    expect(() => parseDataUri("https://example.com")).toThrow()
-    expect(() => parseDataUri("data:text/plain;base64")).toThrow()
+    expect(() => parseDataUri("https://example.com")).toThrow(
+      "Invalid Data URI"
+    )
+    expect(() => parseDataUri("data:text/plain;base64")).toThrow(
+      "Invalid Data URI"
+    )
   })
 })
 

--- a/tools/favicon-assets-generator/client.test.tsx
+++ b/tools/favicon-assets-generator/client.test.tsx
@@ -980,19 +980,17 @@ describe("FaviconAssetsGeneratorClient", () => {
   test("changing the maskable margin slider via keyboard moves the value", async () => {
     render(<FaviconAssetsGeneratorClient messages={messages} />)
 
-    const sliders = document.querySelectorAll<HTMLElement>("[role='slider']")
-    const maskableSlider = Array.from(sliders).find((s) => {
-      const labelledBy = s.getAttribute("aria-labelledby")
-      if (!labelledBy) return false
-      const label = document.getElementById(labelledBy)
-      return (
-        label !== null &&
-        (label.textContent ?? "").includes(messages.maskableMarginLabel)
-      )
-    })
-    if (maskableSlider) {
-      fireEvent.keyDown(maskableSlider, { key: "ArrowLeft" })
-    }
+    const marginLabel = Array.from(document.querySelectorAll("label")).find(
+      (el) => (el.textContent ?? "").includes(messages.maskableMarginLabel)
+    )
+    const sliderId = marginLabel?.getAttribute("for")
+    const root = sliderId ? document.getElementById(sliderId) : null
+    const thumb = root?.querySelector<HTMLElement>("[role='slider']")
+    expect(thumb).toBeTruthy()
+
+    const before = Number(thumb!.getAttribute("aria-valuenow"))
+    fireEvent.keyDown(thumb!, { key: "ArrowLeft" })
+    expect(Number(thumb!.getAttribute("aria-valuenow"))).toBeLessThan(before)
   })
 
   test("the description and asset path FieldDescription elements render", () => {

--- a/tools/json-schema-generator/core/generate-json-schema.test.ts
+++ b/tools/json-schema-generator/core/generate-json-schema.test.ts
@@ -175,9 +175,9 @@ describe("generateJsonSchema", () => {
       string,
       Record<string, unknown>
     >
-    for (const [key, property] of Object.entries(properties)) {
-      expect(property.type, key).toBe("string")
-      expect(property.format, key).toBeUndefined()
+    for (const property of Object.values(properties)) {
+      expect(property.type).toBe("string")
+      expect(property.format).toBeUndefined()
     }
   })
 

--- a/tools/prettier-code-formatter/workers/prettier.worker.test.ts
+++ b/tools/prettier-code-formatter/workers/prettier.worker.test.ts
@@ -63,7 +63,7 @@ describe("formatRequest", () => {
   it("rejects invalid input with the underlying prettier message", async () => {
     await expect(
       formatRequest(createPrettierFormatRequest("{", { language: "json" }))
-    ).rejects.toThrow()
+    ).rejects.toThrow(/Unexpected token/)
   })
 
   it("registers a worker message handler that posts formatted results", async () => {

--- a/tools/radio-timecode/audio/signal-engine.test.ts
+++ b/tools/radio-timecode/audio/signal-engine.test.ts
@@ -119,8 +119,10 @@ describe("SignalEngine", () => {
       () => new FakeAudioContext() as unknown as AudioContext
     )
 
-    engine.setVolume(0.2)
-    ;(engine as unknown as { schedule: () => void }).schedule()
+    expect(() => {
+      engine.setVolume(0.2)
+      ;(engine as unknown as { schedule: () => void }).schedule()
+    }).not.toThrow()
   })
 })
 

--- a/tools/scrypt-key-derivation/client.test.tsx
+++ b/tools/scrypt-key-derivation/client.test.tsx
@@ -121,7 +121,9 @@ describe("ScryptKeyDerivationClient", () => {
 
     expect(screen.getByText(messages.emptyStateDescription)).toBeTruthy()
     expect(getSaltInput().getAttribute("placeholder")).toBe(messages.saltLabel)
-    expect(screen.getByText(`${messages.memoryEstimateLabel}: 16 MiB`))
+    expect(
+      screen.getByText(`${messages.memoryEstimateLabel}: 16 MiB`)
+    ).toBeTruthy()
   })
 
   test("derives a key from password and text salt", async () => {

--- a/tools/url-component-encoder-decoder/core/url-component.test.ts
+++ b/tools/url-component-encoder-decoder/core/url-component.test.ts
@@ -36,11 +36,11 @@ describe("decodeUrlComponent", () => {
   })
 
   test("throws for incomplete escape sequences", () => {
-    expect(() => decodeUrlComponent("100%")).toThrow()
+    expect(() => decodeUrlComponent("100%")).toThrow("URI malformed")
   })
 
   test("throws for malformed utf-8 byte sequences", () => {
-    expect(() => decodeUrlComponent("%E0%A4%A")).toThrow()
+    expect(() => decodeUrlComponent("%E0%A4%A")).toThrow("URI malformed")
   })
 })
 


### PR DESCRIPTION
## What & why

I audited the current oxlint setup against the [oxlint plugin/category docs](https://oxc.rs/docs/guide/usage/linter/plugins.html) for genuinely useful, low-noise additions. The repo enabled `import, react, jsx-a11y, typescript, unicorn, oxc` on the `correctness` category. Two plugins clearly match the stack but were off:

- **`vitest`** — only test runner in the repo, plugin not enabled.
- **`promise`** — zero-cost guard for async/worker code (0 current violations).

I deliberately left the broader categories alone after measuring them: `perf` adds ~80 code-changing findings (candidate for a separate pass), and `suspicious`/`pedantic` are dominated by noise (`react-in-jsx-scope` false-positives under the React 19 automatic runtime, `max-lines-per-function`, etc.).

## Config changes (`.oxlintrc.json`)

- Add `vitest` + `promise` to `plugins`.
- Scope the vitest rules to test files via the existing override:
  - **off** `require-mock-type-parameters` (614 hits, pure noise) and `no-conditional-expect` (82 hits, mostly legit discriminated-union narrowing).
  - **error** `valid-expect`, `expect-expect`, `require-to-throw-message` — the high-signal rules. `expect-expect` is configured with `assertFunctionNames` so Testing Library throwing queries (`screen.getBy*`/`findBy*`) and `expect*`-prefixed helpers count as assertions.
  - `no-conditional-tests` rides along via the `correctness` category.

## Real issues these rules surfaced (all fixed)

- **`valid-expect`** — `expect(value, label).toBe(...)` calls whose second arg Vitest silently ignores (json-schema-generator), and an `expect()` with no matcher (scrypt).
- **`require-to-throw-message`** — bare `toThrow()` now assert the expected message/pattern (url-component, prettier worker, data-uri, base64, aes-encryptor).
- **`expect-expect`** — a favicon test that never located its slider (vacuously passing) now finds the maskable-margin slider by its label and asserts the keyboard interaction moves the value; a SignalEngine smoke test now asserts it does not throw.
- **`no-conditional-tests`** — the i18n-consistency test's JSON/markdown branch moved out of test generation and into the test body.

## Verification

- `pnpm lint` → 0 warnings / 0 errors (164 rules active, up from 144)
- `pnpm format:check`, `pnpm typecheck` → clean
- `pnpm test` → 583 files, 19866 tests passing

https://claude.ai/code/session_01UC36Nc7CVt2pJ89gCcNMXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UC36Nc7CVt2pJ89gCcNMXY)_