### PR TITLE
test(tools): stabilize async download link assertions

### DIFF
--- a/tools/image-to-ico/client.test.tsx
+++ b/tools/image-to-ico/client.test.tsx
@@ -110,13 +110,12 @@ describe("ImageToIcoClient", () => {
       screen.getByRole("button", { name: messages.generateLabel })
     )
 
-    await waitFor(() => {
-      expect(mockedConvertImageFileToIco).toHaveBeenCalledTimes(1)
+    const downloadLink = await screen.findByRole("link", {
+      name: messages.downloadLabel,
     })
 
-    expect(
-      screen.getByRole("link", { name: messages.downloadLabel })
-    ).toBeTruthy()
+    expect(mockedConvertImageFileToIco).toHaveBeenCalledTimes(1)
+    expect(downloadLink).toBeTruthy()
     expect(screen.getAllByText("256 × 256").length).toBeGreaterThan(0)
   })
 

--- a/tools/pdf-merger/client.test.tsx
+++ b/tools/pdf-merger/client.test.tsx
@@ -172,19 +172,16 @@ describe("PdfMergerClient", () => {
     )
     fireEvent.click(screen.getByRole("button", { name: messages.mergeLabel }))
 
-    await waitFor(() => {
-      expect(mockedMergePdfFilesWithWorker).toHaveBeenCalledTimes(1)
+    const downloadLink = await screen.findByRole("link", {
+      name: messages.downloadPdfLabel,
     })
 
+    expect(mockedMergePdfFilesWithWorker).toHaveBeenCalledTimes(1)
     expect(
       mockedMergePdfFilesWithWorker.mock.calls[0]?.[0].files[0]?.name
     ).toBe("second.pdf")
     expect(screen.getByText(messages.resultReadyTitle)).toBeTruthy()
-    expect(
-      screen
-        .getByRole("link", { name: messages.downloadPdfLabel })
-        .getAttribute("download")
-    ).toBe("combined-report.pdf")
+    expect(downloadLink.getAttribute("download")).toBe("combined-report.pdf")
   })
 
   test("adds files from drop and paste interactions", async () => {


### PR DESCRIPTION
## What changed

- wait for the PDF Merger download link before asserting the worker call, result state, and output filename
- wait for the Image-to-ICO download link before asserting conversion output
- keep the fix scoped to tests; no production component behavior changes

## Root cause

The tests waited only until their async worker/converter mocks were invoked. That can happen before the returned promise updates React state and before the `useObjectUrl` effect publishes the download URL, so the following synchronous link lookup raced with rendering. This caused the repeated failures in the full-coverage job on `main`.

Waiting for the user-visible download link covers the complete async path: operation completion, result state commit, object URL effect, and final render.

## Impact

This removes the flaky assertions blocking the `main` test job without changing either tool at runtime.

## Validation

- `pnpm exec vitest run tools/pdf-merger/client.test.tsx tools/image-to-ico/client.test.tsx` — 2 files, 13 tests passed
- `pnpm test:coverage` — 583 files, 19,866 tests passed; coverage thresholds passed
- `pnpm exec oxfmt --check tools/pdf-merger/client.test.tsx tools/image-to-ico/client.test.tsx`
- `pnpm exec oxlint tools/pdf-merger/client.test.tsx tools/image-to-ico/client.test.tsx`

Previous failing run: https://github.com/InBrowserApp/InBrowserApp/actions/runs/28309314752