### PR TITLE
feat(web): paginate tools directory

### DIFF
--- a/apps/web/src/components/pages/home-page.astro
+++ b/apps/web/src/components/pages/home-page.astro
@@ -1,10 +1,19 @@
 ---
 import { toolSearchIndex } from "@workspace/tool-registry"
+import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
+import { Badge } from "@workspace/ui/components/ui/badge"
+import { buttonVariants } from "@workspace/ui/components/ui/button"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@workspace/ui/components/ui/input-group"
+import { ArrowRight, Search } from "@workspace/ui/icons"
 import MainLayout from "@/layouts/main.astro"
-import { ToolsDirectorySearch } from "@/components/pages/tools-directory-search"
+import { localizePath, type SiteLanguage } from "@/lib/site"
 import { loadSiteMessages } from "@/lib/site-messages"
 import { createPageSeo } from "@/lib/seo"
-import type { SiteLanguage } from "@/lib/site"
 
 interface Props {
   language: SiteLanguage
@@ -12,22 +21,14 @@ interface Props {
 
 const { language } = Astro.props
 const { catalog } = loadSiteMessages(language)
+const toolsPath = localizePath("/tools", language)
+const toolCount = new Intl.NumberFormat(language).format(toolSearchIndex.length)
 const seo = createPageSeo({
   description: catalog.metadata.homeDescription,
   language,
   pathname: "/",
   title: catalog.metadata.homeTitle,
 })
-const searchMessages = {
-  clearSearchLabel: catalog.tools.clearSearchLabel,
-  emptyRegistryDescription: catalog.tools.emptyRegistryDescription,
-  emptyRegistryTitle: catalog.tools.emptyRegistryTitle,
-  emptySearchDescription: catalog.tools.emptySearchDescription,
-  emptySearchTitle: catalog.tools.emptySearchTitle,
-  resultCountSuffix: catalog.tools.resultCountSuffix,
-  searchLabel: catalog.tools.searchLabel,
-  searchPlaceholder: catalog.tools.searchPlaceholder,
-}
 ---
 
 <MainLayout
@@ -39,19 +40,79 @@ const searchMessages = {
   current="home"
   pathname="/"
 >
-  <header class="max-w-3xl space-y-3">
-    <h1 class="font-heading text-4xl leading-none tracking-[var(--tracking-display)] text-balance sm:text-5xl">
-      {catalog.home.title}
-    </h1>
-    <p class="max-w-2xl text-base leading-7 text-muted-foreground sm:text-lg">
-      {catalog.home.description}
-    </p>
-  </header>
+  <section
+    class="relative isolate overflow-hidden rounded-[calc(var(--radius)*2.5)] border border-border/70 bg-card/60 px-5 py-8 shadow-[var(--shadow-elevated)] sm:px-8 sm:py-12 lg:px-12 lg:py-16"
+  >
+    <div
+      class="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top_left,var(--color-muted),transparent_55%)] opacity-80 rtl:bg-[radial-gradient(circle_at_top_right,var(--color-muted),transparent_55%)]"
+      aria-hidden="true"
+    >
+    </div>
 
-  <ToolsDirectorySearch
-    client:load
-    entries={toolSearchIndex}
-    language={language}
-    messages={searchMessages}
-  />
+    <div class="grid items-center gap-10 lg:grid-cols-[minmax(0,1.05fr)_minmax(20rem,0.95fr)] lg:gap-14">
+      <header class="max-w-2xl space-y-5">
+        <Badge variant="outline" className="bg-background/70 tabular-nums">
+          {`${toolCount} ${catalog.tools.resultCountSuffix}`}
+        </Badge>
+        <div class="space-y-4">
+          <h1 class="font-heading text-4xl leading-none tracking-[var(--tracking-display)] text-balance sm:text-5xl lg:text-6xl">
+            {catalog.home.title}
+          </h1>
+          <p class="max-w-xl text-base leading-7 text-muted-foreground sm:text-lg">
+            {catalog.home.description}
+          </p>
+        </div>
+        <a href={toolsPath} class={buttonVariants({ size: "lg" })}>
+          {catalog.home.primaryAction}
+          <ArrowRight data-icon="inline-end" className="rtl:rotate-180" aria-hidden="true" />
+        </a>
+      </header>
+
+      <ToolSurface className="relative bg-background/85 p-5 sm:p-6">
+        <div class="mb-5 space-y-2">
+          <h2 class="font-heading text-xl tracking-tight">
+            {catalog.tools.title}
+          </h2>
+          <p class="text-sm leading-6 text-muted-foreground">
+            {catalog.tools.description}
+          </p>
+        </div>
+
+        <form action={toolsPath} method="get" role="search">
+          <label class="sr-only" for="home-tool-search">
+            {catalog.tools.searchLabel}
+          </label>
+          <InputGroup className="h-12 bg-background">
+            <InputGroupAddon align="inline-start">
+              <Search aria-hidden="true" />
+            </InputGroupAddon>
+            <InputGroupInput
+              id="home-tool-search"
+              name="query"
+              type="search"
+              autoComplete="off"
+              enterKeyHint="search"
+              placeholder={catalog.tools.searchPlaceholder}
+              spellCheck={false}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                className="h-9 px-3"
+                size="sm"
+                type="submit"
+                variant="default"
+              >
+                {catalog.tools.searchLabel}
+                <ArrowRight
+                  data-icon="inline-end"
+                  className="hidden sm:block rtl:rotate-180"
+                  aria-hidden="true"
+                />
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        </form>
+      </ToolSurface>
+    </div>
+  </section>
 </MainLayout>

--- a/apps/web/src/components/pages/tool-directory-card.tsx
+++ b/apps/web/src/components/pages/tool-directory-card.tsx
@@ -1,0 +1,37 @@
+import { ToolIcon } from "@workspace/ui/components/tool/tool-icon"
+import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
+
+import type { ToolDirectoryEntry } from "@/lib/tools-directory"
+
+type ToolDirectoryCardProps = Readonly<{
+  entry: ToolDirectoryEntry
+  href: string
+}>
+
+function ToolDirectoryCard({ entry, href }: ToolDirectoryCardProps) {
+  return (
+    <a
+      data-tool-card={entry.slug}
+      href={href}
+      className="group block h-full rounded-[calc(var(--radius)*1.8)] outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
+    >
+      <ToolSurface className="flex h-full flex-col gap-3 transition-[border-color,box-shadow] group-hover:border-foreground/20 group-focus-visible:border-foreground/30 motion-reduce:transition-none">
+        <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+          <h2 className="flex min-w-0 items-center gap-2 font-heading text-lg leading-tight tracking-[var(--tracking-display)]">
+            <ToolIcon
+              aria-hidden="true"
+              icon={entry.icon}
+              className="size-4 shrink-0 text-muted-foreground"
+            />
+            <span className="min-w-0 truncate">{entry.name}</span>
+          </h2>
+          <p className="line-clamp-2 text-sm leading-relaxed text-pretty text-muted-foreground">
+            {entry.description}
+          </p>
+        </div>
+      </ToolSurface>
+    </a>
+  )
+}
+
+export { ToolDirectoryCard }

--- a/apps/web/src/components/pages/tools-directory-pagination.tsx
+++ b/apps/web/src/components/pages/tools-directory-pagination.tsx
@@ -1,0 +1,125 @@
+import type { MouseEvent } from "react"
+
+import {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+} from "@workspace/ui/components/ui/pagination"
+import { ChevronLeft, ChevronRight } from "@workspace/ui/icons"
+import {
+  getLocalizedToolsPagePath,
+  getPaginationItems,
+} from "@/lib/tools-directory"
+
+import type { SiteLanguage } from "@/lib/site"
+
+type ToolsDirectoryPaginationProps = Readonly<{
+  basePath: string
+  browsePageNumber: number
+  currentPage: number
+  label: string
+  language: SiteLanguage
+  onSearchPageChange: (
+    event: MouseEvent<HTMLAnchorElement>,
+    pageNumber: number
+  ) => void
+  pageCount: number
+  query: string
+}>
+
+function getSearchPageHref(
+  browsePath: string,
+  query: string,
+  pageNumber: number
+) {
+  const params = new URLSearchParams({ query })
+
+  if (pageNumber > 1) {
+    params.set("page", String(pageNumber))
+  }
+
+  return `${browsePath}?${params.toString()}`
+}
+
+function ToolsDirectoryPagination({
+  basePath,
+  browsePageNumber,
+  currentPage,
+  label,
+  language,
+  onSearchPageChange,
+  pageCount,
+  query,
+}: ToolsDirectoryPaginationProps) {
+  const numberFormatter = new Intl.NumberFormat(language)
+  const browsePath = getLocalizedToolsPagePath(basePath, browsePageNumber)
+  const getHref = (pageNumber: number) =>
+    query
+      ? getSearchPageHref(browsePath, query, pageNumber)
+      : getLocalizedToolsPagePath(basePath, pageNumber)
+  const getLabel = (pageNumber: number) =>
+    `${label} ${numberFormatter.format(pageNumber)}`
+  const handleClick = (
+    event: MouseEvent<HTMLAnchorElement>,
+    pageNumber: number
+  ) => {
+    if (query) {
+      onSearchPageChange(event, pageNumber)
+    }
+  }
+
+  return (
+    <Pagination aria-label={label}>
+      <PaginationContent>
+        {currentPage > 1 ? (
+          <PaginationItem>
+            <PaginationLink
+              aria-label={getLabel(currentPage - 1)}
+              href={getHref(currentPage - 1)}
+              rel="prev"
+              onClick={(event) => handleClick(event, currentPage - 1)}
+            >
+              <ChevronLeft aria-hidden="true" className="rtl:rotate-180" />
+            </PaginationLink>
+          </PaginationItem>
+        ) : null}
+
+        {getPaginationItems(currentPage, pageCount).map((item, index) =>
+          item === null ? (
+            <PaginationItem key={`ellipsis-${index}`}>
+              <PaginationEllipsis />
+            </PaginationItem>
+          ) : (
+            <PaginationItem key={item}>
+              <PaginationLink
+                aria-label={getLabel(item)}
+                href={getHref(item)}
+                isActive={item === currentPage}
+                onClick={(event) => handleClick(event, item)}
+              >
+                {numberFormatter.format(item)}
+              </PaginationLink>
+            </PaginationItem>
+          )
+        )}
+
+        {currentPage < pageCount ? (
+          <PaginationItem>
+            <PaginationLink
+              aria-label={getLabel(currentPage + 1)}
+              href={getHref(currentPage + 1)}
+              rel="next"
+              onClick={(event) => handleClick(event, currentPage + 1)}
+            >
+              <ChevronRight aria-hidden="true" className="rtl:rotate-180" />
+            </PaginationLink>
+          </PaginationItem>
+        ) : null}
+      </PaginationContent>
+    </Pagination>
+  )
+}
+
+export { ToolsDirectoryPagination }

--- a/apps/web/src/components/pages/tools-directory-results.tsx
+++ b/apps/web/src/components/pages/tools-directory-results.tsx
@@ -1,0 +1,125 @@
+import type { MouseEvent, RefObject } from "react"
+
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@workspace/ui/components/ui/empty"
+import { LayoutGrid, Search } from "@workspace/ui/icons"
+import { ToolDirectoryCard } from "@/components/pages/tool-directory-card"
+import { ToolsDirectoryPagination } from "@/components/pages/tools-directory-pagination"
+import { localizePath } from "@/lib/site"
+
+import type { SiteLanguage } from "@/lib/site"
+import type { ToolDirectoryPage } from "@/lib/tools-directory"
+
+type ToolsDirectoryResultsProps = Readonly<{
+  basePath: string
+  browsePageNumber: number
+  busy: boolean
+  emptyRegistryDescription: string
+  emptyRegistryTitle: string
+  emptySearchDescription: string
+  emptySearchTitle: string
+  language: SiteLanguage
+  onSearchPageChange: (
+    event: MouseEvent<HTMLAnchorElement>,
+    pageNumber: number
+  ) => void
+  page: ToolDirectoryPage
+  query: string
+  resultCount: string
+  resultsStatusRef: RefObject<HTMLParagraphElement | null>
+  toolsTitle: string
+}>
+
+function ToolsDirectoryResults({
+  basePath,
+  browsePageNumber,
+  busy,
+  emptyRegistryDescription,
+  emptyRegistryTitle,
+  emptySearchDescription,
+  emptySearchTitle,
+  language,
+  onSearchPageChange,
+  page,
+  query,
+  resultCount,
+  resultsStatusRef,
+  toolsTitle,
+}: ToolsDirectoryResultsProps) {
+  const isRegistryEmpty = !query && page.total === 0
+  const isSearchEmpty = Boolean(query) && page.total === 0
+
+  return (
+    <div
+      id="tool-directory-results"
+      className="flex flex-col gap-6"
+      aria-busy={busy}
+    >
+      {!isRegistryEmpty && !isSearchEmpty ? (
+        <p
+          ref={resultsStatusRef}
+          role="status"
+          tabIndex={-1}
+          className="scroll-mt-6 text-sm text-muted-foreground tabular-nums outline-none"
+          aria-atomic="true"
+          aria-live="polite"
+        >
+          {resultCount}
+        </p>
+      ) : null}
+
+      {isRegistryEmpty || isSearchEmpty ? (
+        <Empty className="border bg-muted/30 py-12">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              {isRegistryEmpty ? (
+                <LayoutGrid aria-hidden="true" />
+              ) : (
+                <Search aria-hidden="true" />
+              )}
+            </EmptyMedia>
+            <EmptyTitle>
+              {isRegistryEmpty ? emptyRegistryTitle : emptySearchTitle}
+            </EmptyTitle>
+            <EmptyDescription>
+              {isRegistryEmpty
+                ? emptyRegistryDescription
+                : emptySearchDescription}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {page.entries.map((entry) => (
+            <li key={entry.slug} className="min-w-0">
+              <ToolDirectoryCard
+                entry={entry}
+                href={localizePath(`/tools/${entry.slug}`, language)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!isRegistryEmpty && !isSearchEmpty && page.pageCount > 1 ? (
+        <ToolsDirectoryPagination
+          basePath={basePath}
+          browsePageNumber={browsePageNumber}
+          currentPage={page.pageNumber}
+          label={toolsTitle}
+          language={language}
+          pageCount={page.pageCount}
+          query={query}
+          onSearchPageChange={onSearchPageChange}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+export { ToolsDirectoryResults }

--- a/apps/web/src/components/pages/tools-directory-search-utils.test.ts
+++ b/apps/web/src/components/pages/tools-directory-search-utils.test.ts
@@ -1,0 +1,98 @@
+import type { MouseEvent } from "react"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import type { ToolDirectoryEntry } from "@/lib/tools-directory"
+
+import {
+  isPlainLeftClick,
+  normalizeQuery,
+  rankEntries,
+  readLocationState,
+} from "./tools-directory-search-utils"
+
+const ENTRIES = [
+  {
+    description: "Exact description",
+    icon: "one",
+    name: "Needle",
+    slug: "exact",
+  },
+  {
+    description: "Starts description",
+    icon: "two",
+    name: "Needlework",
+    slug: "starts",
+  },
+  {
+    description: "Contains description",
+    icon: "three",
+    name: "A Needle Tool",
+    slug: "contains",
+  },
+  {
+    description: "Find a needle here",
+    icon: "four",
+    name: "Description match",
+    slug: "description",
+  },
+] as const satisfies readonly ToolDirectoryEntry[]
+
+describe("tools directory search helpers", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/tools/")
+  })
+
+  it("normalizes surrounding and repeated whitespace", () => {
+    expect(normalizeQuery("  needle\n\t tool  ")).toBe("needle tool")
+  })
+
+  it("ranks exact, prefix, name, and description matches in that order", () => {
+    expect(
+      rankEntries(ENTRIES, "needle", "en").map(({ slug }) => slug)
+    ).toEqual(["exact", "starts", "contains", "description"])
+  })
+
+  it("requires every query token and preserves the input for no query", () => {
+    expect(rankEntries(ENTRIES, "needle exact", "en")).toEqual([ENTRIES[0]])
+    expect(rankEntries(ENTRIES, "missing token", "en")).toEqual([])
+    expect(rankEntries(ENTRIES, "", "en")).toBe(ENTRIES)
+  })
+
+  it("reads a normalized query and valid search result page from the URL", () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/tools/page/2/?query=%20needle%20%20tool%20&page=3"
+    )
+
+    expect(readLocationState(2)).toEqual({
+      pageNumber: 3,
+      query: "needle tool",
+    })
+  })
+
+  it("uses page one for an invalid search page and the fallback otherwise", () => {
+    window.history.replaceState(null, "", "/tools/?query=needle&page=-2")
+    expect(readLocationState(4)).toEqual({
+      pageNumber: 1,
+      query: "needle",
+    })
+
+    window.history.replaceState(null, "", "/tools/page/4/?page=9")
+    expect(readLocationState(4)).toEqual({ pageNumber: 4, query: "" })
+  })
+
+  it("only intercepts unmodified primary-button clicks", () => {
+    const event = {
+      altKey: false,
+      button: 0,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+    } as MouseEvent<HTMLAnchorElement>
+
+    expect(isPlainLeftClick(event)).toBe(true)
+    expect(isPlainLeftClick({ ...event, button: 1 })).toBe(false)
+    expect(isPlainLeftClick({ ...event, metaKey: true })).toBe(false)
+  })
+})

--- a/apps/web/src/components/pages/tools-directory-search-utils.ts
+++ b/apps/web/src/components/pages/tools-directory-search-utils.ts
@@ -1,0 +1,78 @@
+import type { MouseEvent } from "react"
+import type { SiteLanguage } from "@/lib/site"
+import type { ToolDirectoryEntry } from "@/lib/tools-directory"
+
+function normalizeQuery(query: string) {
+  return query.trim().replace(/\s+/g, " ")
+}
+
+function readLocationState(fallbackPage: number) {
+  if (typeof window === "undefined") {
+    return { pageNumber: fallbackPage, query: "" }
+  }
+
+  const url = new URL(window.location.href)
+  const query = normalizeQuery(url.searchParams.get("query") ?? "")
+  const requestedPage = Number(url.searchParams.get("page"))
+
+  return {
+    pageNumber:
+      query && Number.isInteger(requestedPage) && requestedPage > 1
+        ? requestedPage
+        : query
+          ? 1
+          : fallbackPage,
+    query,
+  }
+}
+
+function rankEntries(
+  entries: readonly ToolDirectoryEntry[],
+  query: string,
+  language: SiteLanguage
+) {
+  if (!query) {
+    return entries
+  }
+
+  const normalizedQuery = query.toLocaleLowerCase(language)
+  const tokens = normalizedQuery.split(" ")
+
+  return entries
+    .map((entry) => {
+      const name = entry.name.toLocaleLowerCase(language)
+      const description = entry.description.toLocaleLowerCase(language)
+      const searchableText = `${name} ${description}`
+
+      if (!tokens.every((token) => searchableText.includes(token))) {
+        return { entry, score: -1 }
+      }
+
+      const score =
+        (name === normalizedQuery ? 120 : 0) +
+        (name.startsWith(normalizedQuery) ? 60 : 0) +
+        (name.includes(normalizedQuery) ? 30 : 0) +
+        (description.includes(normalizedQuery) ? 15 : 0)
+
+      return { entry, score }
+    })
+    .filter(({ score }) => score >= 0)
+    .sort(
+      (left, right) =>
+        right.score - left.score ||
+        left.entry.name.localeCompare(right.entry.name, language)
+    )
+    .map(({ entry }) => entry)
+}
+
+function isPlainLeftClick(event: MouseEvent<HTMLAnchorElement>) {
+  return (
+    event.button === 0 &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.metaKey &&
+    !event.shiftKey
+  )
+}
+
+export { isPlainLeftClick, normalizeQuery, rankEntries, readLocationState }

--- a/apps/web/src/components/pages/tools-directory-search.test.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.test.tsx
@@ -1,0 +1,114 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import type { ToolDirectoryEntry } from "@/lib/tools-directory"
+
+import { ToolsDirectorySearch } from "./tools-directory-search"
+
+const MESSAGES = {
+  clearSearchLabel: "Clear search",
+  emptyRegistryDescription: "No tools are registered.",
+  emptyRegistryTitle: "No tools",
+  emptySearchDescription: "Try another search.",
+  emptySearchTitle: "No matches",
+  resultCountSuffix: "tools",
+  searchLabel: "Search tools",
+  searchPlaceholder: "Search all tools",
+  toolsTitle: "Tools",
+} as const
+
+const ENTRIES = Array.from({ length: 30 }, (_, index) => {
+  const number = index + 1
+
+  return {
+    description:
+      number === 25
+        ? "The only off-page needle tool"
+        : `Tool description ${number}`,
+    icon: "wrench",
+    name: number === 25 ? "Off-page Needle" : `Tool ${number}`,
+    slug: `tool-${number}`,
+  }
+}) satisfies readonly ToolDirectoryEntry[]
+
+function getRenderedSlugs() {
+  return [...document.querySelectorAll<HTMLElement>("[data-tool-card]")].map(
+    (card) => card.dataset.toolCard
+  )
+}
+
+describe("ToolsDirectorySearch", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "/tools/")
+  })
+
+  afterEach(cleanup)
+
+  it("searches the full index and clears back to the original browse page", async () => {
+    render(
+      <ToolsDirectorySearch
+        basePath="/tools/"
+        entries={ENTRIES}
+        language="en"
+        messages={MESSAGES}
+        pageNumber={1}
+      />
+    )
+
+    await waitFor(() => expect(getRenderedSlugs()).toHaveLength(24))
+    expect(getRenderedSlugs()).not.toContain("tool-25")
+
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search tools" }), {
+      target: { value: "Off-page Needle" },
+    })
+
+    await waitFor(() => expect(getRenderedSlugs()).toEqual(["tool-25"]))
+    expect(window.location.search).toBe("?query=Off-page+Needle")
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }))
+
+    await waitFor(() => expect(getRenderedSlugs()).toHaveLength(24))
+    expect(getRenderedSlugs()).not.toContain("tool-25")
+    expect(window.location.pathname).toBe("/tools/")
+    expect(window.location.search).toBe("")
+  })
+
+  it("keeps the page-two pathname while paging through search results", async () => {
+    window.history.replaceState(null, "", "/tools/page/2/")
+
+    render(
+      <ToolsDirectorySearch
+        basePath="/tools/"
+        entries={ENTRIES}
+        language="en"
+        messages={MESSAGES}
+        pageNumber={2}
+      />
+    )
+
+    await waitFor(() => expect(getRenderedSlugs()).toHaveLength(6))
+    fireEvent.change(screen.getByRole("searchbox", { name: "Search tools" }), {
+      target: { value: "Tool" },
+    })
+
+    const pageTwoLink = await waitFor(() => {
+      const link = document.querySelector<HTMLAnchorElement>(
+        'a[href="/tools/page/2/?query=Tool&page=2"]'
+      )
+      expect(link).toBeTruthy()
+      return link as HTMLAnchorElement
+    })
+
+    fireEvent.click(pageTwoLink)
+
+    await waitFor(() => expect(getRenderedSlugs()).toHaveLength(6))
+    expect(window.location.pathname).toBe("/tools/page/2/")
+    expect(window.location.search).toBe("?query=Tool&page=2")
+  })
+})

--- a/apps/web/src/components/pages/tools-directory-search.tsx
+++ b/apps/web/src/components/pages/tools-directory-search.tsx
@@ -2,19 +2,39 @@ import {
   useDeferredValue,
   useEffect,
   useEffectEvent,
+  useMemo,
   useRef,
   useState,
 } from "react"
 
-import { Button } from "@workspace/ui/components/ui/button"
-import { Input } from "@workspace/ui/components/ui/input"
-import { ToolIcon } from "@workspace/ui/components/tool/tool-icon"
-import { ToolSurface } from "@workspace/ui/components/tool/tool-surface"
-import { LayoutGrid, Search } from "@workspace/ui/icons"
-import { localizePath } from "@/lib/site"
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+} from "@workspace/ui/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@workspace/ui/components/ui/input-group"
+import { Search, X } from "@workspace/ui/icons"
+import { ToolsDirectoryResults } from "@/components/pages/tools-directory-results"
+import {
+  isPlainLeftClick,
+  normalizeQuery,
+  rankEntries,
+  readLocationState,
+} from "@/components/pages/tools-directory-search-utils"
+import {
+  TOOLS_PER_PAGE,
+  getLocalizedToolsPagePath,
+  paginateToolEntries,
+} from "@/lib/tools-directory"
 
-import type { ToolSearchIndexEntry } from "@workspace/tool-registry"
+import type { MouseEvent } from "react"
 import type { SiteLanguage } from "@/lib/site"
+import type { ToolDirectoryEntry } from "@/lib/tools-directory"
 
 type ToolsDirectorySearchMessages = Readonly<{
   searchLabel: string
@@ -25,112 +45,69 @@ type ToolsDirectorySearchMessages = Readonly<{
   emptyRegistryDescription: string
   emptySearchTitle: string
   emptySearchDescription: string
+  toolsTitle: string
 }>
 
 type ToolsDirectorySearchProps = Readonly<{
-  entries: readonly ToolSearchIndexEntry[]
+  basePath: string
+  entries: readonly ToolDirectoryEntry[]
   language: SiteLanguage
   messages: ToolsDirectorySearchMessages
+  pageNumber: number
 }>
 
-function normalizeQuery(query: string) {
-  return query.trim().replace(/\s+/g, " ")
-}
-
-function readQueryFromLocation() {
-  if (typeof window === "undefined") {
-    return ""
-  }
-
-  return normalizeQuery(
-    new URL(window.location.href).searchParams.get("query") ?? ""
-  )
-}
-
-function resolveLocale(entry: ToolSearchIndexEntry, language: SiteLanguage) {
-  return (
-    entry.locales[language] ??
-    entry.locales.en ??
-    Object.values(entry.locales)[0] ?? {
-      description: "",
-      name: entry.slug,
-    }
-  )
-}
-
-function getSearchScore(
-  entry: ToolSearchIndexEntry,
-  query: string,
-  language: SiteLanguage
-) {
-  const normalizedQuery = normalizeQuery(query).toLowerCase()
-
-  if (!normalizedQuery) {
-    return 0
-  }
-
-  const locale = resolveLocale(entry, language)
-  const tokens = normalizedQuery.split(" ")
-  const searchableText = [locale.name, locale.description]
-    .join(" ")
-    .toLowerCase()
-
-  if (!tokens.every((token) => searchableText.includes(token))) {
-    return -1
-  }
-
-  let score = 0
-  const normalizedName = locale.name.toLowerCase()
-  const normalizedDescription = locale.description.toLowerCase()
-
-  if (normalizedName === normalizedQuery) {
-    score += 120
-  }
-
-  if (normalizedName.startsWith(normalizedQuery)) {
-    score += 60
-  }
-
-  if (normalizedName.includes(normalizedQuery)) {
-    score += 30
-  }
-
-  if (normalizedDescription.includes(normalizedQuery)) {
-    score += 15
-  }
-  return score
-}
-
 function ToolsDirectorySearch({
+  basePath,
   entries,
   language,
   messages,
+  pageNumber,
 }: ToolsDirectorySearchProps) {
   const [query, setQuery] = useState("")
+  const [currentPage, setCurrentPage] = useState(pageNumber)
+  const [locationReady, setLocationReady] = useState(false)
   const deferredQuery = useDeferredValue(query)
   const inputRef = useRef<HTMLInputElement>(null)
+  const resultsStatusRef = useRef<HTMLParagraphElement>(null)
   const composingRef = useRef(false)
-  const syncQueryToUrl = useEffectEvent((nextQuery: string) => {
-    if (typeof window === "undefined") {
-      return
+  const focusResultsRef = useRef(false)
+  const normalizedQuery = normalizeQuery(deferredQuery)
+  const rankedEntries = useMemo(
+    () => rankEntries(entries, normalizedQuery, language),
+    [entries, language, normalizedQuery]
+  )
+  const pageCount = Math.max(
+    1,
+    Math.ceil(rankedEntries.length / TOOLS_PER_PAGE)
+  )
+  const safePage = Math.min(currentPage, pageCount)
+  const page = paginateToolEntries(rankedEntries, safePage)
+  const numberFormatter = useMemo(
+    () => new Intl.NumberFormat(language),
+    [language]
+  )
+  const syncStateToUrl = useEffectEvent(
+    (nextQuery: string, nextPage: number) => {
+      const url = new URL(window.location.href)
+
+      if (nextQuery) {
+        url.pathname = getLocalizedToolsPagePath(basePath, pageNumber)
+        url.searchParams.set("query", nextQuery)
+        if (nextPage > 1) {
+          url.searchParams.set("page", String(nextPage))
+        } else {
+          url.searchParams.delete("page")
+        }
+      } else {
+        url.pathname = getLocalizedToolsPagePath(basePath, nextPage)
+        url.searchParams.delete("query")
+        url.searchParams.delete("page")
+      }
+
+      window.history.replaceState(window.history.state, "", url)
     }
+  )
 
-    const url = new URL(window.location.href)
-
-    if (nextQuery) {
-      url.searchParams.set("query", nextQuery)
-    } else {
-      url.searchParams.delete("query")
-    }
-
-    window.history.replaceState(window.history.state, "", url)
-  })
-
-  /**
-   * Keep the uncontrolled input in sync with React state for
-   * programmatic updates (clear button, popstate, etc.) but only
-   * when the user is NOT mid-IME-composition.
-   */
   useEffect(() => {
     if (inputRef.current && !composingRef.current) {
       inputRef.current.value = query
@@ -139,145 +116,125 @@ function ToolsDirectorySearch({
 
   useEffect(() => {
     const syncFromLocation = () => {
-      const nextQuery = readQueryFromLocation()
-
-      setQuery((currentQuery) =>
-        currentQuery === nextQuery ? currentQuery : nextQuery
-      )
+      const state = readLocationState(pageNumber)
+      setQuery(state.query)
+      setCurrentPage(state.query ? state.pageNumber : pageNumber)
+      setLocationReady(true)
     }
 
     syncFromLocation()
     window.addEventListener("popstate", syncFromLocation)
-
-    return () => {
-      window.removeEventListener("popstate", syncFromLocation)
-    }
-  }, [])
+    return () => window.removeEventListener("popstate", syncFromLocation)
+  }, [pageNumber])
 
   useEffect(() => {
-    syncQueryToUrl(normalizeQuery(deferredQuery))
-  }, [deferredQuery])
+    if (locationReady && query === deferredQuery) {
+      syncStateToUrl(normalizedQuery, safePage)
+    }
+  }, [deferredQuery, locationReady, normalizedQuery, query, safePage])
 
-  const normalizedQuery = normalizeQuery(deferredQuery)
-  const rankedEntries = entries
-    .map((entry) => ({
-      entry,
-      score: getSearchScore(entry, normalizedQuery, language),
-    }))
-    .filter(({ score }) => normalizedQuery === "" || score >= 0)
-    .sort((left, right) => {
-      if (normalizedQuery === "") {
-        return resolveLocale(left.entry, language).name.localeCompare(
-          resolveLocale(right.entry, language).name,
-          language
-        )
-      }
+  useEffect(() => {
+    if (focusResultsRef.current) {
+      focusResultsRef.current = false
+      resultsStatusRef.current?.focus({ preventScroll: true })
+      resultsStatusRef.current?.scrollIntoView({ block: "start" })
+    }
+  }, [safePage])
 
-      return right.score - left.score
-    })
-  const resultCount = new Intl.NumberFormat(language).format(
-    rankedEntries.length
-  )
-  const isRegistryEmpty = entries.length === 0
-  const isSearchEmpty = !isRegistryEmpty && rankedEntries.length === 0
+  const setSearchQuery = (nextQuery: string) => {
+    setQuery(nextQuery)
+    setCurrentPage(normalizeQuery(nextQuery) ? 1 : pageNumber)
+  }
+  const handleSearchPageChange = (
+    event: MouseEvent<HTMLAnchorElement>,
+    nextPage: number
+  ) => {
+    if (!isPlainLeftClick(event)) {
+      return
+    }
 
+    event.preventDefault()
+    const url = new URL(event.currentTarget.href)
+    window.history.pushState(window.history.state, "", url)
+    focusResultsRef.current = true
+    setCurrentPage(nextPage)
+  }
+  const resultRange = page.total
+    ? `${numberFormatter.format(page.start)}–${numberFormatter.format(page.end)} / `
+    : ""
+  const resultCount = `${resultRange}${numberFormatter.format(page.total)} ${messages.resultCountSuffix}`
   return (
-    <div
-      className="space-y-6"
-      aria-busy={query !== deferredQuery}
-      aria-live="polite"
-    >
-      <div className="flex items-center gap-3">
-        <div className="relative flex-1">
-          <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            ref={inputRef}
-            aria-label={messages.searchLabel}
-            className="h-11 pl-10 text-base md:text-sm"
-            placeholder={messages.searchPlaceholder}
-            defaultValue={query}
-            onCompositionStart={() => {
-              composingRef.current = true
-            }}
-            onCompositionEnd={(event) => {
-              composingRef.current = false
-              setQuery(event.currentTarget.value)
-            }}
-            onChange={(event) => {
-              if (composingRef.current) {
-                return
-              }
-
-              setQuery(event.currentTarget.value)
-            }}
-          />
-        </div>
-
-        {query ? (
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => {
-              setQuery("")
-            }}
-          >
-            {messages.clearSearchLabel}
-          </Button>
-        ) : null}
+    <div className="flex flex-col gap-6">
+      <div role="search">
+        <FieldGroup>
+          <Field>
+            <FieldLabel className="sr-only" htmlFor="tool-directory-search">
+              {messages.searchLabel}
+            </FieldLabel>
+            <InputGroup className="h-11">
+              <InputGroupInput
+                ref={inputRef}
+                id="tool-directory-search"
+                name="query"
+                type="search"
+                autoComplete="off"
+                enterKeyHint="search"
+                spellCheck={false}
+                aria-controls="tool-directory-results"
+                className="text-base md:text-sm"
+                defaultValue={query}
+                placeholder={messages.searchPlaceholder}
+                onCompositionStart={() => {
+                  composingRef.current = true
+                }}
+                onCompositionEnd={(event) => {
+                  composingRef.current = false
+                  setSearchQuery(event.currentTarget.value)
+                }}
+                onChange={(event) => {
+                  if (!composingRef.current) {
+                    setSearchQuery(event.currentTarget.value)
+                  }
+                }}
+              />
+              <InputGroupAddon align="inline-start">
+                <Search aria-hidden="true" />
+              </InputGroupAddon>
+              {query ? (
+                <InputGroupAddon align="inline-end">
+                  <InputGroupButton
+                    aria-label={messages.clearSearchLabel}
+                    size="icon-sm"
+                    onClick={() => {
+                      setSearchQuery("")
+                      inputRef.current?.focus()
+                    }}
+                  >
+                    <X aria-hidden="true" />
+                  </InputGroupButton>
+                </InputGroupAddon>
+              ) : null}
+            </InputGroup>
+          </Field>
+        </FieldGroup>
       </div>
 
-      {!isRegistryEmpty && !isSearchEmpty ? (
-        <p className="text-sm text-muted-foreground">
-          {resultCount} {messages.resultCountSuffix}
-        </p>
-      ) : null}
-
-      {isRegistryEmpty ? (
-        <div className="rounded-xl border border-dashed border-border/80 bg-muted/30 px-6 py-12 text-center">
-          <LayoutGrid className="mx-auto size-6 text-muted-foreground" />
-          <h3 className="mt-3 font-medium">{messages.emptyRegistryTitle}</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {messages.emptyRegistryDescription}
-          </p>
-        </div>
-      ) : isSearchEmpty ? (
-        <div className="rounded-xl border border-dashed border-border/80 bg-muted/30 px-6 py-12 text-center">
-          <Search className="mx-auto size-6 text-muted-foreground" />
-          <h3 className="mt-3 font-medium">{messages.emptySearchTitle}</h3>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {messages.emptySearchDescription}
-          </p>
-        </div>
-      ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {rankedEntries.map(({ entry }) => {
-            const locale = resolveLocale(entry, language)
-
-            return (
-              <a
-                key={entry.slug}
-                href={localizePath(`/tools/${entry.slug}`, language)}
-                className="group block"
-              >
-                <ToolSurface className="flex h-full flex-col gap-3 transition-colors group-hover:border-foreground/20">
-                  <div className="flex flex-1 flex-col gap-1.5">
-                    <h3 className="flex items-center gap-2 font-heading text-lg leading-tight tracking-[var(--tracking-display)]">
-                      <ToolIcon
-                        icon={entry.icon}
-                        className="size-4 shrink-0 text-muted-foreground"
-                      />
-                      <span className="min-w-0 truncate">{locale.name}</span>
-                    </h3>
-                    <p className="line-clamp-2 text-sm leading-relaxed text-muted-foreground">
-                      {locale.description}
-                    </p>
-                  </div>
-                </ToolSurface>
-              </a>
-            )
-          })}
-        </div>
-      )}
+      <ToolsDirectoryResults
+        basePath={basePath}
+        browsePageNumber={pageNumber}
+        busy={query !== deferredQuery}
+        emptyRegistryDescription={messages.emptyRegistryDescription}
+        emptyRegistryTitle={messages.emptyRegistryTitle}
+        emptySearchDescription={messages.emptySearchDescription}
+        emptySearchTitle={messages.emptySearchTitle}
+        language={language}
+        page={page}
+        query={normalizedQuery}
+        resultCount={resultCount}
+        resultsStatusRef={resultsStatusRef}
+        toolsTitle={messages.toolsTitle}
+        onSearchPageChange={handleSearchPageChange}
+      />
     </div>
   )
 }

--- a/apps/web/src/components/pages/tools-index-page.astro
+++ b/apps/web/src/components/pages/tools-index-page.astro
@@ -4,19 +4,38 @@ import MainLayout from "@/layouts/main.astro"
 import { ToolsDirectorySearch } from "@/components/pages/tools-directory-search"
 import { loadSiteMessages } from "@/lib/site-messages"
 import { createPageSeo } from "@/lib/seo"
+import { localizePath } from "@/lib/site"
+import {
+  createLocalizedToolEntries,
+  getToolsPagePath,
+  paginateToolEntries,
+} from "@/lib/tools-directory"
+
 import type { SiteLanguage } from "@/lib/site"
 
 interface Props {
   language: SiteLanguage
+  pageNumber?: number
 }
 
-const { language } = Astro.props
+const { language, pageNumber = 1 } = Astro.props
 const { catalog } = loadSiteMessages(language)
+const entries = createLocalizedToolEntries(toolSearchIndex, language)
+const page = paginateToolEntries(entries, pageNumber)
+const pathname = getToolsPagePath(pageNumber)
+const formattedPageNumber = new Intl.NumberFormat(language).format(pageNumber)
+const formattedPageCount = new Intl.NumberFormat(language).format(
+  page.pageCount
+)
+const pageTitle =
+  pageNumber === 1
+    ? catalog.metadata.toolsTitle
+    : `${catalog.metadata.toolsTitle} · ${formattedPageNumber}/${formattedPageCount}`
 const seo = createPageSeo({
   description: catalog.metadata.toolsDescription,
   language,
-  pathname: "/tools",
-  title: catalog.metadata.toolsTitle,
+  pathname,
+  title: pageTitle,
 })
 const searchMessages = {
   clearSearchLabel: catalog.tools.clearSearchLabel,
@@ -27,6 +46,7 @@ const searchMessages = {
   resultCountSuffix: catalog.tools.resultCountSuffix,
   searchLabel: catalog.tools.searchLabel,
   searchPlaceholder: catalog.tools.searchPlaceholder,
+  toolsTitle: catalog.tools.title,
 }
 ---
 
@@ -37,7 +57,7 @@ const searchMessages = {
   lang={language}
   title={seo.title}
   current="tools"
-  pathname="/tools"
+  pathname={pathname}
 >
   <header class="max-w-3xl space-y-3">
     <h1 class="font-heading text-4xl leading-none tracking-[var(--tracking-display)] text-balance sm:text-5xl">
@@ -50,8 +70,10 @@ const searchMessages = {
 
   <ToolsDirectorySearch
     client:load
-    entries={toolSearchIndex}
+    basePath={localizePath("/tools", language)}
+    entries={entries}
     language={language}
     messages={searchMessages}
+    pageNumber={pageNumber}
   />
 </MainLayout>

--- a/apps/web/src/components/site-navbar.astro
+++ b/apps/web/src/components/site-navbar.astro
@@ -31,15 +31,17 @@ const navItems = [
   <div class="flex items-center gap-4">
     <a
       href={localizePath("/", language)}
-      class="text-sm font-semibold text-foreground"
+      aria-current={current === "home" ? "page" : undefined}
+      class="rounded-sm text-sm font-semibold text-foreground outline-none focus-visible:ring-3 focus-visible:ring-ring/50"
     >
       {catalog.site.name}
     </a>
     {navItems.map((item) => (
       <a
         href={item.href}
+        aria-current={item.id === current ? "page" : undefined}
         class:list={[
-          "text-sm transition-colors hover:text-foreground",
+          "rounded-sm text-sm transition-colors outline-none hover:text-foreground focus-visible:ring-3 focus-visible:ring-ring/50",
           item.id === current ? "text-foreground" : "text-muted-foreground",
         ]}
       >

--- a/apps/web/src/layouts/main.astro
+++ b/apps/web/src/layouts/main.astro
@@ -106,7 +106,9 @@ const languageOptions = createLanguageOptions(
           pathname={pathname}
           availableLanguages={availableLanguages}
         />
-        <slot />
+        <main id="main-content" class="flex min-w-0 flex-col gap-8">
+          <slot />
+        </main>
       </div>
     </div>
     <LanguageSuggestion

--- a/apps/web/src/lib/static-paths.test.ts
+++ b/apps/web/src/lib/static-paths.test.ts
@@ -1,0 +1,51 @@
+import { toolSearchIndex } from "@workspace/tool-registry"
+import { describe, expect, it } from "vitest"
+
+import { SUPPORTED_SITE_LANGUAGES } from "./site"
+import {
+  getDefaultToolsDirectoryStaticPaths,
+  getNonDefaultToolsDirectoryStaticPaths,
+} from "./static-paths"
+import { getPageCount } from "./tools-directory"
+
+function getExpectedPageNumbers() {
+  const pageCount = getPageCount(toolSearchIndex.length)
+
+  return Array.from({ length: pageCount - 1 }, (_, index) => index + 2)
+}
+
+describe("tools directory static paths", () => {
+  it("generates default-language pages two through the last page", () => {
+    const expectedPages = getExpectedPageNumbers()
+    const paths = getDefaultToolsDirectoryStaticPaths()
+
+    expect(paths).toHaveLength(expectedPages.length)
+    expect(paths.map(({ params }) => Number(params.page))).toEqual(
+      expectedPages
+    )
+    expect(paths.map(({ props }) => props.pageNumber)).toEqual(expectedPages)
+    expect(paths.some(({ params }) => params.page === "1")).toBe(false)
+  })
+
+  it("generates the same page range for every non-default language", () => {
+    const expectedPages = getExpectedPageNumbers()
+    const paths = getNonDefaultToolsDirectoryStaticPaths()
+    const nonDefaultLanguageCount = SUPPORTED_SITE_LANGUAGES.length - 1
+
+    expect(paths).toHaveLength(expectedPages.length * nonDefaultLanguageCount)
+    expect(paths.some(({ params }) => params.page === "1")).toBe(false)
+
+    for (const language of SUPPORTED_SITE_LANGUAGES.slice(1)) {
+      const languagePaths = paths.filter(
+        ({ params }) => params.lang === language
+      )
+
+      expect(languagePaths.map(({ params }) => Number(params.page))).toEqual(
+        expectedPages
+      )
+      expect(
+        languagePaths.every(({ props }) => props.language === language)
+      ).toBe(true)
+    }
+  })
+})

--- a/apps/web/src/lib/static-paths.ts
+++ b/apps/web/src/lib/static-paths.ts
@@ -1,7 +1,11 @@
-import { toolStaticPaths } from "@workspace/tool-registry"
+import { toolSearchIndex, toolStaticPaths } from "@workspace/tool-registry"
 
-import { DEFAULT_SITE_LANGUAGE, isSupportedSiteLanguage } from "./site"
-import { createNonDefaultLanguageStaticPaths } from "./site"
+import { getPageCount } from "./tools-directory"
+import {
+  DEFAULT_SITE_LANGUAGE,
+  createNonDefaultLanguageStaticPaths,
+  isSupportedSiteLanguage,
+} from "./site"
 
 function getNonDefaultSiteStaticPaths() {
   return createNonDefaultLanguageStaticPaths().map(({ params }) => ({ params }))
@@ -32,8 +36,38 @@ function getNonDefaultToolStaticPaths() {
     }))
 }
 
+function getToolsDirectoryPageNumbers() {
+  const pageCount = getPageCount(toolSearchIndex.length)
+
+  return Array.from({ length: pageCount - 1 }, (_, index) => index + 2)
+}
+
+function getDefaultToolsDirectoryStaticPaths() {
+  return getToolsDirectoryPageNumbers().map((pageNumber) => ({
+    params: { page: String(pageNumber) },
+    props: { pageNumber },
+  }))
+}
+
+function getNonDefaultToolsDirectoryStaticPaths() {
+  return createNonDefaultLanguageStaticPaths().flatMap(({ params, props }) =>
+    getToolsDirectoryPageNumbers().map((pageNumber) => ({
+      params: {
+        lang: params.lang,
+        page: String(pageNumber),
+      },
+      props: {
+        language: props.language,
+        pageNumber,
+      },
+    }))
+  )
+}
+
 export {
   getDefaultToolStaticPaths,
+  getDefaultToolsDirectoryStaticPaths,
   getNonDefaultSiteStaticPaths,
   getNonDefaultToolStaticPaths,
+  getNonDefaultToolsDirectoryStaticPaths,
 }

--- a/apps/web/src/lib/tools-directory.test.ts
+++ b/apps/web/src/lib/tools-directory.test.ts
@@ -1,0 +1,190 @@
+import type { ToolSearchIndexEntry } from "@workspace/tool-registry"
+import { describe, expect, it } from "vitest"
+
+import {
+  createLocalizedToolEntries,
+  getLocalizedToolsPagePath,
+  getPageCount,
+  getPaginationItems,
+  getToolsPagePath,
+  paginateToolEntries,
+  type ToolDirectoryEntry,
+} from "./tools-directory"
+
+function createSearchEntry(
+  slug: string,
+  locales: ToolSearchIndexEntry["locales"]
+): ToolSearchIndexEntry {
+  return {
+    category: "developer",
+    icon: `${slug}-icon`,
+    locales,
+    slug,
+    tags: [],
+  }
+}
+
+function createDirectoryEntries(count: number): ToolDirectoryEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    description: `Description ${index + 1}`,
+    icon: "tool-icon",
+    name: `Tool ${index + 1}`,
+    slug: `tool-${index + 1}`,
+  }))
+}
+
+describe("createLocalizedToolEntries", () => {
+  it("returns only the flat fields needed by the directory", () => {
+    const entries = createLocalizedToolEntries(
+      [
+        createSearchEntry("alpha", {
+          en: { description: "English description", name: "Alpha" },
+          "zh-CN": { description: "中文描述", name: "阿尔法" },
+        }),
+      ],
+      "zh-CN"
+    )
+
+    expect(entries).toEqual([
+      {
+        description: "中文描述",
+        icon: "alpha-icon",
+        name: "阿尔法",
+        slug: "alpha",
+      },
+    ])
+    expect(Object.keys(entries[0])).toEqual([
+      "description",
+      "icon",
+      "name",
+      "slug",
+    ])
+  })
+
+  it("falls back to English and then the first available locale", () => {
+    const entries = createLocalizedToolEntries(
+      [
+        createSearchEntry("english-fallback", {
+          en: { description: "English", name: "English fallback" },
+        }),
+        createSearchEntry("available-fallback", {
+          de: { description: "Deutsch", name: "Verfuegbar" },
+        }),
+      ],
+      "zh-CN"
+    )
+
+    expect(entries.map(({ name }) => name)).toEqual([
+      "Verfuegbar",
+      "English fallback",
+    ])
+  })
+
+  it("keeps page membership stable by sorting on canonical English names", () => {
+    const source = [
+      createSearchEntry("beta", {
+        en: { description: "B", name: "Beta" },
+        "zh-CN": { description: "B", name: "阿尔法" },
+      }),
+      createSearchEntry("alpha", {
+        en: { description: "A", name: "Alpha" },
+        "zh-CN": { description: "A", name: "祖鲁" },
+      }),
+    ]
+
+    const englishSlugs = createLocalizedToolEntries(source, "en").map(
+      ({ slug }) => slug
+    )
+    const chineseSlugs = createLocalizedToolEntries(source, "zh-CN").map(
+      ({ slug }) => slug
+    )
+
+    expect(englishSlugs).toEqual(["alpha", "beta"])
+    expect(chineseSlugs).toEqual(englishSlugs)
+  })
+})
+
+describe("directory page boundaries", () => {
+  it("calculates at least one page", () => {
+    expect(getPageCount(0)).toBe(1)
+    expect(getPageCount(24)).toBe(1)
+    expect(getPageCount(25)).toBe(2)
+    expect(getPageCount(49)).toBe(3)
+  })
+
+  it("slices entries and reports one-based result boundaries", () => {
+    const entries = createDirectoryEntries(49)
+
+    expect(paginateToolEntries(entries, 1)).toMatchObject({
+      end: 24,
+      pageCount: 3,
+      pageNumber: 1,
+      start: 1,
+      total: 49,
+    })
+    expect(paginateToolEntries(entries, 2)).toMatchObject({
+      end: 48,
+      pageNumber: 2,
+      start: 25,
+    })
+    expect(paginateToolEntries(entries, 3)).toMatchObject({
+      end: 49,
+      entries: [entries[48]],
+      pageNumber: 3,
+      start: 49,
+    })
+  })
+
+  it("reports empty boundaries for an empty first page", () => {
+    expect(paginateToolEntries([], 1)).toMatchObject({
+      end: 0,
+      entries: [],
+      pageCount: 1,
+      start: 0,
+      total: 0,
+    })
+  })
+
+  it("rejects invalid totals, sizes, and requested pages", () => {
+    expect(() => getPageCount(-1)).toThrow(RangeError)
+    expect(() => getPageCount(1.5)).toThrow(RangeError)
+    expect(() => getPageCount(1, 0)).toThrow(RangeError)
+    expect(() => getPageCount(1, 1.5)).toThrow(RangeError)
+
+    const entries = createDirectoryEntries(25)
+    expect(() => paginateToolEntries(entries, 0)).toThrow(RangeError)
+    expect(() => paginateToolEntries(entries, 1.5)).toThrow(RangeError)
+    expect(() => paginateToolEntries(entries, 3)).toThrow(RangeError)
+  })
+})
+
+describe("directory pagination links", () => {
+  it("keeps page one canonical and emits trailing slashes for localized URLs", () => {
+    expect(getToolsPagePath(1)).toBe("/tools")
+    expect(getToolsPagePath(3)).toBe("/tools/page/3")
+    expect(getLocalizedToolsPagePath("/tools", 1)).toBe("/tools/")
+    expect(getLocalizedToolsPagePath("/zh-CN/tools/", 3)).toBe(
+      "/zh-CN/tools/page/3/"
+    )
+  })
+
+  it("rejects invalid page numbers in paths", () => {
+    expect(() => getToolsPagePath(0)).toThrow(RangeError)
+    expect(() => getToolsPagePath(1.5)).toThrow(RangeError)
+    expect(() => getLocalizedToolsPagePath("/tools", -1)).toThrow(RangeError)
+  })
+
+  it("shows every page for short ranges and ellipses for long ranges", () => {
+    expect(getPaginationItems(4, 7)).toEqual([1, 2, 3, 4, 5, 6, 7])
+    expect(getPaginationItems(1, 10)).toEqual([1, 2, 3, null, 10])
+    expect(getPaginationItems(5, 10)).toEqual([1, null, 4, 5, 6, null, 10])
+    expect(getPaginationItems(10, 10)).toEqual([1, null, 8, 9, 10])
+  })
+
+  it("rejects impossible pagination states", () => {
+    expect(() => getPaginationItems(0, 10)).toThrow(RangeError)
+    expect(() => getPaginationItems(11, 10)).toThrow(RangeError)
+    expect(() => getPaginationItems(1, 0)).toThrow(RangeError)
+    expect(() => getPaginationItems(1.5, 10)).toThrow(RangeError)
+  })
+})

--- a/apps/web/src/lib/tools-directory.ts
+++ b/apps/web/src/lib/tools-directory.ts
@@ -1,0 +1,172 @@
+import type { ToolSearchIndexEntry } from "@workspace/tool-registry"
+
+import type { SiteLanguage } from "./site"
+
+const TOOLS_PER_PAGE = 24
+
+type ToolDirectoryEntry = Readonly<{
+  slug: string
+  icon: string
+  name: string
+  description: string
+}>
+
+type ToolDirectoryPage = Readonly<{
+  entries: readonly ToolDirectoryEntry[]
+  end: number
+  pageCount: number
+  pageNumber: number
+  start: number
+  total: number
+}>
+
+function createLocalizedToolEntries(
+  entries: readonly ToolSearchIndexEntry[],
+  language: SiteLanguage
+) {
+  return [...entries]
+    .sort((left, right) => {
+      const leftName = left.locales.en?.name ?? left.slug
+      const rightName = right.locales.en?.name ?? right.slug
+
+      return (
+        leftName.localeCompare(rightName, "en") ||
+        left.slug.localeCompare(right.slug, "en")
+      )
+    })
+    .map((entry) => {
+      const locale =
+        entry.locales[language] ??
+        entry.locales.en ??
+        Object.values(entry.locales)[0]
+
+      return {
+        description: locale?.description ?? "",
+        icon: entry.icon,
+        name: locale?.name ?? entry.slug,
+        slug: entry.slug,
+      } satisfies ToolDirectoryEntry
+    })
+}
+
+function getPageCount(total: number, pageSize = TOOLS_PER_PAGE) {
+  if (!Number.isInteger(total) || total < 0) {
+    throw new RangeError("Tool total must be a non-negative integer.")
+  }
+
+  if (!Number.isInteger(pageSize) || pageSize < 1) {
+    throw new RangeError("Page size must be a positive integer.")
+  }
+
+  return Math.max(1, Math.ceil(total / pageSize))
+}
+
+function paginateToolEntries(
+  entries: readonly ToolDirectoryEntry[],
+  pageNumber: number,
+  pageSize = TOOLS_PER_PAGE
+): ToolDirectoryPage {
+  const pageCount = getPageCount(entries.length, pageSize)
+
+  if (
+    !Number.isInteger(pageNumber) ||
+    pageNumber < 1 ||
+    pageNumber > pageCount
+  ) {
+    throw new RangeError(`Page ${pageNumber} is outside 1-${pageCount}.`)
+  }
+
+  const startIndex = (pageNumber - 1) * pageSize
+  const pageEntries = entries.slice(startIndex, startIndex + pageSize)
+
+  return {
+    end: pageEntries.length === 0 ? 0 : startIndex + pageEntries.length,
+    entries: pageEntries,
+    pageCount,
+    pageNumber,
+    start: pageEntries.length === 0 ? 0 : startIndex + 1,
+    total: entries.length,
+  }
+}
+
+function getToolsPagePath(pageNumber: number) {
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new RangeError("Page number must be a positive integer.")
+  }
+
+  return pageNumber === 1 ? "/tools" : `/tools/page/${pageNumber}`
+}
+
+function getLocalizedToolsPagePath(basePath: string, pageNumber: number) {
+  if (!Number.isInteger(pageNumber) || pageNumber < 1) {
+    throw new RangeError("Page number must be a positive integer.")
+  }
+
+  const normalizedBasePath = basePath.endsWith("/") ? basePath : `${basePath}/`
+
+  return pageNumber === 1
+    ? normalizedBasePath
+    : `${normalizedBasePath}page/${pageNumber}/`
+}
+
+function getPaginationItems(pageNumber: number, pageCount: number) {
+  if (
+    !Number.isInteger(pageNumber) ||
+    !Number.isInteger(pageCount) ||
+    pageCount < 1 ||
+    pageNumber < 1 ||
+    pageNumber > pageCount
+  ) {
+    throw new RangeError("Pagination state is invalid.")
+  }
+
+  if (pageCount <= 7) {
+    return Array.from({ length: pageCount }, (_, index) => index + 1)
+  }
+
+  const visiblePages = new Set([
+    1,
+    pageCount,
+    pageNumber - 1,
+    pageNumber,
+    pageNumber + 1,
+  ])
+
+  if (pageNumber <= 3) {
+    visiblePages.add(2)
+    visiblePages.add(3)
+  }
+
+  if (pageNumber >= pageCount - 2) {
+    visiblePages.add(pageCount - 2)
+    visiblePages.add(pageCount - 1)
+  }
+
+  const pages = [...visiblePages]
+    .filter((page) => page >= 1 && page <= pageCount)
+    .sort((left, right) => left - right)
+  const items: Array<number | null> = []
+
+  for (const page of pages) {
+    const previousPage = items.at(-1)
+
+    if (typeof previousPage === "number" && page - previousPage > 1) {
+      items.push(null)
+    }
+
+    items.push(page)
+  }
+
+  return items
+}
+
+export {
+  TOOLS_PER_PAGE,
+  createLocalizedToolEntries,
+  getLocalizedToolsPagePath,
+  getPageCount,
+  getPaginationItems,
+  getToolsPagePath,
+  paginateToolEntries,
+}
+export type { ToolDirectoryEntry, ToolDirectoryPage }

--- a/apps/web/src/pages/[lang]/tools/index.astro
+++ b/apps/web/src/pages/[lang]/tools/index.astro
@@ -8,4 +8,4 @@ export { getNonDefaultSiteStaticPaths as getStaticPaths }
 const language = resolveSiteLanguage(Astro.params.lang)
 ---
 
-<ToolsIndexPage language={language} />
+<ToolsIndexPage language={language} pageNumber={1} />

--- a/apps/web/src/pages/[lang]/tools/page/[page].astro
+++ b/apps/web/src/pages/[lang]/tools/page/[page].astro
@@ -1,0 +1,17 @@
+---
+import ToolsIndexPage from "@/components/pages/tools-index-page.astro"
+import { getNonDefaultToolsDirectoryStaticPaths } from "@/lib/static-paths"
+
+import type { SiteLanguage } from "@/lib/site"
+
+export { getNonDefaultToolsDirectoryStaticPaths as getStaticPaths }
+
+interface Props {
+  language: SiteLanguage
+  pageNumber: number
+}
+
+const { language, pageNumber } = Astro.props
+---
+
+<ToolsIndexPage language={language} pageNumber={pageNumber} />

--- a/apps/web/src/pages/tools/index.astro
+++ b/apps/web/src/pages/tools/index.astro
@@ -3,4 +3,4 @@ import ToolsIndexPage from "@/components/pages/tools-index-page.astro"
 import { DEFAULT_SITE_LANGUAGE } from "@/lib/site"
 ---
 
-<ToolsIndexPage language={DEFAULT_SITE_LANGUAGE} />
+<ToolsIndexPage language={DEFAULT_SITE_LANGUAGE} pageNumber={1} />

--- a/apps/web/src/pages/tools/page/[page].astro
+++ b/apps/web/src/pages/tools/page/[page].astro
@@ -1,0 +1,15 @@
+---
+import ToolsIndexPage from "@/components/pages/tools-index-page.astro"
+import { DEFAULT_SITE_LANGUAGE } from "@/lib/site"
+import { getDefaultToolsDirectoryStaticPaths } from "@/lib/static-paths"
+
+export { getDefaultToolsDirectoryStaticPaths as getStaticPaths }
+
+interface Props {
+  pageNumber: number
+}
+
+const { pageNumber } = Astro.props
+---
+
+<ToolsIndexPage language={DEFAULT_SITE_LANGUAGE} pageNumber={pageNumber} />

--- a/packages/ui/src/components/ui/pagination.tsx
+++ b/packages/ui/src/components/ui/pagination.tsx
@@ -1,0 +1,88 @@
+import * as React from "react"
+
+import { buttonVariants, type Button } from "@workspace/ui/components/ui/button"
+import { cn } from "@workspace/ui/lib/utils"
+
+function Pagination({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="pagination"
+      data-slot="pagination"
+      className={cn("mx-auto flex w-full justify-center", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationContent({
+  className,
+  ...props
+}: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="pagination-content"
+      className={cn("flex flex-row items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function PaginationItem(props: React.ComponentProps<"li">) {
+  return <li data-slot="pagination-item" {...props} />
+}
+
+type PaginationLinkProps = Readonly<{
+  isActive?: boolean
+}> &
+  Pick<React.ComponentProps<typeof Button>, "size"> &
+  React.ComponentProps<"a">
+
+function PaginationLink({
+  children,
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) {
+  return (
+    <a
+      aria-current={isActive ? "page" : undefined}
+      data-slot="pagination-link"
+      data-active={isActive}
+      className={cn(
+        buttonVariants({
+          variant: isActive ? "outline" : "ghost",
+          size,
+        }),
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </a>
+  )
+}
+
+function PaginationEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      aria-hidden="true"
+      data-slot="pagination-ellipsis"
+      className={cn("flex size-8 items-center justify-center", className)}
+      {...props}
+    >
+      …
+    </span>
+  )
+}
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+}


### PR DESCRIPTION
## Summary

- replace the homepage's hydrated 213-card directory with a server-rendered hero and no-JavaScript GET search entry point
- paginate the tools directory at 24 tools per page using crawlable static routes across all 23 site languages
- keep search global across the full current-language index, including query-result pagination and browser history
- add semantic pagination, focus states, RTL behavior, page-specific canonical/hreflang metadata, and focused tests

## Why

The homepage and `/tools` previously rendered every tool and serialized every locale into a React island. That made both documents about 1.69 MB raw, serialized roughly 1.40 MB of search props, and produced more than 2,200 DOM elements.

| Production output | Before | After |
| --- | ---: | ---: |
| Homepage HTML | ~1.69 MB | 45.3 KB |
| Homepage Brotli (quality 11) | — | 7.0 KB |
| Homepage tool cards | 213 | 0 |
| `/tools` HTML | ~1.69 MB | 148.2 KB |
| `/tools` Brotli (quality 11) | — | 17.7 KB |
| `/tools` tool cards | 213 | 24 |
| `/tools` DOM elements | ~2,285 | 421 |
| Search island props | ~1.40 MB | ~66.6 KB encoded |

The search island now receives only `slug`, `icon`, `name`, and `description` for the active language; the built HTML no longer contains the full `locales` payload.

## Route and UX behavior

- page 1 remains `/tools/`
- later pages use `/tools/page/2/`, etc.; `/tools/page/1/` is never generated
- 213 tools currently produce 9 pages per language (184 new static pagination URLs across 23 languages)
- page membership uses a stable canonical ordering so every hreflang variant represents the same tool set
- page-number links are real anchors and work without JavaScript
- search still covers all 213 tools, resets to search page 1 while typing, and preserves the originating browse pathname
- clearing search restores the originating static page
- the homepage avoids ungrounded “popular” recommendations and provides one primary browse CTA plus an accessible GET search form

## SEO and accessibility

- each pagination page has a self-canonical URL, page-specific title, complete hreflang set, and sitemap entry
- cards use semantic `ul` / `li` structure with `h2` headings
- pagination exposes `aria-current`, localized page labels, previous/next relationships, keyboard focus styles, and RTL arrows
- search announces only the result status instead of marking the whole grid as live
- the application content now has a single `main` landmark and current navigation links expose `aria-current`

The routing follows [Google's pagination guidance](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading), the interaction follows the [GOV.UK pagination pattern](https://design-system.service.gov.uk/components/pagination/), and the payload/DOM reduction follows [web.dev's DOM-size guidance](https://web.dev/articles/dom-size-and-interactivity).

## Verification

- `pnpm format:check`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 587 files / 19,887 tests passed
- changed-test coverage run — 4 files / 21 tests passed
- `pnpm depcruise`
- `pnpm knip`
- `pnpm dedupe --check`
- `NODE_OPTIONS=--max-old-space-size=6144 pnpm build` — 5,129 pages built
- local Lighthouse CI assertion on home, tools, and a tool page — 100 in Performance, Accessibility, Best Practices, and SEO
- real Chromium checks at desktop/mobile widths, including page-2 search/clear history, localized RTL pagination, no horizontal overflow, and zero console errors
